### PR TITLE
Improve hash-table implementations of SolutionMappingsIndex

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableOverCollectionOfLists.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableOverCollectionOfLists.java
@@ -6,6 +6,11 @@ import java.util.List;
 
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 
+/**
+ * This is an iterable that wraps a nested collection of solution mappings
+ * (more precisely, lists of solution mappings contained in a collection)
+ * and that can be used to iterate over all these solution mappings.
+ */
 public class SolutionMappingsIterableOverCollectionOfLists implements Iterable<SolutionMapping>
 {
 	protected final Collection<List<SolutionMapping>> c;

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableOverCollectionOfLists.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableOverCollectionOfLists.java
@@ -1,0 +1,23 @@
+package se.liu.ida.hefquin.engine.data.utils;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+
+public class SolutionMappingsIterableOverCollectionOfLists implements Iterable<SolutionMapping>
+{
+	protected final Collection<List<SolutionMapping>> c;
+
+	public SolutionMappingsIterableOverCollectionOfLists( final Collection<List<SolutionMapping>> c ) {
+		assert c != null;
+		this.c = c;
+	}
+
+	@Override
+	public Iterator<SolutionMapping> iterator() {
+		return new SolutionMappingsIteratorOverCollectionOfLists(c);
+	}
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithOneVarFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithOneVarFilter.java
@@ -1,0 +1,27 @@
+package se.liu.ida.hefquin.engine.data.utils;
+
+import java.util.Iterator;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.Var;
+
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+
+public class SolutionMappingsIterableWithOneVarFilter implements Iterable<SolutionMapping>
+{
+	protected final Iterable<SolutionMapping> input;
+	protected final Var var;
+	protected final Node value;
+
+	public SolutionMappingsIterableWithOneVarFilter( final Iterable<SolutionMapping> input, final Var var, final Node value ) {
+		this.input = input;
+		this.var   = var;
+		this.value = value;
+	}
+
+	@Override
+	public Iterator<SolutionMapping> iterator() {
+		return new SolutionMappingsIteratorWithOneVarFilter( input.iterator(), var, value );
+	}
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithOneVarFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithOneVarFilter.java
@@ -7,6 +7,11 @@ import org.apache.jena.sparql.core.Var;
 
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 
+/**
+ * This is an iterable of solution mappings that wraps another such iterable
+ * and that can be used to iterate over the subset of solution mappings that
+ * have a given value for a given variable.
+ */
 public class SolutionMappingsIterableWithOneVarFilter implements Iterable<SolutionMapping>
 {
 	protected final Iterable<SolutionMapping> input;

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithSolMapFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithSolMapFilter.java
@@ -1,0 +1,22 @@
+package se.liu.ida.hefquin.engine.data.utils;
+
+import java.util.Iterator;
+
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+
+public class SolutionMappingsIterableWithSolMapFilter implements Iterable<SolutionMapping>
+{
+	protected final Iterable<SolutionMapping> input;
+	protected final SolutionMapping sm;
+
+	public SolutionMappingsIterableWithSolMapFilter( final Iterable<SolutionMapping> input, final SolutionMapping sm ) {
+		this.input = input;
+		this.sm   = sm;
+	}
+
+	@Override
+	public Iterator<SolutionMapping> iterator() {
+		return new SolutionMappingsIteratorWithSolMapFilter( input.iterator(), sm );
+	}
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithSolMapFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithSolMapFilter.java
@@ -4,6 +4,11 @@ import java.util.Iterator;
 
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 
+/**
+ * This is an iterable of solution mappings that wraps another such iterable
+ * and that can be used to iterate over the subset of solution mappings that
+ * are compatible with a given solution mapping.
+ */
 public class SolutionMappingsIterableWithSolMapFilter implements Iterable<SolutionMapping>
 {
 	protected final Iterable<SolutionMapping> input;

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithThreeVarsFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithThreeVarsFilter.java
@@ -1,0 +1,36 @@
+package se.liu.ida.hefquin.engine.data.utils;
+
+import java.util.Iterator;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.Var;
+
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+
+public class SolutionMappingsIterableWithThreeVarsFilter implements Iterable<SolutionMapping>
+{
+	protected final Iterable<SolutionMapping> input;
+	protected final Var var1, var2, var3;
+	protected final Node value1, value2, value3;
+
+	public SolutionMappingsIterableWithThreeVarsFilter(
+			final Iterable<SolutionMapping> input,
+			final Var var1, final Node value1,
+			final Var var2, final Node value2,
+			final Var var3, final Node value3 )
+	{
+		this.input = input;
+		this.var1   = var1;
+		this.var2   = var2;
+		this.var3   = var3;
+		this.value1 = value1;
+		this.value2 = value2;
+		this.value3 = value3;
+	}
+
+	@Override
+	public Iterator<SolutionMapping> iterator() {
+		return new SolutionMappingsIteratorWithThreeVarsFilter( input.iterator(), var1, value1, var2, value2, var3, value3 );
+	}
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithThreeVarsFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithThreeVarsFilter.java
@@ -7,6 +7,11 @@ import org.apache.jena.sparql.core.Var;
 
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 
+/**
+ * This is an iterable of solution mappings that wraps another such iterable
+ * and that can be used to iterate over the subset of solution mappings that
+ * have given values for three variables.
+ */
 public class SolutionMappingsIterableWithThreeVarsFilter implements Iterable<SolutionMapping>
 {
 	protected final Iterable<SolutionMapping> input;

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithTwoVarsFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithTwoVarsFilter.java
@@ -7,6 +7,11 @@ import org.apache.jena.sparql.core.Var;
 
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 
+/**
+ * This is an iterable of solution mappings that wraps another such iterable
+ * and that can be used to iterate over the subset of solution mappings that
+ * have given values for two variables.
+ */
 public class SolutionMappingsIterableWithTwoVarsFilter implements Iterable<SolutionMapping>
 {
 	protected final Iterable<SolutionMapping> input;

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithTwoVarsFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithTwoVarsFilter.java
@@ -1,0 +1,33 @@
+package se.liu.ida.hefquin.engine.data.utils;
+
+import java.util.Iterator;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.Var;
+
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+
+public class SolutionMappingsIterableWithTwoVarsFilter implements Iterable<SolutionMapping>
+{
+	protected final Iterable<SolutionMapping> input;
+	protected final Var var1, var2;
+	protected final Node value1, value2;
+
+	public SolutionMappingsIterableWithTwoVarsFilter(
+			final Iterable<SolutionMapping> input,
+			final Var var1, final Node value1,
+			final Var var2, final Node value2 )
+	{
+		this.input = input;
+		this.var1   = var1;
+		this.var2   = var2;
+		this.value1 = value1;
+		this.value2 = value2;
+	}
+
+	@Override
+	public Iterator<SolutionMapping> iterator() {
+		return new SolutionMappingsIteratorWithTwoVarsFilter( input.iterator(), var1, value1, var2, value2 );
+	}
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorOverCollectionOfLists.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorOverCollectionOfLists.java
@@ -1,0 +1,43 @@
+package se.liu.ida.hefquin.engine.data.utils;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+
+public class SolutionMappingsIteratorOverCollectionOfLists implements Iterator<SolutionMapping>
+{
+	final protected Iterator<List<SolutionMapping>> itBuckets;
+	protected Iterator<SolutionMapping> itCurBucketElmts;
+
+	public SolutionMappingsIteratorOverCollectionOfLists( final Collection<List<SolutionMapping>> c ) {
+		itBuckets = c.iterator();
+		if ( itBuckets.hasNext() )
+			itCurBucketElmts = itBuckets.next().iterator();
+		else
+			itCurBucketElmts = null;
+	}
+
+	@Override
+	public boolean hasNext() {
+		if ( itCurBucketElmts == null )
+			return false;
+
+		while ( ! itCurBucketElmts.hasNext() && itBuckets.hasNext() ) {
+			itCurBucketElmts = itBuckets.next().iterator();
+		}
+
+		return itCurBucketElmts.hasNext();
+	}
+
+	@Override
+	public SolutionMapping next() {
+		if ( ! hasNext() )
+			throw new NoSuchElementException();
+
+		return itCurBucketElmts.next();
+	}
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorOverCollectionOfLists.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorOverCollectionOfLists.java
@@ -7,6 +7,10 @@ import java.util.NoSuchElementException;
 
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 
+/**
+ * This is an iterator over all solution mappings contained in a nested
+ * collection (more precisely, in lists contained in a collection).
+ */
 public class SolutionMappingsIteratorOverCollectionOfLists implements Iterator<SolutionMapping>
 {
 	final protected Iterator<List<SolutionMapping>> itBuckets;

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithOneVarFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithOneVarFilter.java
@@ -8,6 +8,11 @@ import org.apache.jena.sparql.core.Var;
 
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 
+/**
+ * This is an iterator of solution mappings that consumes another iterator
+ * and passes on only the solution mappings that have a given value for a
+ * given variable.
+ */
 public class SolutionMappingsIteratorWithOneVarFilter implements Iterator<SolutionMapping>
 {
 	protected final Iterator<SolutionMapping> input;

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithOneVarFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithOneVarFilter.java
@@ -1,0 +1,46 @@
+package se.liu.ida.hefquin.engine.data.utils;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.Var;
+
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+
+public class SolutionMappingsIteratorWithOneVarFilter implements Iterator<SolutionMapping>
+{
+	protected final Iterator<SolutionMapping> input;
+	protected final Var var;
+	protected final Node value;
+
+	protected SolutionMapping nextOutputElement = null;
+
+	public SolutionMappingsIteratorWithOneVarFilter( final Iterator<SolutionMapping> input, final Var var, final Node value ) {
+		this.input = input;
+		this.var   = var;
+		this.value = value;
+	}
+
+	@Override
+	public boolean hasNext() {
+		while ( nextOutputElement == null && input.hasNext() ) {
+			final SolutionMapping nextInputElement = input.next();
+			final Node inputValue = nextInputElement.asJenaBinding().get(var);
+			if ( inputValue == null || inputValue.equals(value) ) {
+				nextOutputElement = nextInputElement;
+			}
+		}
+
+		return ( nextOutputElement != null );
+	}
+
+	@Override
+	public SolutionMapping next() {
+		if ( ! hasNext() )
+			throw new NoSuchElementException();
+
+		return nextOutputElement;
+	};
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithOneVarFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithOneVarFilter.java
@@ -45,7 +45,9 @@ public class SolutionMappingsIteratorWithOneVarFilter implements Iterator<Soluti
 		if ( ! hasNext() )
 			throw new NoSuchElementException();
 
-		return nextOutputElement;
+		final SolutionMapping output = nextOutputElement;
+		nextOutputElement = null;
+		return output;
 	};
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithSolMapFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithSolMapFilter.java
@@ -6,6 +6,11 @@ import java.util.NoSuchElementException;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
 
+/**
+ * This is an iterator of solution mappings that consumes another iterator
+ * and passes on only the solution mappings that are compatible to a given
+ * solution mapping.
+ */
 public class SolutionMappingsIteratorWithSolMapFilter implements Iterator<SolutionMapping>
 {
 	protected final Iterator<SolutionMapping> input;

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithSolMapFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithSolMapFilter.java
@@ -1,0 +1,41 @@
+package se.liu.ida.hefquin.engine.data.utils;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
+
+public class SolutionMappingsIteratorWithSolMapFilter implements Iterator<SolutionMapping>
+{
+	protected final Iterator<SolutionMapping> input;
+	protected final SolutionMapping sm;
+
+	protected SolutionMapping nextOutputElement = null;
+
+	public SolutionMappingsIteratorWithSolMapFilter( final Iterator<SolutionMapping> input, final SolutionMapping sm ) {
+		this.input = input;
+		this.sm = sm;
+	}
+
+	@Override
+	public boolean hasNext() {
+		while ( nextOutputElement == null && input.hasNext() ) {
+			final SolutionMapping nextInputElement = input.next();
+			if ( SolutionMappingUtils.compatible(sm, nextInputElement) ) {
+				nextOutputElement = nextInputElement;
+			}
+		}
+
+		return ( nextOutputElement != null );
+	}
+
+	@Override
+	public SolutionMapping next() {
+		if ( ! hasNext() )
+			throw new NoSuchElementException();
+
+		return nextOutputElement;
+	};
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithSolMapFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithSolMapFilter.java
@@ -25,6 +25,7 @@ public class SolutionMappingsIteratorWithSolMapFilter implements Iterator<Soluti
 
 	@Override
 	public boolean hasNext() {
+		nextOutputElement = null;
 		while ( nextOutputElement == null && input.hasNext() ) {
 			final SolutionMapping nextInputElement = input.next();
 			if ( SolutionMappingUtils.compatible(sm, nextInputElement) ) {
@@ -37,8 +38,8 @@ public class SolutionMappingsIteratorWithSolMapFilter implements Iterator<Soluti
 
 	@Override
 	public SolutionMapping next() {
-		if ( ! hasNext() )
-			throw new NoSuchElementException();
+		//if ( ! hasNext() )
+		//	throw new NoSuchElementException();
 
 		return nextOutputElement;
 	};

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithSolMapFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithSolMapFilter.java
@@ -25,7 +25,6 @@ public class SolutionMappingsIteratorWithSolMapFilter implements Iterator<Soluti
 
 	@Override
 	public boolean hasNext() {
-		nextOutputElement = null;
 		while ( nextOutputElement == null && input.hasNext() ) {
 			final SolutionMapping nextInputElement = input.next();
 			if ( SolutionMappingUtils.compatible(sm, nextInputElement) ) {
@@ -38,10 +37,12 @@ public class SolutionMappingsIteratorWithSolMapFilter implements Iterator<Soluti
 
 	@Override
 	public SolutionMapping next() {
-		//if ( ! hasNext() )
-		//	throw new NoSuchElementException();
+		if ( ! hasNext() )
+			throw new NoSuchElementException();
 
-		return nextOutputElement;
+		final SolutionMapping output = nextOutputElement;
+		nextOutputElement = null;
+		return output;
 	};
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithThreeVarsFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithThreeVarsFilter.java
@@ -1,0 +1,65 @@
+package se.liu.ida.hefquin.engine.data.utils;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.binding.Binding;
+
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+
+public class SolutionMappingsIteratorWithThreeVarsFilter implements Iterator<SolutionMapping>
+{
+	protected final Iterator<SolutionMapping> input;
+	protected final Var var1, var2, var3;
+	protected final Node value1, value2, value3;
+
+	protected SolutionMapping nextOutputElement = null;
+
+	public SolutionMappingsIteratorWithThreeVarsFilter(
+			final Iterator<SolutionMapping> input,
+			final Var var1, final Node value1,
+			final Var var2, final Node value2,
+			final Var var3, final Node value3 )
+	{
+		this.input = input;
+		this.var1   = var1;
+		this.var2   = var2;
+		this.var3   = var3;
+		this.value1 = value1;
+		this.value2 = value2;
+		this.value3 = value3;
+	}
+
+	@Override
+	public boolean hasNext() {
+		while ( nextOutputElement == null && input.hasNext() ) {
+			final SolutionMapping nextInputElement = input.next();
+
+			final Binding b = nextInputElement.asJenaBinding();
+			final Node inputValue1 = b.get(var1);
+			final Node inputValue2 = b.get(var2);
+			final Node inputValue3 = b.get(var3);
+
+			if ( inputValue1 == null || inputValue1.equals(value1) ) {
+				if ( inputValue2 == null || inputValue2.equals(value2) ) {
+					if ( inputValue3 == null || inputValue3.equals(value3) ) {
+						nextOutputElement = nextInputElement;
+					}
+				}
+			}
+		}
+
+		return ( nextOutputElement != null );
+	}
+
+	@Override
+	public SolutionMapping next() {
+		if ( ! hasNext() )
+			throw new NoSuchElementException();
+
+		return nextOutputElement;
+	};
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithThreeVarsFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithThreeVarsFilter.java
@@ -9,6 +9,11 @@ import org.apache.jena.sparql.engine.binding.Binding;
 
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 
+/**
+ * This is an iterator of solution mappings that consumes another iterator
+ * and passes on only the solution mappings that have given values for three
+ * variables.
+ */
 public class SolutionMappingsIteratorWithThreeVarsFilter implements Iterator<SolutionMapping>
 {
 	protected final Iterator<SolutionMapping> input;

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithThreeVarsFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithThreeVarsFilter.java
@@ -64,7 +64,9 @@ public class SolutionMappingsIteratorWithThreeVarsFilter implements Iterator<Sol
 		if ( ! hasNext() )
 			throw new NoSuchElementException();
 
-		return nextOutputElement;
+		final SolutionMapping output = nextOutputElement;
+		nextOutputElement = null;
+		return output;
 	};
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithTwoVarsFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithTwoVarsFilter.java
@@ -58,7 +58,9 @@ public class SolutionMappingsIteratorWithTwoVarsFilter implements Iterator<Solut
 		if ( ! hasNext() )
 			throw new NoSuchElementException();
 
-		return nextOutputElement;
+		final SolutionMapping output = nextOutputElement;
+		nextOutputElement = null;
+		return output;
 	};
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithTwoVarsFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithTwoVarsFilter.java
@@ -1,0 +1,59 @@
+package se.liu.ida.hefquin.engine.data.utils;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.binding.Binding;
+
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+
+public class SolutionMappingsIteratorWithTwoVarsFilter implements Iterator<SolutionMapping>
+{
+	protected final Iterator<SolutionMapping> input;
+	protected final Var var1, var2;
+	protected final Node value1, value2;
+
+	protected SolutionMapping nextOutputElement = null;
+
+	public SolutionMappingsIteratorWithTwoVarsFilter(
+			final Iterator<SolutionMapping> input,
+			final Var var1, final Node value1,
+			final Var var2, final Node value2 )
+	{
+		this.input = input;
+		this.var1   = var1;
+		this.var2   = var2;
+		this.value1 = value1;
+		this.value2 = value2;
+	}
+
+	@Override
+	public boolean hasNext() {
+		while ( nextOutputElement == null && input.hasNext() ) {
+			final SolutionMapping nextInputElement = input.next();
+
+			final Binding b = nextInputElement.asJenaBinding();
+			final Node inputValue1 = b.get(var1);
+			final Node inputValue2 = b.get(var2);
+
+			if ( inputValue1 == null || inputValue1.equals(value1) ) {
+				if ( inputValue2 == null || inputValue2.equals(value2) ) {
+					nextOutputElement = nextInputElement;
+				}
+			}
+		}
+
+		return ( nextOutputElement != null );
+	}
+
+	@Override
+	public SolutionMapping next() {
+		if ( ! hasNext() )
+			throw new NoSuchElementException();
+
+		return nextOutputElement;
+	};
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithTwoVarsFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIteratorWithTwoVarsFilter.java
@@ -9,6 +9,11 @@ import org.apache.jena.sparql.engine.binding.Binding;
 
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 
+/**
+ * This is an iterator of solution mappings that consumes another iterator
+ * and passes on only the solution mappings that have given values for two
+ * variables.
+ */
 public class SolutionMappingsIteratorWithTwoVarsFilter implements Iterator<SolutionMapping>
 {
 	protected final Iterator<SolutionMapping> input;

--- a/src/main/java/se/liu/ida/hefquin/engine/datastructures/SolutionMappingsIndex.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/datastructures/SolutionMappingsIndex.java
@@ -1,6 +1,7 @@
 package se.liu.ida.hefquin.engine.datastructures;
 
 import java.util.Collection;
+import java.util.Iterator;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.Var;
@@ -67,4 +68,15 @@ public interface SolutionMappingsIndex extends Collection<SolutionMapping>
 	                                                Var var2, Node value2,
 	                                                Var var3, Node value3 )
 			throws UnsupportedOperationException;
+
+	/**
+	 * Returns all solution mappings currently in this index.
+	 */
+	Iterable<SolutionMapping> getAllSolutionMappings();
+
+	@Override
+	default Iterator<SolutionMapping> iterator() {
+		return getAllSolutionMappings().iterator();
+	}
+
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTable.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTable.java
@@ -209,8 +209,8 @@ public class SolutionMappingsHashTable extends SolutionMappingsIndexBase
 			final Var var3, final Node value3 )
 	{
 		final boolean c1 = joinVariables.contains(var1);
-		final boolean c2 = joinVariables.contains(var1);
-		final boolean c3 = joinVariables.contains(var1);
+		final boolean c2 = joinVariables.contains(var2);
+		final boolean c3 = joinVariables.contains(var3);
 
 		if ( joinVariables.size() == 1 ) {
 			if ( c1 ) {

--- a/src/main/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTable.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTable.java
@@ -63,6 +63,10 @@ public class SolutionMappingsHashTable extends SolutionMappingsIndexBase
 		this( Arrays.asList(vars) );
 	}
 
+	public SolutionMappingsHashTable( final Set<Var> joinVariables ) {
+		this( new ArrayList<>(joinVariables) );
+	}
+
 	@Override
 	public int size() {
 		int size = 0;

--- a/src/main/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTable.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTable.java
@@ -8,7 +8,43 @@ import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.binding.Binding;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
+import se.liu.ida.hefquin.engine.data.utils.SolutionMappingsIterableOverCollectionOfLists;
+import se.liu.ida.hefquin.engine.data.utils.SolutionMappingsIterableWithOneVarFilter;
+import se.liu.ida.hefquin.engine.data.utils.SolutionMappingsIterableWithTwoVarsFilter;
 
+/**
+ * This is a hash table based implementation of {@link SolutionMappingsIndex}
+ * that can be used for indexes that are meant to be used for cases in which
+ * adding and probing into the index may not happen concurrently.
+ *
+ * As mentioned above, this implementation assumes that adding and probing
+ * into the index may not happen concurrently. Based on this assumption,
+ * for every method that returns an {@link Iterable} of solution mappings,
+ * the {@link Iterable} that it returns is directly based on an internal
+ * data structure (rather than being a new {@link Iterable} into which the  
+ * solution mappings have been copied). For cases in which the assumption
+ * does not hold (i.e., cases in which adding and probing into the index
+ * may actually happen concurrently), an object of this class may simply
+ * be wrapped in a {@link SolutionMappingsIndexForMixedUsage} which then
+ * creates a new {@link Iterable} for every {@link Iterable} returned by
+ * this implementation. 
+ *
+ * Another assumption of this implementation is that the only variables
+ * relevant for index look-ups are the variables on which the index is built.
+ * In other words, the assumption is that the only variables that the solution
+ * mappings added to the index have in common with the solution mappings
+ * given to the method {@link #getJoinPartners(SolutionMapping)} are the
+ * variables on which the index is built. For cases in which this assumption
+ * does not hold, a {@link SolutionMappingsIndexWithPostMatching} can be
+ * used to wrap a {@link SolutionMappingsHashTable}.
+ *
+ * This implementation is generic in the sense that it can be used for an index
+ * on an arbitrary number of variables. As a consequence, it is not the most
+ * efficient implementation for cases in which the possible number of variables
+ * is fix. More efficient alternatives for the cases in which the number of
+ * variables is one or two are {@link SolutionMappingsHashTableBasedOnOneVar}
+ * and {@link SolutionMappingsHashTableBasedOnTwoVars}, respectively. 
+ */
 public class SolutionMappingsHashTable extends SolutionMappingsIndexBase
 {
 	// Having List<Node> as key type for the hash table is probably
@@ -16,18 +52,15 @@ public class SolutionMappingsHashTable extends SolutionMappingsIndexBase
 	// to do for the moment.
 	// TODO: can this be made more efficient?
 	protected final Map<List<Node>, List<SolutionMapping>> map = new HashMap<>();
-	protected final Collection<Var> joinVariables;
+	protected final List<Var> joinVariables;
 
-	public SolutionMappingsHashTable( final Set<Var> joinVariables ){
-		if( joinVariables.isEmpty() ){
-			throw new IllegalArgumentException();
-		}
-		else {
-			this.joinVariables = joinVariables;
-		}
+	public SolutionMappingsHashTable( final List<Var> joinVariables ){
+		assert ! joinVariables.isEmpty();
+		this.joinVariables = joinVariables;
 	}
+
 	public SolutionMappingsHashTable( final Var ... vars ) {
-		this.joinVariables = Arrays.asList(vars);
+		this( Arrays.asList(vars) );
 	}
 
 	@Override
@@ -52,34 +85,20 @@ public class SolutionMappingsHashTable extends SolutionMappingsIndexBase
 
 	@Override
 	public boolean contains( final Object o ) {
-		if( !(o instanceof SolutionMapping) ){
-			return false;
-		}
+        if( o instanceof SolutionMapping ){
+            final SolutionMapping sm = (SolutionMapping) o;
+            for ( final SolutionMapping sm2 : getJoinPartners(sm)) {
+                if ( sm == sm2 || SolutionMappingUtils.equals(sm, sm2) )
+                    return true;
+            }
+        }
 
-		final Binding b = ((SolutionMapping) o).asJenaBinding();
-		for ( final List<SolutionMapping> li : map.values() ) {
-			for ( final SolutionMapping sm : li){
-				if ( sm.asJenaBinding().equals(b) ){
-					return true;
-				}
-			}
-		}
 		return false;
 	}
 
 	@Override
-	public Iterator<SolutionMapping> iterator() {
-		// The following implementation of this method is inefficient because,
-		// each time it is called, it creates and populates a list of solution
-		// mappings by iterating over the content of this index. However,
-		// for a thread-safe implementation, we may have to live with this.
-		// TODO: is there a more efficient way to implement this method?
-		final List<SolutionMapping> solMap = new ArrayList<>();
-		final Iterator<List<SolutionMapping>> li = map.values().iterator();
-		while(li.hasNext()){
-			solMap.addAll(li.next());
-		}
-		return solMap.iterator();
+	public Iterable<SolutionMapping> getAllSolutionMappings() {
+		return new SolutionMappingsIterableOverCollectionOfLists( map.values() );
 	}
 
 	@Override
@@ -110,44 +129,28 @@ public class SolutionMappingsHashTable extends SolutionMappingsIndexBase
 
 	@Override
 	public Iterable<SolutionMapping> getJoinPartners( final SolutionMapping sm )
-			throws UnsupportedOperationException
 	{
 		final List<Node> valKeys = getVarKeys(sm);
-		final Iterator<SolutionMapping> matchingSolMaps;
 		if ( valKeys == null ){
-			matchingSolMaps = iterator();
+			return getAllSolutionMappings();
 		}
 		else {
-			final List<SolutionMapping> l = map.get(valKeys);
-			matchingSolMaps = (l != null) ? l.iterator() : null;
+			return returnLookupResultOrEmptyList(valKeys);
 		}
-
-		final List<SolutionMapping> joinPartner = new ArrayList<>();
-		while (matchingSolMaps != null && matchingSolMaps.hasNext()) {
-			final SolutionMapping matchSolM = matchingSolMaps.next();
-			if (SolutionMappingUtils.compatible(sm, matchSolM)) {
-				joinPartner.add(matchSolM);
-			}
-		}
-		return joinPartner;
 	}
 
 	@Override
 	public Iterable<SolutionMapping> findSolutionMappings( final Var var, final Node value )
-			throws UnsupportedOperationException
 	{
-		if ( joinVariables.size() == 1 && joinVariables.contains(var) ){
-			final List<Node> valKeyL = new ArrayList<>();
-			valKeyL.add(value);
-
-			List<SolutionMapping> solMapList = map.get(valKeyL);
-			if ( solMapList == null) {
-				solMapList = new ArrayList<>();
-			}
-			return solMapList;
+		if ( ! joinVariables.contains(var) ) {
+			return getAllSolutionMappings();
 		}
-		else{
-			throw new UnsupportedOperationException();
+		else if ( joinVariables.size() > 1 ) {
+			return findSolutionMappingsLastResort(var, value);
+		}
+		else {
+			final List<Node> valKeyL = Arrays.asList(value);
+			return returnLookupResultOrEmptyList(valKeyL);
 		}
 	}
 
@@ -155,31 +158,44 @@ public class SolutionMappingsHashTable extends SolutionMappingsIndexBase
 	public Iterable<SolutionMapping> findSolutionMappings(
 			final Var var1, final Node value1,
 			final Var var2, final Node value2 )
-			throws UnsupportedOperationException
 	{
-		if ( joinVariables.size() == 2 && joinVariables.contains(var1) && joinVariables.contains(var2) ){
-			final List<Node> valKeyL = new ArrayList<>();
-			for ( final Var v : joinVariables ) {
-				if( v.equals(var1) ){
-					valKeyL.add(value1);
-				}
-				else if( v.equals(var2) ){
-					valKeyL.add(value2);
-				}
-				else{
-					throw new IllegalStateException();
-				}
+		if ( joinVariables.size() == 1 ) {
+			if ( joinVariables.contains(var1) ) {
+				final Iterable<SolutionMapping> it = findSolutionMappings(var1, value1);
+				return new SolutionMappingsIterableWithOneVarFilter(it, var2, value2);
 			}
+			else if ( joinVariables.contains(var2) ) {
+				final Iterable<SolutionMapping> it = findSolutionMappings(var2, value2);
+				return new SolutionMappingsIterableWithOneVarFilter(it, var1, value1);
+			}
+			else {
+				return findSolutionMappingsLastResort(var1, value1, var2, value2);
+			}
+		}
 
-			List<SolutionMapping> solMapList = map.get(valKeyL);
-			if ( solMapList == null) {
-				solMapList = new ArrayList<>();
+		if ( joinVariables.size() > 2 ) {
+			return findSolutionMappingsLastResort(var1, value1, var2, value2);
+		}
+
+		// at this point we know that joinVariables.size() == 2
+
+		if (    (joinVariables.contains(var1) && ! joinVariables.contains(var2))
+		     || (joinVariables.contains(var2) && ! joinVariables.contains(var1)) )
+		{
+			return findSolutionMappingsLastResort(var1, value1, var2, value2);
+		}
+
+		final List<Node> valKeyL = new ArrayList<>();
+		for ( final Var v : joinVariables ) {
+			if( v.equals(var1) ) {
+				valKeyL.add(value1);
 			}
-			return solMapList;
+			else {
+				valKeyL.add(value2);
+			}
 		}
-		else{
-			throw new UnsupportedOperationException();
-		}
+
+		return returnLookupResultOrEmptyList(valKeyL);
 	}
 
 	@Override
@@ -187,34 +203,73 @@ public class SolutionMappingsHashTable extends SolutionMappingsIndexBase
 			final Var var1, final Node value1,
 			final Var var2, final Node value2,
 			final Var var3, final Node value3 )
-			throws UnsupportedOperationException
 	{
-		if( joinVariables.size() == 3 && joinVariables.contains(var1) && joinVariables.contains(var2) && joinVariables.contains(var3) ){
-			final List<Node> valKeyL = new ArrayList<>();
-			for ( final Var v : joinVariables ) {
-				if( v.equals(var1) ){
-					valKeyL.add(value1);
-				}
-				else if( v.equals(var2) ){
-					valKeyL.add(value2);
-				}
-				else if( v.equals(var3) ){
-					valKeyL.add(value3);
-				}
-				else{
-					throw new IllegalArgumentException();
-				}
-			}
+		final boolean c1 = joinVariables.contains(var1);
+		final boolean c2 = joinVariables.contains(var1);
+		final boolean c3 = joinVariables.contains(var1);
 
-			List<SolutionMapping> solMapList = map.get(valKeyL);
-			if ( solMapList == null) {
-				solMapList = new ArrayList<>();
+		if ( joinVariables.size() == 1 ) {
+			if ( c1 ) {
+				final Iterable<SolutionMapping> it = findSolutionMappings(var1, value1);
+				return new SolutionMappingsIterableWithTwoVarsFilter(it, var2, value2, var3, value3);
 			}
-			return solMapList;
+			else if ( c2 ) {
+				final Iterable<SolutionMapping> it = findSolutionMappings(var2, value2);
+				return new SolutionMappingsIterableWithTwoVarsFilter(it, var1, value1, var3, value3);
+			}
+			else if ( c3 ) {
+				final Iterable<SolutionMapping> it = findSolutionMappings(var3, value3);
+				return new SolutionMappingsIterableWithTwoVarsFilter(it, var1, value1, var2, value2);
+			}
+			else {
+				return findSolutionMappingsLastResort(var1, value1, var2, value2, var3, value3);
+			}
 		}
-		else{
-			throw new UnsupportedOperationException();
+
+		if ( joinVariables.size() == 2 ) {
+			if ( c1 && c2 ) {
+				final Iterable<SolutionMapping> it = findSolutionMappings(var1, value1, var2, value2);
+				return new SolutionMappingsIterableWithOneVarFilter(it, var3, value3);
+			}
+			else if ( c1 && c3 ) {
+				final Iterable<SolutionMapping> it = findSolutionMappings(var1, value1, var3, value3);
+				return new SolutionMappingsIterableWithOneVarFilter(it, var2, value2);
+			}
+			else if ( c2 && c3 ) {
+				final Iterable<SolutionMapping> it = findSolutionMappings(var2, value2, var3, value3);
+				return new SolutionMappingsIterableWithOneVarFilter(it, var1, value1);
+			}
+			else {
+				return findSolutionMappingsLastResort(var1, value1, var2, value2, var3, value3);
+			}
 		}
+
+		if ( joinVariables.size() > 3 ) {
+			return findSolutionMappingsLastResort(var1, value1, var2, value2, var3, value3);
+		}
+
+		// at this point we know that joinVariables.size() == 3
+
+		if ( ! c1 || ! c2 || ! c3 ) {
+			return findSolutionMappingsLastResort(var1, value1, var2, value2, var3, value3);
+		}
+
+		// at this point we know that joinVariables consists of exactly the three given variables
+
+		final List<Node> valKeyL = new ArrayList<>();
+		for ( final Var v : joinVariables ) {
+			if( v.equals(var1) ) {
+				valKeyL.add(value1);
+			}
+			else if( v.equals(var2) ) {
+				valKeyL.add(value2);
+			}
+			else {
+				valKeyL.add(value3);
+			}
+		}
+
+		return returnLookupResultOrEmptyList(valKeyL);
 	}
 
 	protected List<Node> getVarKeys(final SolutionMapping e){
@@ -230,4 +285,16 @@ public class SolutionMappingsHashTable extends SolutionMappingsIndexBase
 		}
 		return valKeys;
 	}
+
+	protected Iterable<SolutionMapping> returnLookupResultOrEmptyList( final List<Node> indexKey ) {
+		final List<SolutionMapping> solMapList = map.get(indexKey);
+		
+		// return an empty list if index look-up was unsuccessful
+		if ( solMapList == null) {
+			return Arrays.asList();
+		}
+
+		return solMapList;
+	}
+
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnTwoVars.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnTwoVars.java
@@ -5,10 +5,42 @@ import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.binding.Binding;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
+import se.liu.ida.hefquin.engine.data.utils.SolutionMappingsIterableOverCollectionOfLists;
+import se.liu.ida.hefquin.engine.data.utils.SolutionMappingsIterableWithOneVarFilter;
+import se.liu.ida.hefquin.engine.data.utils.SolutionMappingsIterableWithTwoVarsFilter;
+import se.liu.ida.hefquin.engine.data.utils.SolutionMappingsIteratorOverCollectionOfLists;
 
 import java.util.*;
 
-public class SolutionMappingsHashTableBasedOnTwoVars extends SolutionMappingsIndexBase{
+/**
+ * This is a hash table based implementation of {@link SolutionMappingsIndex}
+ * that can be used for indexes that are built on two query variables and that
+ * are meant to be used for cases in which adding and probing into the index
+ * may not happen concurrently.
+ *
+ * As mentioned above, this implementation assumes that adding and probing
+ * into the index may not happen concurrently. Based on this assumption,
+ * for every method that returns an {@link Iterable} of solution mappings,
+ * the {@link Iterable} that it returns is directly based on an internal
+ * data structure (rather than being a new {@link Iterable} into which the  
+ * solution mappings have been copied). For cases in which the assumption
+ * does not hold (i.e., cases in which adding and probing into the index
+ * may actually happen concurrently), an object of this class may simply
+ * be wrapped in a {@link SolutionMappingsIndexForMixedUsage} which then
+ * creates a new {@link Iterable} for every {@link Iterable} returned by
+ * this implementation. 
+ *
+ * Another assumption of this implementation is that the only variables
+ * relevant for index look-ups are the variable on which the index is built.
+ * In other words, the assumption is that the only variables that the solution
+ * mappings added to the index have in common with the solution mappings given
+ * to the method {@link #getJoinPartners(SolutionMapping)} are the two variables
+ * on which the index is built. For cases in which this assumption does not
+ * hold, a {@link SolutionMappingsIndexWithPostMatching} can be used to wrap
+ * a {@link SolutionMappingsHashTableBasedOnTwoVars}.
+ */
+public class SolutionMappingsHashTableBasedOnTwoVars extends SolutionMappingsIndexBase
+{
     protected final Map<Node, Map<Node, List<SolutionMapping>>> map = new HashMap<>();
     protected final Var joinVar1;
     protected final Var joinVar2;
@@ -46,35 +78,21 @@ public class SolutionMappingsHashTableBasedOnTwoVars extends SolutionMappingsInd
     }
 
     @Override
-    public boolean contains(Object o) {
-        if( !(o instanceof SolutionMapping) ){
-            return false;
-        }
-
-        final Binding b = ((SolutionMapping) o).asJenaBinding();
-        for ( final Map<Node, List<SolutionMapping>> mapIn : map.values() ) {
-            for (final List<SolutionMapping> li : mapIn.values()) {
-                for (final SolutionMapping sm : li) {
-                    if (sm.asJenaBinding().equals(b)) {
-                        return true;
-                    }
-                }
+    public boolean contains( final Object o ) {
+        if( o instanceof SolutionMapping ){
+            final SolutionMapping sm = (SolutionMapping) o;
+            for ( final SolutionMapping sm2 : getJoinPartners(sm)) {
+                if ( sm == sm2 || SolutionMappingUtils.equals(sm, sm2) )
+                    return true;
             }
         }
+
         return false;
     }
 
     @Override
-    public Iterator<SolutionMapping> iterator() {
-        final List<SolutionMapping> solMap = new ArrayList<>();
-
-        final Iterator<Map<Node, List<SolutionMapping>>> mapIn = map.values().iterator();
-        while( mapIn.hasNext() ){
-            for ( final List<SolutionMapping> l : mapIn.next().values()){
-                solMap.addAll(l);
-            }
-        }
-        return solMap.iterator();
+    public Iterable<SolutionMapping> getAllSolutionMappings() {
+        return new MyAllSolutionMappingsIterable();
     }
 
     @Override
@@ -112,99 +130,204 @@ public class SolutionMappingsHashTableBasedOnTwoVars extends SolutionMappingsInd
             for ( final List<SolutionMapping> li : mapIn.values() ) {
                 li.clear();
             }
+            mapIn.clear();
         }
         map.clear();
     }
 
+    /**
+     * This method assumes that the only variables that the given solution
+     * mapping has in common with the solution mappings in the index are the
+     * two variables on which the index is built. For cases in which this
+     * assumption does not hold, the returned solution mappings are not
+     * actually join partners but only candidates for join partners; hence,
+     * they still need to be checked for compatibility with the given solution
+     * mapping. In cases in which he assumption is not guaranteed to hold, this
+     * index can be wrapped by a {@link SolutionMappingsIndexWithPostMatching}
+     * which takes care of the compatibility check. 
+     */
     @Override
     public Iterable<SolutionMapping> getJoinPartners( final SolutionMapping sm )
-            throws UnsupportedOperationException
     {
         final Binding solMapBinding = sm.asJenaBinding();
         final Node n1 = solMapBinding.get(joinVar1);
         final Node n2 = solMapBinding.get(joinVar2);
-        Iterator<SolutionMapping> matchingSolMaps;
 
-        if ( n1 == null ){
-            matchingSolMaps = iterator();
+        if ( n1 == null && n2 == null ) {
+            return getAllSolutionMappings();
         }
-        else if (n2 == null){
-            final Map<Node, List<SolutionMapping>> mapIn = map.get(n1);
-            matchingSolMaps = iteratorInnerMap(mapIn);
+        else if ( n1 == null ) {
+            return findSolutionMappings(joinVar2, n2);
+        }
+        else if ( n2 == null ) {
+            return findSolutionMappings(joinVar1, n1);
         }
         else {
-            final Iterable<SolutionMapping> l = findSolMappingList(n1, n2);
-            matchingSolMaps = ( l != null) ? l.iterator() : null;
+            return findSolutionMappings(joinVar1, n1, joinVar2, n2);
         }
-
-        final List<SolutionMapping> joinPartner = new ArrayList<>();
-        while (matchingSolMaps != null && matchingSolMaps.hasNext()) {
-            final SolutionMapping matchSolM = matchingSolMaps.next();
-            if (SolutionMappingUtils.compatible(sm, matchSolM)) {
-                joinPartner.add(matchSolM);
-            }
-        }
-        return joinPartner;
     }
 
     @Override
-    public Iterable<SolutionMapping> findSolutionMappings(Var var, Node value)
-            throws UnsupportedOperationException {
-        throw new UnsupportedOperationException();
+    public Iterable<SolutionMapping> findSolutionMappings( final Var var, final Node value )
+    {
+        if ( var.equals(joinVar1) ) {
+            return new SolutionMappingsIterableOverCollectionOfLists( map.get(value).values() );
+        }
+        else if ( var.equals(joinVar2) ) {
+            return new SolutionMappingsIterableWithOneVarFilter( getAllSolutionMappings(), joinVar2, value );
+        }
+        else {
+            return findSolutionMappingsLastResort(var, value);
+        }
     }
 
     @Override
     public Iterable<SolutionMapping> findSolutionMappings(
             final Var var1, final Node value1,
             final Var var2, final Node value2 )
-            throws UnsupportedOperationException
-    {
-        if (var1.equals(joinVar1) && var2.equals(joinVar2)){
-            Iterable<SolutionMapping> solMapList = findSolMappingList(value1, value2);
-            if(solMapList == null){
-                solMapList = new ArrayList<>();
-            }
-            return solMapList;
+	{
+		if ( var1.equals(joinVar1) ) {
+			if ( var2.equals(joinVar2) ) {
+				return returnLookupResultOrEmptyList(value1, value2);
+			}
+			else {
+				final Iterable<SolutionMapping> it = findSolutionMappings(var1, value1);
+				return new SolutionMappingsIterableWithOneVarFilter(it, var2, value2);
+			}
         }
-        else if (var1.equals(joinVar2) && var2.equals(joinVar1)){
-            Iterable<SolutionMapping> solMapList = findSolMappingList(value2, value1);
-            if(solMapList == null){
-                solMapList = new ArrayList<>();
-            }
-            return solMapList;
+
+		if ( var2.equals(joinVar1) ) {
+			if ( var1.equals(joinVar2) ) {
+				return returnLookupResultOrEmptyList(value2, value1);
+			}
+			else {
+				final Iterable<SolutionMapping> it = findSolutionMappings(var2, value2);
+				return new SolutionMappingsIterableWithOneVarFilter(it, var1, value1);
+			}
         }
-        else
-        {
-            throw new UnsupportedOperationException();
-        }
-    }
+
+		return findSolutionMappingsLastResort(var1, value1, var2, value2);
+	}
 
     @Override
-    public Iterable<SolutionMapping> findSolutionMappings(Var var1, Node value1, Var var2, Node value2, Var var3, Node value3)
-            throws UnsupportedOperationException {
-        throw new UnsupportedOperationException();
-    }
+    public Iterable<SolutionMapping> findSolutionMappings(
+    		final Var var1, final Node value1,
+    		final Var var2, final Node value2,
+    		final Var var3, final Node value3 )
+	{
+		if ( var1.equals(joinVar1) ) {
+			if ( var2.equals(joinVar2) ) {
+				final Iterable<SolutionMapping> it = returnLookupResultOrEmptyList(value1, value2);
+				return new SolutionMappingsIterableWithOneVarFilter(it, var3, value3);
+			}
+			else if ( var3.equals(joinVar2) ) {
+				final Iterable<SolutionMapping> it = returnLookupResultOrEmptyList(value1, value3);
+				return new SolutionMappingsIterableWithOneVarFilter(it, var2, value2);
+			}
+			else {
+				final Iterable<SolutionMapping> it = findSolutionMappings(var1, value1);
+				return new SolutionMappingsIterableWithTwoVarsFilter(it, var2, value2, var3, value3);
+			}
+        }
 
-    protected Iterable<SolutionMapping> findSolMappingList(
+		if ( var2.equals(joinVar1) ) {
+			if ( var1.equals(joinVar2) ) {
+				final Iterable<SolutionMapping> it = returnLookupResultOrEmptyList(value2, value1);
+				return new SolutionMappingsIterableWithOneVarFilter(it, var3, value3);
+			}
+			else if ( var3.equals(joinVar2) ) {
+				final Iterable<SolutionMapping> it = returnLookupResultOrEmptyList(value2, value3);
+				return new SolutionMappingsIterableWithOneVarFilter(it, var1, value1);
+			}
+			else {
+				final Iterable<SolutionMapping> it = findSolutionMappings(var2, value2);
+				return new SolutionMappingsIterableWithTwoVarsFilter(it, var1, value1, var3, value3);
+			}
+        }
+
+		if ( var3.equals(joinVar1) ) {
+			if ( var1.equals(joinVar2) ) {
+				final Iterable<SolutionMapping> it = returnLookupResultOrEmptyList(value3, value1);
+				return new SolutionMappingsIterableWithOneVarFilter(it, var2, value2);
+			}
+			else if ( var2.equals(joinVar2) ) {
+				final Iterable<SolutionMapping> it = returnLookupResultOrEmptyList(value3, value2);
+				return new SolutionMappingsIterableWithOneVarFilter(it, var3, value3);
+			}
+			else {
+				final Iterable<SolutionMapping> it = findSolutionMappings(var3, value3);
+				return new SolutionMappingsIterableWithTwoVarsFilter(it, var1, value1, var2, value2);
+			}
+        }
+
+		return findSolutionMappingsLastResort(var1, value1, var2, value2, var3, value3);
+	}
+
+
+    protected List<SolutionMapping> returnLookupResultOrEmptyList(
             final Node keyValue1, final Node keyValue2 )
-            throws UnsupportedOperationException
     {
         final Map<Node, List<SolutionMapping>> mapIn = map.get(keyValue1);
-        if (mapIn == null) {
-            return null;
+
+        // return an empty list if index look-up was unsuccessful
+        if ( mapIn == null ) {
+            return Arrays.asList();
         }
-        final List<SolutionMapping> solMapList = mapIn.get(keyValue2);
-        if(solMapList == null){
-            return null;
+
+        final List<SolutionMapping> bucket = mapIn.get(keyValue2);
+
+        // return an empty list if index look-up was unsuccessful
+        if ( bucket == null ) {
+            return Arrays.asList();
         }
-        return solMapList;
+
+        return bucket;
     }
 
-    protected Iterator<SolutionMapping> iteratorInnerMap(final Map<Node, List<SolutionMapping>> mapIn) {
-        final List<SolutionMapping> solMap = new ArrayList<>();
-        for ( final List<SolutionMapping> l : mapIn.values()){
-            solMap.addAll(l);
-        }
-        return solMap.iterator();
-    }
+
+    // ---- helper classes --------
+
+	protected class MyAllSolutionMappingsIterable implements Iterable<SolutionMapping>
+	{
+		@Override
+		public Iterator<SolutionMapping> iterator() {
+			return new MyAllSolutionMappingsIterator();
+		}
+	}
+
+	protected class MyAllSolutionMappingsIterator implements Iterator<SolutionMapping>
+	{
+		final protected Iterator<Map<Node, List<SolutionMapping>>> itInnerMaps = map.values().iterator();
+		protected Iterator<SolutionMapping> itInnerMapElmts;
+
+		public MyAllSolutionMappingsIterator() {
+			if ( itInnerMaps.hasNext() )
+				itInnerMapElmts = new SolutionMappingsIteratorOverCollectionOfLists(
+						itInnerMaps.next().values() );
+			else
+				itInnerMapElmts = null;
+		}
+
+		@Override
+		public boolean hasNext() {
+			if ( itInnerMapElmts == null )
+				return false;
+
+			while ( ! itInnerMapElmts.hasNext() && itInnerMaps.hasNext() ) {
+				itInnerMapElmts = new SolutionMappingsIteratorOverCollectionOfLists(
+						itInnerMaps.next().values() );
+			}
+
+			return itInnerMapElmts.hasNext();
+		}
+
+		@Override
+		public SolutionMapping next() {
+			if ( ! hasNext() )
+				throw new NoSuchElementException();
+
+			return itInnerMapElmts.next();
+		}
+	}
+
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsIndexBase.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsIndexBase.java
@@ -2,7 +2,13 @@ package se.liu.ida.hefquin.engine.datastructures.impl;
 
 import java.util.Collection;
 
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.Var;
+
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
+import se.liu.ida.hefquin.engine.data.utils.SolutionMappingsIterableWithOneVarFilter;
+import se.liu.ida.hefquin.engine.data.utils.SolutionMappingsIterableWithThreeVarsFilter;
+import se.liu.ida.hefquin.engine.data.utils.SolutionMappingsIterableWithTwoVarsFilter;
 import se.liu.ida.hefquin.engine.datastructures.SolutionMappingsIndex;
 
 public abstract class SolutionMappingsIndexBase implements SolutionMappingsIndex
@@ -54,6 +60,42 @@ public abstract class SolutionMappingsIndexBase implements SolutionMappingsIndex
 	@Override
 	public <T> T[] toArray(T[] a) {
 		throw new UnsupportedOperationException();
+	}
+
+	/**
+	 * Wraps a {@link SolutionMappingsIterableWithOneVarFilter}
+	 * around the output of {@link #getAllSolutionMappings()}.
+	 */
+	protected Iterable<SolutionMapping> findSolutionMappingsLastResort(
+			final Var var, final Node value )
+	{
+		final Iterable<SolutionMapping> it = getAllSolutionMappings();
+		return new SolutionMappingsIterableWithOneVarFilter(it, var, value);
+	}
+
+	/**
+	 * Wraps a {@link SolutionMappingsIterableWithTwoVarsFilter}
+	 * around the output of {@link #getAllSolutionMappings()}.
+	 */
+	protected Iterable<SolutionMapping> findSolutionMappingsLastResort(
+			final Var var1, final Node value1,
+			final Var var2, final Node value2 )
+	{
+		final Iterable<SolutionMapping> it = getAllSolutionMappings();
+		return new SolutionMappingsIterableWithTwoVarsFilter(it, var1, value1, var2, value2);
+	}
+
+	/**
+	 * Wraps a {@link SolutionMappingsIterableWithThreeVarsFilter}
+	 * around the output of {@link #getAllSolutionMappings()}.
+	 */
+	protected Iterable<SolutionMapping> findSolutionMappingsLastResort(
+			final Var var1, final Node value1,
+			final Var var2, final Node value2,
+			final Var var3, final Node value3 )
+	{
+		final Iterable<SolutionMapping> it = getAllSolutionMappings();
+		return new SolutionMappingsIterableWithThreeVarsFilter(it, var1, value1, var2, value2, var3, value3);
 	}
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsIndexForMixedUsage.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsIndexForMixedUsage.java
@@ -1,0 +1,82 @@
+package se.liu.ida.hefquin.engine.datastructures.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.Var;
+
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+import se.liu.ida.hefquin.engine.datastructures.SolutionMappingsIndex;
+
+/**
+ * Wraps another {@link SolutionMappingsIndex} and, for every method that
+ * returns an {@link Iterable} of solution mappings, this implementation
+ * copies the {@link Iterable} returned by the wrapped index into a new
+ * list and, then, returns that list.
+ *
+ * This class can be used for cases in which adding and probing into such
+ * an index may happen concurrently. In such cases, there can be conflicts
+ * when the index is updated by one thread while another thread is still
+ * consuming an {@link Iterable} returned by one of the methods. Returning
+ * a copy of the {@link Iterable} avoids such conflicts.
+ */
+public class SolutionMappingsIndexForMixedUsage extends WrappingSolutionMappingsIndex
+{
+	public SolutionMappingsIndexForMixedUsage( final SolutionMappingsIndex wrappedIndex ) {
+		super(wrappedIndex);
+	}
+
+	@Override
+	public <T> T[] toArray( final T[] a ) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Iterable<SolutionMapping> getJoinPartners( final SolutionMapping sm )
+			throws UnsupportedOperationException {
+		return copy( wrappedIndex.getJoinPartners(sm) );
+	}
+
+	@Override
+	public Iterable<SolutionMapping> findSolutionMappings(
+			final Var var, final Node value )
+					throws UnsupportedOperationException
+	{
+		return copy( wrappedIndex.findSolutionMappings(var, value) );
+	}
+
+	@Override
+	public Iterable<SolutionMapping> findSolutionMappings(
+			final Var var1, final Node value1,
+			final Var var2, final Node value2 )
+					throws UnsupportedOperationException
+	{
+		return copy( wrappedIndex.findSolutionMappings(var1, value1, var2, value2) );
+	}
+
+	@Override
+	public Iterable<SolutionMapping> findSolutionMappings(
+			final Var var1, final Node value1,
+			final Var var2, final Node value2,
+			final Var var3, final Node value3 )
+					throws UnsupportedOperationException
+	{
+		return copy( wrappedIndex.findSolutionMappings(var1, value1, var2, value2, var3, value3) );
+	}
+
+	@Override
+	public Iterable<SolutionMapping> getAllSolutionMappings() {
+		return copy( wrappedIndex.getAllSolutionMappings() );
+	}
+
+
+	public static Iterable<SolutionMapping> copy( final Iterable<SolutionMapping> i ) {
+		final List<SolutionMapping> l = new ArrayList<>();
+		for ( final SolutionMapping sm : i ) {
+			l.add(sm);
+		}
+		return l;
+	}
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsIndexWithPostMatching.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsIndexWithPostMatching.java
@@ -1,0 +1,19 @@
+package se.liu.ida.hefquin.engine.datastructures.impl;
+
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+import se.liu.ida.hefquin.engine.data.utils.SolutionMappingsIterableWithSolMapFilter;
+import se.liu.ida.hefquin.engine.datastructures.SolutionMappingsIndex;
+
+public class SolutionMappingsIndexWithPostMatching extends WrappingSolutionMappingsIndex
+{
+	public SolutionMappingsIndexWithPostMatching( final SolutionMappingsIndex wrappedIndex ) {
+		super(wrappedIndex);
+	}
+
+	@Override
+	public Iterable<SolutionMapping> getJoinPartners( final SolutionMapping sm ) {
+		final Iterable<SolutionMapping> it = wrappedIndex.getJoinPartners(sm);
+		return new SolutionMappingsIterableWithSolMapFilter(it, sm);
+	}
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/datastructures/impl/WrappingSolutionMappingsIndex.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/datastructures/impl/WrappingSolutionMappingsIndex.java
@@ -1,0 +1,125 @@
+package se.liu.ida.hefquin.engine.datastructures.impl;
+
+import java.util.Collection;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.Var;
+
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+import se.liu.ida.hefquin.engine.datastructures.SolutionMappingsIndex;
+
+/**
+ * Base class for implementations of {@link SolutionMappingsIndex}
+ * that wrap another {@link SolutionMappingsIndex}. This base class
+ * simply forwards all method calls to the wrapped index. Subclasses
+ * may override this behavior for selected methods.
+ */
+public class WrappingSolutionMappingsIndex implements SolutionMappingsIndex
+{
+	protected final SolutionMappingsIndex wrappedIndex;
+
+	public WrappingSolutionMappingsIndex( final SolutionMappingsIndex wrappedIndex ) {
+		assert wrappedIndex != null;
+		this.wrappedIndex = wrappedIndex;
+	}
+
+	@Override
+	public int size() {
+		return wrappedIndex.size();
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return wrappedIndex.isEmpty();
+	}
+
+	@Override
+	public boolean contains( final Object o ) {
+		return wrappedIndex.contains(o);
+	}
+
+	@Override
+	public Object[] toArray() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public <T> T[] toArray( final T[] a ) {
+		return wrappedIndex.toArray(a);
+	}
+
+	@Override
+	public boolean add( final SolutionMapping e ) {
+		return wrappedIndex.add(e);
+	}
+
+	@Override
+	public boolean remove( final Object o ) {
+		return wrappedIndex.remove(o);
+	}
+
+	@Override
+	public boolean containsAll( final Collection<?> c ) {
+		return wrappedIndex.containsAll(c);
+	}
+
+	@Override
+	public boolean addAll( final Collection<? extends SolutionMapping> c ) {
+		return wrappedIndex.addAll(c);
+	}
+
+	@Override
+	public boolean removeAll( final Collection<?> c ) {
+		return wrappedIndex.removeAll(c);
+	}
+
+	@Override
+	public boolean retainAll( final Collection<?> c ) {
+		return wrappedIndex.retainAll(c);
+	}
+
+	@Override
+	public void clear() {
+		wrappedIndex.clear();
+	}
+
+	@Override
+	public Iterable<SolutionMapping> getJoinPartners( final SolutionMapping sm )
+			throws UnsupportedOperationException {
+		return wrappedIndex.getJoinPartners(sm);
+	}
+
+	@Override
+	public Iterable<SolutionMapping> findSolutionMappings(
+			final Var var, final Node value )
+					throws UnsupportedOperationException
+	{
+		return wrappedIndex.findSolutionMappings(var, value);
+	}
+
+	@Override
+	public Iterable<SolutionMapping> findSolutionMappings(
+			final Var var1, final Node value1,
+			final Var var2, final Node value2 )
+					throws UnsupportedOperationException
+	{
+		return wrappedIndex.findSolutionMappings(var1, value1, var2, value2);
+	}
+
+	@Override
+	public Iterable<SolutionMapping> findSolutionMappings(
+			final Var var1, final Node value1,
+			final Var var2, final Node value2,
+			final Var var3, final Node value3 )
+					throws UnsupportedOperationException
+	{
+		return wrappedIndex.findSolutionMappings(var1, value1, var2, value2, var3, value3);
+	}
+
+	@Override
+	public Iterable<SolutionMapping> getAllSolutionMappings() {
+		return wrappedIndex.getAllSolutionMappings();
+	}
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashJoin.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashJoin.java
@@ -12,16 +12,16 @@ import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultBlock;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
-import java.util.HashSet;
+import java.util.ArrayList;
 import java.util.Iterator;
-import java.util.Set;
+import java.util.List;
 
 public class ExecOpHashJoin implements BinaryExecutableOp {
     protected final SolutionMappingsIndex solMHashTableL;
     protected boolean child1InputComplete = false;
 
     public ExecOpHashJoin(final ExpectedVariables inputVars1, final ExpectedVariables inputVars2) {
-        final Set<Var> joinVars = new HashSet<>( inputVars1.getCertainVariables());
+        final List<Var> joinVars = new ArrayList<>( inputVars1.getCertainVariables() );
         joinVars.retainAll( inputVars2.getCertainVariables() );
 
         if (joinVars.size() == 1 ){

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashJoin.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashJoin.java
@@ -4,9 +4,7 @@ import org.apache.jena.sparql.core.Var;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
 import se.liu.ida.hefquin.engine.datastructures.SolutionMappingsIndex;
-import se.liu.ida.hefquin.engine.datastructures.impl.SolutionMappingsHashTable;
-import se.liu.ida.hefquin.engine.datastructures.impl.SolutionMappingsHashTableBasedOnOneVar;
-import se.liu.ida.hefquin.engine.datastructures.impl.SolutionMappingsHashTableBasedOnTwoVars;
+import se.liu.ida.hefquin.engine.datastructures.impl.*;
 import se.liu.ida.hefquin.engine.queryplan.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultBlock;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
@@ -17,27 +15,36 @@ import java.util.Iterator;
 import java.util.List;
 
 public class ExecOpHashJoin implements BinaryExecutableOp {
-    protected final SolutionMappingsIndex solMHashTableL;
+    protected final SolutionMappingsIndex solMWithMatching;
     protected boolean child1InputComplete = false;
 
     public ExecOpHashJoin(final ExpectedVariables inputVars1, final ExpectedVariables inputVars2) {
         final List<Var> joinVars = new ArrayList<>( inputVars1.getCertainVariables() );
         joinVars.retainAll( inputVars2.getCertainVariables() );
 
+        SolutionMappingsIndex solMHashTable;
         if (joinVars.size() == 1 ){
             final Var joinVar = joinVars.iterator().next();
-            this.solMHashTableL = new SolutionMappingsHashTableBasedOnOneVar(joinVar);
+            solMHashTable = new SolutionMappingsHashTableBasedOnOneVar(joinVar);
         }
         else if (joinVars.size() == 2){
             final Iterator<Var> liVar = joinVars.iterator();
             final Var joinVar1 = liVar.next();
             final Var joinVar2 = liVar.next();
-
-            this.solMHashTableL = new SolutionMappingsHashTableBasedOnTwoVars(joinVar1, joinVar2);
+            solMHashTable = new SolutionMappingsHashTableBasedOnTwoVars(joinVar1, joinVar2);
         }
         else{
-            this.solMHashTableL = new SolutionMappingsHashTable(joinVars);
+            solMHashTable = new SolutionMappingsHashTable(joinVars);
         }
+
+        final List<Var> vars1 = new ArrayList<>( inputVars1.getCertainVariables() );
+        vars1.addAll(inputVars1.getPossibleVariables());
+        final List<Var> vars2 = new ArrayList<>( inputVars2.getCertainVariables() );
+        vars2.addAll(inputVars2.getPossibleVariables());
+        if (inputVars2.getPossibleVariables().removeAll(vars1)){
+            solMHashTable = new SolutionMappingsIndexWithPostMatching(solMHashTable);
+        }
+        this.solMWithMatching = solMHashTable;
     }
 
     @Override
@@ -53,7 +60,7 @@ public class ExecOpHashJoin implements BinaryExecutableOp {
     @Override
     public void processBlockFromChild1( final IntermediateResultBlock input, final IntermediateResultElementSink sink, final ExecutionContext execCxt ) {
         for ( final SolutionMapping smL : input.getSolutionMappings() ) {
-            solMHashTableL.add(smL);
+            solMWithMatching.add(smL);
         }
     }
 
@@ -68,7 +75,7 @@ public class ExecOpHashJoin implements BinaryExecutableOp {
             throw new IllegalStateException();
         }
         for ( final SolutionMapping smR : input.getSolutionMappings() ) {
-            final Iterable<SolutionMapping> matchSolMapL = solMHashTableL.getJoinPartners(smR);
+            final Iterable<SolutionMapping> matchSolMapL = solMWithMatching.getJoinPartners(smR);
             for ( final SolutionMapping smL : matchSolMapL ){
                 sink.send(SolutionMappingUtils.merge(smL, smR));
             }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSymmetricHashJoin.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSymmetricHashJoin.java
@@ -4,9 +4,7 @@ import org.apache.jena.sparql.core.Var;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
 import se.liu.ida.hefquin.engine.datastructures.SolutionMappingsIndex;
-import se.liu.ida.hefquin.engine.datastructures.impl.SolutionMappingsHashTable;
-import se.liu.ida.hefquin.engine.datastructures.impl.SolutionMappingsHashTableBasedOnOneVar;
-import se.liu.ida.hefquin.engine.datastructures.impl.SolutionMappingsHashTableBasedOnTwoVars;
+import se.liu.ida.hefquin.engine.datastructures.impl.*;
 import se.liu.ida.hefquin.engine.queryplan.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultBlock;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
@@ -16,30 +14,44 @@ import java.util.*;
 
 public class ExecOpSymmetricHashJoin implements BinaryExecutableOp{
 
-    protected final SolutionMappingsIndex solMHashTableL;
-    protected final SolutionMappingsIndex solMHashTableR;
+    protected final SolutionMappingsIndex solMWithMatchingL;
+    protected final SolutionMappingsIndex solMWithMatchingR;
 
     public ExecOpSymmetricHashJoin( final ExpectedVariables inputVars1, final ExpectedVariables inputVars2 ){
         final List<Var> joinVars = new ArrayList<>( inputVars1.getCertainVariables() );
         joinVars.retainAll( inputVars2.getCertainVariables() );
 
+        SolutionMappingsIndex solMHashTableL;
+        SolutionMappingsIndex solMHashTableR;
         if (joinVars.size() == 1 ){
             final Var joinVar = joinVars.iterator().next();
-            this.solMHashTableL = new SolutionMappingsHashTableBasedOnOneVar(joinVar);
-            this.solMHashTableR = new SolutionMappingsHashTableBasedOnOneVar(joinVar);
+            solMHashTableL = new SolutionMappingsHashTableBasedOnOneVar(joinVar);
+            solMHashTableR = new SolutionMappingsHashTableBasedOnOneVar(joinVar);
         }
         else if (joinVars.size() == 2){
             final Iterator<Var> liVar = joinVars.iterator();
             final Var joinVar1 = liVar.next();
             final Var joinVar2 = liVar.next();
 
-            this.solMHashTableL = new SolutionMappingsHashTableBasedOnTwoVars(joinVar1, joinVar2);
-            this.solMHashTableR = new SolutionMappingsHashTableBasedOnTwoVars(joinVar1, joinVar2);
+            solMHashTableL = new SolutionMappingsHashTableBasedOnTwoVars(joinVar1, joinVar2);
+            solMHashTableR = new SolutionMappingsHashTableBasedOnTwoVars(joinVar1, joinVar2);
         }
         else{
-            this.solMHashTableL = new SolutionMappingsHashTable(joinVars);
-            this.solMHashTableR = new SolutionMappingsHashTable(joinVars);
+            solMHashTableL = new SolutionMappingsHashTable(joinVars);
+            solMHashTableR = new SolutionMappingsHashTable(joinVars);
         }
+
+        final List<Var> vars1 = new ArrayList<>( inputVars1.getCertainVariables() );
+        vars1.addAll(inputVars1.getPossibleVariables());
+        final List<Var> vars2 = new ArrayList<>( inputVars2.getCertainVariables() );
+        vars2.addAll(inputVars2.getPossibleVariables());
+
+        if(inputVars1.getPossibleVariables().removeAll(vars2))
+            solMHashTableR = new SolutionMappingsIndexWithPostMatching(solMHashTableR);
+        if (inputVars2.getPossibleVariables().removeAll(vars1))
+            solMHashTableL = new SolutionMappingsIndexWithPostMatching(solMHashTableL);
+        this.solMWithMatchingL = new SolutionMappingsIndexForMixedUsage(solMHashTableL);
+        this.solMWithMatchingR = new SolutionMappingsIndexForMixedUsage(solMHashTableR);
     }
 
     @Override
@@ -55,9 +67,9 @@ public class ExecOpSymmetricHashJoin implements BinaryExecutableOp{
     @Override
     public void processBlockFromChild1( final IntermediateResultBlock input, final IntermediateResultElementSink sink, final ExecutionContext execCxt) {
         for ( final SolutionMapping smL : input.getSolutionMappings() ) {
-            solMHashTableL.add(smL);
+            solMWithMatchingL.add(smL);
 
-            final Iterable<SolutionMapping> matchSolMapR = solMHashTableR.getJoinPartners(smL);
+            final Iterable<SolutionMapping> matchSolMapR = solMWithMatchingR.getJoinPartners(smL);
             for ( final SolutionMapping smR : matchSolMapR ){
                 sink.send(SolutionMappingUtils.merge(smL, smR));
             }
@@ -72,9 +84,9 @@ public class ExecOpSymmetricHashJoin implements BinaryExecutableOp{
     @Override
     public void processBlockFromChild2(IntermediateResultBlock input, IntermediateResultElementSink sink, ExecutionContext execCxt) {
         for ( final SolutionMapping smR : input.getSolutionMappings() ) {
-            solMHashTableR.add(smR);
+            solMWithMatchingR.add(smR);
 
-            final Iterable<SolutionMapping> matchSolMapL = solMHashTableL.getJoinPartners(smR);
+            final Iterable<SolutionMapping> matchSolMapL = solMWithMatchingL.getJoinPartners(smR);
             for ( final SolutionMapping smL : matchSolMapL ){
                 sink.send(SolutionMappingUtils.merge(smL, smR));
             }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSymmetricHashJoin.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSymmetricHashJoin.java
@@ -20,7 +20,7 @@ public class ExecOpSymmetricHashJoin implements BinaryExecutableOp{
     protected final SolutionMappingsIndex solMHashTableR;
 
     public ExecOpSymmetricHashJoin( final ExpectedVariables inputVars1, final ExpectedVariables inputVars2 ){
-        final Set<Var> joinVars = new HashSet<>( inputVars1.getCertainVariables());
+        final List<Var> joinVars = new ArrayList<>( inputVars1.getCertainVariables() );
         joinVars.retainAll( inputVars2.getCertainVariables() );
 
         if (joinVars.size() == 1 ){

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSymmetricHashJoin.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSymmetricHashJoin.java
@@ -8,28 +8,30 @@ import se.liu.ida.hefquin.engine.datastructures.impl.*;
 import se.liu.ida.hefquin.engine.queryplan.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultBlock;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
+import se.liu.ida.hefquin.engine.queryplan.utils.ExpectedVariablesUtils;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 import java.util.*;
 
 public class ExecOpSymmetricHashJoin implements BinaryExecutableOp{
 
-    protected final SolutionMappingsIndex solMWithMatchingL;
-    protected final SolutionMappingsIndex solMWithMatchingR;
+    protected final SolutionMappingsIndex indexForChild1;
+    protected final SolutionMappingsIndex indexForChild2;
 
-    public ExecOpSymmetricHashJoin( final ExpectedVariables inputVars1, final ExpectedVariables inputVars2 ){
-        final List<Var> joinVars = new ArrayList<>( inputVars1.getCertainVariables() );
-        joinVars.retainAll( inputVars2.getCertainVariables() );
+    public ExecOpSymmetricHashJoin( final ExpectedVariables inputVars1, final ExpectedVariables inputVars2 ) {
+        // determine the certain join variables
+        final Set<Var> certainJoinVars = ExpectedVariablesUtils.intersectionOfCertainVariables(inputVars1, inputVars2);
 
+        // set up the core part of the two indexes first; it is built on the certain join variables
         SolutionMappingsIndex solMHashTableL;
         SolutionMappingsIndex solMHashTableR;
-        if (joinVars.size() == 1 ){
-            final Var joinVar = joinVars.iterator().next();
+        if ( certainJoinVars.size() == 1 ) {
+            final Var joinVar = certainJoinVars.iterator().next();
             solMHashTableL = new SolutionMappingsHashTableBasedOnOneVar(joinVar);
             solMHashTableR = new SolutionMappingsHashTableBasedOnOneVar(joinVar);
         }
-        else if (joinVars.size() == 2){
-            final Iterator<Var> liVar = joinVars.iterator();
+        else if ( certainJoinVars.size() == 2 ) {
+            final Iterator<Var> liVar = certainJoinVars.iterator();
             final Var joinVar1 = liVar.next();
             final Var joinVar2 = liVar.next();
 
@@ -37,21 +39,20 @@ public class ExecOpSymmetricHashJoin implements BinaryExecutableOp{
             solMHashTableR = new SolutionMappingsHashTableBasedOnTwoVars(joinVar1, joinVar2);
         }
         else{
-            solMHashTableL = new SolutionMappingsHashTable(joinVars);
-            solMHashTableR = new SolutionMappingsHashTable(joinVars);
+            solMHashTableL = new SolutionMappingsHashTable(certainJoinVars);
+            solMHashTableR = new SolutionMappingsHashTable(certainJoinVars);
         }
 
-        final List<Var> vars1 = new ArrayList<>( inputVars1.getCertainVariables() );
-        vars1.addAll(inputVars1.getPossibleVariables());
-        final List<Var> vars2 = new ArrayList<>( inputVars2.getCertainVariables() );
-        vars2.addAll(inputVars2.getPossibleVariables());
-
-        if(inputVars1.getPossibleVariables().removeAll(vars2))
-            solMHashTableR = new SolutionMappingsIndexWithPostMatching(solMHashTableR);
-        if (inputVars2.getPossibleVariables().removeAll(vars1))
+        // Check whether there are other variables that may be relevant for
+        // the join and, if so, set up the indexes to use post-matching.
+        final Set<Var> potentialJoinVars = ExpectedVariablesUtils.intersectionOfAllVariables(inputVars1, inputVars2);
+        if ( ! potentialJoinVars.equals(certainJoinVars) ) {
             solMHashTableL = new SolutionMappingsIndexWithPostMatching(solMHashTableL);
-        this.solMWithMatchingL = new SolutionMappingsIndexForMixedUsage(solMHashTableL);
-        this.solMWithMatchingR = new SolutionMappingsIndexForMixedUsage(solMHashTableR);
+            solMHashTableR = new SolutionMappingsIndexWithPostMatching(solMHashTableR);
+        }
+
+        this.indexForChild1 = new SolutionMappingsIndexForMixedUsage(solMHashTableL);
+        this.indexForChild2 = new SolutionMappingsIndexForMixedUsage(solMHashTableR);
     }
 
     @Override
@@ -67,9 +68,9 @@ public class ExecOpSymmetricHashJoin implements BinaryExecutableOp{
     @Override
     public void processBlockFromChild1( final IntermediateResultBlock input, final IntermediateResultElementSink sink, final ExecutionContext execCxt) {
         for ( final SolutionMapping smL : input.getSolutionMappings() ) {
-            solMWithMatchingL.add(smL);
+            indexForChild1.add(smL);
 
-            final Iterable<SolutionMapping> matchSolMapR = solMWithMatchingR.getJoinPartners(smL);
+            final Iterable<SolutionMapping> matchSolMapR = indexForChild2.getJoinPartners(smL);
             for ( final SolutionMapping smR : matchSolMapR ){
                 sink.send(SolutionMappingUtils.merge(smL, smR));
             }
@@ -84,9 +85,9 @@ public class ExecOpSymmetricHashJoin implements BinaryExecutableOp{
     @Override
     public void processBlockFromChild2(IntermediateResultBlock input, IntermediateResultElementSink sink, ExecutionContext execCxt) {
         for ( final SolutionMapping smR : input.getSolutionMappings() ) {
-            solMWithMatchingR.add(smR);
+            indexForChild2.add(smR);
 
-            final Iterable<SolutionMapping> matchSolMapL = solMWithMatchingL.getJoinPartners(smR);
+            final Iterable<SolutionMapping> matchSolMapL = indexForChild1.getJoinPartners(smR);
             for ( final SolutionMapping smL : matchSolMapL ){
                 sink.send(SolutionMappingUtils.merge(smL, smR));
             }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/ExpectedVariablesUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/ExpectedVariablesUtils.java
@@ -1,0 +1,130 @@
+package se.liu.ida.hefquin.engine.queryplan.utils;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.jena.sparql.core.Var;
+
+import se.liu.ida.hefquin.engine.queryplan.ExpectedVariables;
+
+public class ExpectedVariablesUtils
+{
+	/**
+	 * Returns a set of all the certain variables in all the given
+	 * {@link ExpectedVariables} objects. Returns null if no such
+	 * object is given.
+	 */
+	public static Set<Var> unionOfCertainVariables( final ExpectedVariables ... e ) {
+		if ( e.length == 0 ) {
+			return null;
+		}
+
+		final Set<Var> result = new HashSet<>( e[0].getCertainVariables() );
+
+		for ( int i = 1; i < e.length; ++i ) {
+			result.addAll( e[i].getCertainVariables() );
+		}
+
+		return result;
+	}
+
+	/**
+	 * Returns a set of all the possible variables in all the given
+	 * {@link ExpectedVariables} objects. Returns null if no such
+	 * object is given.
+	 */
+	public static Set<Var> unionOfPossibleVariables( final ExpectedVariables ... e ) {
+		if ( e.length == 0 ) {
+			return null;
+		}
+
+		final Set<Var> result = new HashSet<>( e[0].getPossibleVariables() );
+
+		for ( int i = 1; i < e.length; ++i ) {
+			result.addAll( e[i].getPossibleVariables() );
+		}
+
+		return result;
+	}
+
+	/**
+	 * Returns a set of all the variables (certain and possible) in all
+	 * the given {@link ExpectedVariables} objects. Returns null if no
+	 * such object is given.
+	 */
+	public static Set<Var> unionOfAllVariables( final ExpectedVariables ... e ) {
+		if ( e.length == 0 ) {
+			return null;
+		}
+
+		final Set<Var> result = new HashSet<>( e[0].getCertainVariables() );
+		result.addAll( e[0].getPossibleVariables() );
+
+		for ( int i = 1; i < e.length; ++i ) {
+			result.addAll( e[i].getCertainVariables() );
+			result.addAll( e[i].getPossibleVariables() );
+		}
+
+		return result;
+	}
+
+	/**
+	 * Returns an intersection of the sets of certain variables in all
+	 * the given {@link ExpectedVariables} objects. Returns null if no
+	 * such object is given.
+	 */
+	public static Set<Var> intersectionOfCertainVariables( final ExpectedVariables ... e ) {
+		if ( e.length == 0 ) {
+			return null;
+		}
+
+		final Set<Var> result = new HashSet<>( e[0].getCertainVariables() );
+
+		for ( int i = 1; i < e.length; ++i ) {
+			result.retainAll( e[i].getCertainVariables() );
+		}
+
+		return result;
+	}
+
+	/**
+	 * Returns an intersection of the sets of possible variables in all
+	 * the given {@link ExpectedVariables} objects. Returns null if no
+	 * such object is given.
+	 */
+	public static Set<Var> intersectionOfPossibleVariables( final ExpectedVariables ... e ) {
+		if ( e.length == 0 ) {
+			return null;
+		}
+
+		final Set<Var> result = new HashSet<>( e[0].getPossibleVariables() );
+
+		for ( int i = 1; i < e.length; ++i ) {
+			result.retainAll( e[i].getPossibleVariables() );
+		}
+
+		return result;
+	}
+
+	/**
+	 * Returns an intersection of the sets of all variables (certain and
+	 * possible) in all the given {@link ExpectedVariables} objects.
+	 * Returns null if no such object is given.
+	 */
+	public static Set<Var> intersectionOfAllVariables( final ExpectedVariables ... e ) {
+		if ( e.length == 0 ) {
+			return null;
+		}
+
+		final Set<Var> result = new HashSet<>( e[0].getCertainVariables() );
+		result.addAll( e[0].getPossibleVariables() );
+
+		for ( int i = 1; i < e.length; ++i ) {
+			final Set<Var> allVarsInCurrentObject = unionOfAllVariables( e[i] );
+			result.retainAll( allVarsInCurrentObject );
+		}
+
+		return result;
+	}
+
+}

--- a/src/test/java/se/liu/ida/hefquin/engine/EngineTestBase.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/EngineTestBase.java
@@ -1,5 +1,8 @@
 package se.liu.ida.hefquin.engine;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Date;
@@ -51,6 +54,35 @@ public abstract class EngineTestBase
 	 * unit tests that access servers on the actual Web.
 	 */
 	public static boolean skipLiveWebTests = true;
+
+
+	protected void assertHasNext( final Iterator<SolutionMapping> it,
+	                              final String expectedURIforV1, final Var v1,
+	                              final String expectedURIforV2, final Var v2 )
+	{
+		assertTrue( it.hasNext() );
+
+        final Binding b = it.next().asJenaBinding();
+        assertEquals( 2, b.size() );
+
+        assertEquals( expectedURIforV1, b.get(v1).getURI() );
+        assertEquals( expectedURIforV2, b.get(v2).getURI() );
+	}
+
+	protected void assertHasNext( final Iterator<SolutionMapping> it,
+	                              final String expectedURIforV1, final Var v1,
+	                              final String expectedURIforV2, final Var v2,
+	                              final String expectedURIforV3, final Var v3 )
+	{
+		assertTrue( it.hasNext() );
+
+        final Binding b = it.next().asJenaBinding();
+        assertEquals( 3, b.size() );
+
+        assertEquals( expectedURIforV1, b.get(v1).getURI() );
+        assertEquals( expectedURIforV2, b.get(v2).getURI() );
+        assertEquals( expectedURIforV3, b.get(v3).getURI() );
+	}
 
 
 	protected static abstract class FederationMemberBaseForTest implements FederationMember

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableOverCollectionOfListsTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableOverCollectionOfListsTest.java
@@ -1,12 +1,8 @@
 package se.liu.ida.hefquin.engine.data.utils;
 
-import org.apache.jena.graph.Node;
-import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.junit.Test;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
-import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
 
 import java.util.*;
 
@@ -14,29 +10,13 @@ import static org.junit.Assert.*;
 
 public class SolutionMappingsIterableOverCollectionOfListsTest {
     @Test
-    public void hashTableWithOneInputVariable() {
-        final Var var2 = Var.alloc("v2");
-        final Var var3 = Var.alloc("v3");
-
-        final Node y1 = NodeFactory.createURI("http://example.org/y1");
-        final Node y2 = NodeFactory.createURI("http://example.org/y2");
-        final Node z1 = NodeFactory.createURI("http://example.org/z1");
-        final Node z2 = NodeFactory.createURI("http://example.org/z2");
-        final Node z3 = NodeFactory.createURI("http://example.org/z3");
-
-        final Map<Node, List<SolutionMapping>> map = new HashMap<>();
-
-        final List<SolutionMapping> solMapList1 = new ArrayList<>();
-        solMapList1.add(SolutionMappingUtils.createSolutionMapping(var2, y1, var3, z1));
-        solMapList1.add(SolutionMappingUtils.createSolutionMapping(var2, y1, var3, z2));
-        map.put(y1, solMapList1);
-
-        final List<SolutionMapping> solMapList2 = new ArrayList<>();
-        solMapList2.add(SolutionMappingUtils.createSolutionMapping(var2, y2, var3, z3));
-        map.put(y2, solMapList2);
+    public void solMappingsIterableOverCollectionOfLists() {
+        final Collection<List<SolutionMapping>> solMapCollection = new ArrayList<>();
+        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
+        solMapCollection.add(solMaps.getSolMapListWithTwoVar());
 
         // Iterate over all solution mappings contained in a collection
-        final Iterable<SolutionMapping> allSolMap = new SolutionMappingsIterableOverCollectionOfLists( map.values() );
+        final Iterable<SolutionMapping> allSolMap = new SolutionMappingsIterableOverCollectionOfLists(solMapCollection);
         final Iterator<SolutionMapping> it3 = allSolMap.iterator();
 
         assertTrue( it3.hasNext() );

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableOverCollectionOfListsTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableOverCollectionOfListsTest.java
@@ -1,0 +1,56 @@
+package se.liu.ida.hefquin.engine.data.utils;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.junit.Test;
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class SolutionMappingsIterableOverCollectionOfListsTest {
+    @Test
+    public void hashTableWithOneInputVariable() {
+        final Var var2 = Var.alloc("v2");
+        final Var var3 = Var.alloc("v3");
+
+        final Node y1 = NodeFactory.createURI("http://example.org/y1");
+        final Node y2 = NodeFactory.createURI("http://example.org/y2");
+        final Node z1 = NodeFactory.createURI("http://example.org/z1");
+        final Node z2 = NodeFactory.createURI("http://example.org/z2");
+        final Node z3 = NodeFactory.createURI("http://example.org/z3");
+
+        final Map<Node, List<SolutionMapping>> map = new HashMap<>();
+
+        final List<SolutionMapping> solMapList1 = new ArrayList<>();
+        solMapList1.add(SolutionMappingUtils.createSolutionMapping(var2, y1, var3, z1));
+        solMapList1.add(SolutionMappingUtils.createSolutionMapping(var2, y1, var3, z2));
+        map.put(y1, solMapList1);
+
+        final List<SolutionMapping> solMapList2 = new ArrayList<>();
+        solMapList2.add(SolutionMappingUtils.createSolutionMapping(var2, y2, var3, z3));
+        map.put(y2, solMapList2);
+
+        // Iterate over all solution mappings contained in a collection
+        final Iterable<SolutionMapping> allSolMap = new SolutionMappingsIterableOverCollectionOfLists( map.values() );
+        final Iterator<SolutionMapping> it3 = allSolMap.iterator();
+
+        assertTrue( it3.hasNext() );
+        final Binding bIt31 = it3.next().asJenaBinding();
+        assertEquals( 2, bIt31.size() );
+
+        assertTrue( it3.hasNext() );
+        final Binding bIt32 = it3.next().asJenaBinding();
+        assertEquals( 2, bIt32.size() );
+
+        assertTrue( it3.hasNext() );
+        final Binding bIt33 = it3.next().asJenaBinding();
+        assertEquals( 2, bIt33.size() );
+
+        assertFalse( it3.hasNext() );
+    }
+}

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableOverCollectionOfListsTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableOverCollectionOfListsTest.java
@@ -3,10 +3,12 @@ package se.liu.ida.hefquin.engine.data.utils;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.junit.Test;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
+import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
 
 import java.util.*;
 
 import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 public class SolutionMappingsIterableOverCollectionOfListsTest {
     @Test
@@ -22,14 +24,20 @@ public class SolutionMappingsIterableOverCollectionOfListsTest {
         assertTrue( it3.hasNext() );
         final Binding bIt31 = it3.next().asJenaBinding();
         assertEquals( 2, bIt31.size() );
+        assertEquals( "http://example.org/y1", bIt31.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z1", bIt31.get(solMaps.var3).getURI() );
 
         assertTrue( it3.hasNext() );
         final Binding bIt32 = it3.next().asJenaBinding();
         assertEquals( 2, bIt32.size() );
+        assertEquals("http://example.org/y1", bIt32.get(solMaps.var2).getURI());
+        assertEquals("http://example.org/z2", bIt32.get(solMaps.var3).getURI());
 
         assertTrue( it3.hasNext() );
         final Binding bIt33 = it3.next().asJenaBinding();
         assertEquals( 2, bIt33.size() );
+        assertEquals("http://example.org/y2", bIt33.get(solMaps.var2).getURI());
+        assertEquals("http://example.org/z3", bIt33.get(solMaps.var3).getURI());
 
         assertFalse( it3.hasNext() );
     }

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableOverCollectionOfListsTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableOverCollectionOfListsTest.java
@@ -1,42 +1,110 @@
 package se.liu.ida.hefquin.engine.data.utils;
 
-import org.apache.jena.sparql.engine.binding.Binding;
 import org.junit.Test;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 
 import java.util.*;
 
-import static org.junit.Assert.*;
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 
 public class SolutionMappingsIterableOverCollectionOfListsTest extends TestsForSolutionMappingsIterableWithFilter
 {
     @Test
-    public void solMappingsIterableOverCollectionOfLists() {
+    public void oneList() {
         final Collection<List<SolutionMapping>> solMapCollection = new ArrayList<>();
         solMapCollection.add( getSolMapListWithTwoVar() );
 
         // Iterate over all solution mappings contained in a collection
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableOverCollectionOfLists(solMapCollection).iterator();
 
-        assertTrue( it.hasNext() );
-        final Binding b1 = it.next().asJenaBinding();
-        assertEquals( 2, b1.size() );
-        assertEquals( "http://example.org/y1", b1.get(var2).getURI() );
-        assertEquals( "http://example.org/z1", b1.get(var3).getURI() );
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z1", var3 );
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z2", var3 );
+        assertHasNext( it, "http://example.org/y2", var2, "http://example.org/z3", var3 );
+        assertFalse( it.hasNext() );
+    }
 
-        assertTrue( it.hasNext() );
-        final Binding b2 = it.next().asJenaBinding();
-        assertEquals( 2, b2.size() );
-        assertEquals("http://example.org/y1", b2.get(var2).getURI());
-        assertEquals("http://example.org/z2", b2.get(var3).getURI());
+    @Test
+    public void twoListsSame() {
+        final Collection<List<SolutionMapping>> solMapCollection = new ArrayList<>();
+        solMapCollection.add( getSolMapListWithTwoVar() );
+        solMapCollection.add( getSolMapListWithTwoVar() );
 
-        assertTrue( it.hasNext() );
-        final Binding b3 = it.next().asJenaBinding();
-        assertEquals( 2, b3.size() );
-        assertEquals("http://example.org/y2", b3.get(var2).getURI());
-        assertEquals("http://example.org/z3", b3.get(var3).getURI());
+        // Iterate over all solution mappings contained in a collection
+        final Iterator<SolutionMapping> it = new SolutionMappingsIterableOverCollectionOfLists(solMapCollection).iterator();
+
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z1", var3 );
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z2", var3 );
+        assertHasNext( it, "http://example.org/y2", var2, "http://example.org/z3", var3 );
+
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z1", var3 );
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z2", var3 );
+        assertHasNext( it, "http://example.org/y2", var2, "http://example.org/z3", var3 );
 
         assertFalse( it.hasNext() );
     }
+
+    @Test
+    public void twoListsDifferent() {
+        final Collection<List<SolutionMapping>> solMapCollection = new ArrayList<>();
+        solMapCollection.add( getSolMapListWithTwoVar() );
+        solMapCollection.add( getSolMapListWithThreeVar() );
+
+        // Iterate over all solution mappings contained in a collection
+        final Iterator<SolutionMapping> it = new SolutionMappingsIterableOverCollectionOfLists(solMapCollection).iterator();
+
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z1", var3 );
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z2", var3 );
+        assertHasNext( it, "http://example.org/y2", var2, "http://example.org/z3", var3 );
+
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z1", var3, "http://example.org/x1", var1 );
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z2", var3, "http://example.org/x1", var1 );
+        assertHasNext( it, "http://example.org/y2", var2, "http://example.org/z2", var3, "http://example.org/x2", var1 );
+
+        assertFalse( it.hasNext() );
+    }
+
+    @Test
+    public void twoListsOneEmpty1() {
+        final Collection<List<SolutionMapping>> solMapCollection = new ArrayList<>();
+        solMapCollection.add( getSolMapListWithTwoVar() );
+        solMapCollection.add( new ArrayList<>() );  // <--- empty list second
+
+        // Iterate over all solution mappings contained in a collection
+        final Iterator<SolutionMapping> it = new SolutionMappingsIterableOverCollectionOfLists(solMapCollection).iterator();
+
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z1", var3 );
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z2", var3 );
+        assertHasNext( it, "http://example.org/y2", var2, "http://example.org/z3", var3 );
+
+        assertFalse( it.hasNext() );
+    }
+
+    @Test
+    public void twoListsOneEmpty2() {
+        final Collection<List<SolutionMapping>> solMapCollection = new ArrayList<>();
+        solMapCollection.add( new ArrayList<>() );  // <--- empty list first
+        solMapCollection.add( getSolMapListWithTwoVar() );
+
+        // Iterate over all solution mappings contained in a collection
+        final Iterator<SolutionMapping> it = new SolutionMappingsIterableOverCollectionOfLists(solMapCollection).iterator();
+
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z1", var3 );
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z2", var3 );
+        assertHasNext( it, "http://example.org/y2", var2, "http://example.org/z3", var3 );
+
+        assertFalse( it.hasNext() );
+    }
+
+    @Test
+    public void twoEmptyLists() {
+        final Collection<List<SolutionMapping>> solMapCollection = new ArrayList<>();
+        solMapCollection.add( new ArrayList<>() );
+        solMapCollection.add( new ArrayList<>() );
+
+        // Iterate over all solution mappings contained in a collection
+        final Iterator<SolutionMapping> it = new SolutionMappingsIterableOverCollectionOfLists(solMapCollection).iterator();
+
+        assertFalse( it.hasNext() );
+    }
+
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableOverCollectionOfListsTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableOverCollectionOfListsTest.java
@@ -3,42 +3,40 @@ package se.liu.ida.hefquin.engine.data.utils;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.junit.Test;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
-import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
 
 import java.util.*;
 
 import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 
-public class SolutionMappingsIterableOverCollectionOfListsTest {
+public class SolutionMappingsIterableOverCollectionOfListsTest extends TestsForSolutionMappingsIterableWithFilter
+{
     @Test
     public void solMappingsIterableOverCollectionOfLists() {
         final Collection<List<SolutionMapping>> solMapCollection = new ArrayList<>();
-        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
-        solMapCollection.add(solMaps.getSolMapListWithTwoVar());
+        solMapCollection.add( getSolMapListWithTwoVar() );
 
         // Iterate over all solution mappings contained in a collection
-        final Iterable<SolutionMapping> allSolMap = new SolutionMappingsIterableOverCollectionOfLists(solMapCollection);
-        final Iterator<SolutionMapping> it3 = allSolMap.iterator();
+        final Iterator<SolutionMapping> it = new SolutionMappingsIterableOverCollectionOfLists(solMapCollection).iterator();
 
-        assertTrue( it3.hasNext() );
-        final Binding bIt31 = it3.next().asJenaBinding();
-        assertEquals( 2, bIt31.size() );
-        assertEquals( "http://example.org/y1", bIt31.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z1", bIt31.get(solMaps.var3).getURI() );
+        assertTrue( it.hasNext() );
+        final Binding b1 = it.next().asJenaBinding();
+        assertEquals( 2, b1.size() );
+        assertEquals( "http://example.org/y1", b1.get(var2).getURI() );
+        assertEquals( "http://example.org/z1", b1.get(var3).getURI() );
 
-        assertTrue( it3.hasNext() );
-        final Binding bIt32 = it3.next().asJenaBinding();
-        assertEquals( 2, bIt32.size() );
-        assertEquals("http://example.org/y1", bIt32.get(solMaps.var2).getURI());
-        assertEquals("http://example.org/z2", bIt32.get(solMaps.var3).getURI());
+        assertTrue( it.hasNext() );
+        final Binding b2 = it.next().asJenaBinding();
+        assertEquals( 2, b2.size() );
+        assertEquals("http://example.org/y1", b2.get(var2).getURI());
+        assertEquals("http://example.org/z2", b2.get(var3).getURI());
 
-        assertTrue( it3.hasNext() );
-        final Binding bIt33 = it3.next().asJenaBinding();
-        assertEquals( 2, bIt33.size() );
-        assertEquals("http://example.org/y2", bIt33.get(solMaps.var2).getURI());
-        assertEquals("http://example.org/z3", bIt33.get(solMaps.var3).getURI());
+        assertTrue( it.hasNext() );
+        final Binding b3 = it.next().asJenaBinding();
+        assertEquals( 2, b3.size() );
+        assertEquals("http://example.org/y2", b3.get(var2).getURI());
+        assertEquals("http://example.org/z3", b3.get(var3).getURI());
 
-        assertFalse( it3.hasNext() );
+        assertFalse( it.hasNext() );
     }
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithOneVarFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithOneVarFilterTest.java
@@ -1,48 +1,19 @@
 package se.liu.ida.hefquin.engine.data.utils;
 
-import org.apache.jena.graph.Node;
-import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.junit.Test;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
-import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
-import se.liu.ida.hefquin.engine.datastructures.impl.SolutionMappingsHashTableBasedOnOneVar;
-import se.liu.ida.hefquin.engine.datastructures.impl.SolutionMappingsIndexBase;
 
 import java.util.*;
-
 import static org.junit.Assert.*;
 
 public class SolutionMappingsIterableWithOneVarFilterTest {
     @Test
-    public void hashTableWithOneInputVariable() {
-        final Var var1 = Var.alloc("v1");
-        final Var var2 = Var.alloc("v2");
-        final Var var3 = Var.alloc("v3");
+    public void solMappingsIterableWithOneVarFilter_subset() {
+        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
 
-        final Node y1 = NodeFactory.createURI("http://example.org/y1");
-        final Node y2 = NodeFactory.createURI("http://example.org/y2");
-        final Node z1 = NodeFactory.createURI("http://example.org/z1");
-        final Node z2 = NodeFactory.createURI("http://example.org/z2");
-        final Node z3 = NodeFactory.createURI("http://example.org/z3");
-        final Node p = NodeFactory.createURI("http://example.org/p");
-
-        // create SolutionMappingsIndexBase
-        final SolutionMappingsIndexBase solMHashTable = new SolutionMappingsHashTableBasedOnOneVar(var2);
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var2, y1,
-                var3, z1) );
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var2, y1,
-                var3, z2) );
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var2, y2,
-                var3, z3) );
-        final Iterable<SolutionMapping> allSolMap = solMHashTable.getAllSolutionMappings();
-
-        // iterate over the subset of solution mappings that have a given value for var2
-        final Iterable<SolutionMapping> solMapAfterFilter1 = new SolutionMappingsIterableWithOneVarFilter( allSolMap, var2, y1 );
+        // iterate over the subset of solution mappings that y1 for var2
+        final Iterable<SolutionMapping> solMapAfterFilter1 = new SolutionMappingsIterableWithOneVarFilter( solMaps.getSolMapListWithTwoVar(), solMaps.var2, solMaps.y1 );
         final Iterator<SolutionMapping> it1 = solMapAfterFilter1.iterator();
         assertTrue( it1.hasNext() );
         final Binding bIt1 = it1.next().asJenaBinding();
@@ -53,15 +24,25 @@ public class SolutionMappingsIterableWithOneVarFilterTest {
         assertEquals( 2, bIt2.size() );
 
         assertFalse( it1.hasNext() );
+    }
+
+    @Test
+    public void solMappingsIterableWithOneVarFilter_noMatching() {
+        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
 
         // no solution mappings that have p for var3
-        final Iterable<SolutionMapping> solMapAfterFilter2 = new SolutionMappingsIterableWithOneVarFilter( allSolMap, var3, p );
+        final Iterable<SolutionMapping> solMapAfterFilter2 = new SolutionMappingsIterableWithOneVarFilter( solMaps.getSolMapListWithTwoVar(), solMaps.var3, solMaps.p );
         final Iterator<SolutionMapping> it2 = solMapAfterFilter2.iterator();
 
         assertFalse( it2.hasNext() );
+    }
+
+    @Test
+    public void solMappingsIterableWithOneVarFilter_all() {
+        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
 
         // return all solution mappings: no solution mappings that have value for var1
-        final Iterable<SolutionMapping> solMapAfterFilter3 = new SolutionMappingsIterableWithOneVarFilter( allSolMap, var1, y1 );
+        final Iterable<SolutionMapping> solMapAfterFilter3 = new SolutionMappingsIterableWithOneVarFilter( solMaps.getSolMapListWithTwoVar(), solMaps.var1, solMaps.y1 );
         final Iterator<SolutionMapping> it3 = solMapAfterFilter3.iterator();
         assertTrue( it3.hasNext() );
         final Binding bIt31 = it3.next().asJenaBinding();

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithOneVarFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithOneVarFilterTest.java
@@ -7,65 +7,59 @@ import se.liu.ida.hefquin.engine.data.SolutionMapping;
 import java.util.*;
 import static org.junit.Assert.*;
 
-public class SolutionMappingsIterableWithOneVarFilterTest {
+public class SolutionMappingsIterableWithOneVarFilterTest extends TestsForSolutionMappingsIterableWithFilter
+{
     @Test
     public void solMappingsIterableWithOneVarFilter_subset() {
-        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
-
         // iterate over the subset of solution mappings that y1 for var2
-        final Iterable<SolutionMapping> solMapAfterFilter1 = new SolutionMappingsIterableWithOneVarFilter( solMaps.getSolMapListWithTwoVar(), solMaps.var2, solMaps.y1 );
-        final Iterator<SolutionMapping> it1 = solMapAfterFilter1.iterator();
-        assertTrue( it1.hasNext() );
-        final Binding bIt1 = it1.next().asJenaBinding();
-        assertEquals( 2, bIt1.size() );
-        assertEquals( "http://example.org/y1", bIt1.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z1", bIt1.get(solMaps.var3).getURI() );
+        final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithOneVarFilter( getSolMapListWithTwoVar(), var2, y1 ).iterator();
 
-        assertTrue( it1.hasNext() );
-        final Binding bIt2 = it1.next().asJenaBinding();
-        assertEquals( 2, bIt2.size() );
-        assertEquals("http://example.org/y1", bIt2.get(solMaps.var2).getURI());
-        assertEquals("http://example.org/z2", bIt2.get(solMaps.var3).getURI());
+        assertTrue( it.hasNext() );
+        final Binding b1 = it.next().asJenaBinding();
+        assertEquals( 2, b1.size() );
+        assertEquals( "http://example.org/y1", b1.get(var2).getURI() );
+        assertEquals( "http://example.org/z1", b1.get(var3).getURI() );
 
-        assertFalse( it1.hasNext() );
+        assertTrue( it.hasNext() );
+        final Binding b2 = it.next().asJenaBinding();
+        assertEquals( 2, b2.size() );
+        assertEquals("http://example.org/y1", b2.get(var2).getURI());
+        assertEquals("http://example.org/z2", b2.get(var3).getURI());
+
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void solMappingsIterableWithOneVarFilter_noMatching() {
-        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
-
         // no solution mappings that have p for var3
-        final Iterable<SolutionMapping> solMapAfterFilter2 = new SolutionMappingsIterableWithOneVarFilter( solMaps.getSolMapListWithTwoVar(), solMaps.var3, solMaps.p );
-        final Iterator<SolutionMapping> it2 = solMapAfterFilter2.iterator();
+        final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithOneVarFilter( getSolMapListWithTwoVar(), var3, p ).iterator();
 
-        assertFalse( it2.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void solMappingsIterableWithOneVarFilter_all() {
-        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
-
         // return all solution mappings: no solution mappings that have value for var1
-        final Iterable<SolutionMapping> solMapAfterFilter3 = new SolutionMappingsIterableWithOneVarFilter( solMaps.getSolMapListWithTwoVar(), solMaps.var1, solMaps.y1 );
-        final Iterator<SolutionMapping> it3 = solMapAfterFilter3.iterator();
-        assertTrue( it3.hasNext() );
-        final Binding bIt31 = it3.next().asJenaBinding();
-        assertEquals( 2, bIt31.size() );
-        assertEquals( "http://example.org/y1", bIt31.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z1", bIt31.get(solMaps.var3).getURI() );
+        final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithOneVarFilter( getSolMapListWithTwoVar(), var1, y1 ).iterator();
+        
+        assertTrue( it.hasNext() );
+        final Binding b1 = it.next().asJenaBinding();
+        assertEquals( 2, b1.size() );
+        assertEquals( "http://example.org/y1", b1.get(var2).getURI() );
+        assertEquals( "http://example.org/z1", b1.get(var3).getURI() );
 
-        assertTrue( it3.hasNext() );
-        final Binding bIt32 = it3.next().asJenaBinding();
-        assertEquals( 2, bIt32.size() );
-        assertEquals("http://example.org/y1", bIt32.get(solMaps.var2).getURI());
-        assertEquals("http://example.org/z2", bIt32.get(solMaps.var3).getURI());
+        assertTrue( it.hasNext() );
+        final Binding b2 = it.next().asJenaBinding();
+        assertEquals( 2, b2.size() );
+        assertEquals("http://example.org/y1", b2.get(var2).getURI());
+        assertEquals("http://example.org/z2", b2.get(var3).getURI());
 
-        assertTrue( it3.hasNext() );
-        final Binding bIt33 = it3.next().asJenaBinding();
-        assertEquals( 2, bIt33.size() );
-        assertEquals("http://example.org/y2", bIt33.get(solMaps.var2).getURI());
-        assertEquals("http://example.org/z3", bIt33.get(solMaps.var3).getURI());
+        assertTrue( it.hasNext() );
+        final Binding b3 = it.next().asJenaBinding();
+        assertEquals( 2, b3.size() );
+        assertEquals("http://example.org/y2", b3.get(var2).getURI());
+        assertEquals("http://example.org/z3", b3.get(var3).getURI());
 
-        assertFalse( it3.hasNext() );
+        assertFalse( it.hasNext() );
     }
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithOneVarFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithOneVarFilterTest.java
@@ -1,6 +1,5 @@
 package se.liu.ida.hefquin.engine.data.utils;
 
-import org.apache.jena.sparql.engine.binding.Binding;
 import org.junit.Test;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 
@@ -14,17 +13,8 @@ public class SolutionMappingsIterableWithOneVarFilterTest extends TestsForSoluti
         // iterate over the subset of solution mappings that y1 for var2
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithOneVarFilter( getSolMapListWithTwoVar(), var2, y1 ).iterator();
 
-        assertTrue( it.hasNext() );
-        final Binding b1 = it.next().asJenaBinding();
-        assertEquals( 2, b1.size() );
-        assertEquals( "http://example.org/y1", b1.get(var2).getURI() );
-        assertEquals( "http://example.org/z1", b1.get(var3).getURI() );
-
-        assertTrue( it.hasNext() );
-        final Binding b2 = it.next().asJenaBinding();
-        assertEquals( 2, b2.size() );
-        assertEquals("http://example.org/y1", b2.get(var2).getURI());
-        assertEquals("http://example.org/z2", b2.get(var3).getURI());
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z1", var3 );
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z2", var3 );
 
         assertFalse( it.hasNext() );
     }
@@ -41,24 +31,10 @@ public class SolutionMappingsIterableWithOneVarFilterTest extends TestsForSoluti
     public void solMappingsIterableWithOneVarFilter_all() {
         // return all solution mappings: no solution mappings that have value for var1
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithOneVarFilter( getSolMapListWithTwoVar(), var1, y1 ).iterator();
-        
-        assertTrue( it.hasNext() );
-        final Binding b1 = it.next().asJenaBinding();
-        assertEquals( 2, b1.size() );
-        assertEquals( "http://example.org/y1", b1.get(var2).getURI() );
-        assertEquals( "http://example.org/z1", b1.get(var3).getURI() );
 
-        assertTrue( it.hasNext() );
-        final Binding b2 = it.next().asJenaBinding();
-        assertEquals( 2, b2.size() );
-        assertEquals("http://example.org/y1", b2.get(var2).getURI());
-        assertEquals("http://example.org/z2", b2.get(var3).getURI());
-
-        assertTrue( it.hasNext() );
-        final Binding b3 = it.next().asJenaBinding();
-        assertEquals( 2, b3.size() );
-        assertEquals("http://example.org/y2", b3.get(var2).getURI());
-        assertEquals("http://example.org/z3", b3.get(var3).getURI());
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z1", var3 );
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z2", var3 );
+        assertHasNext( it, "http://example.org/y2", var2, "http://example.org/z3", var3 );
 
         assertFalse( it.hasNext() );
     }

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithOneVarFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithOneVarFilterTest.java
@@ -1,0 +1,80 @@
+package se.liu.ida.hefquin.engine.data.utils;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.junit.Test;
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
+import se.liu.ida.hefquin.engine.datastructures.impl.SolutionMappingsHashTableBasedOnOneVar;
+import se.liu.ida.hefquin.engine.datastructures.impl.SolutionMappingsIndexBase;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class SolutionMappingsIterableWithOneVarFilterTest {
+    @Test
+    public void hashTableWithOneInputVariable() {
+        final Var var1 = Var.alloc("v1");
+        final Var var2 = Var.alloc("v2");
+        final Var var3 = Var.alloc("v3");
+
+        final Node y1 = NodeFactory.createURI("http://example.org/y1");
+        final Node y2 = NodeFactory.createURI("http://example.org/y2");
+        final Node z1 = NodeFactory.createURI("http://example.org/z1");
+        final Node z2 = NodeFactory.createURI("http://example.org/z2");
+        final Node z3 = NodeFactory.createURI("http://example.org/z3");
+        final Node p = NodeFactory.createURI("http://example.org/p");
+
+        // create SolutionMappingsIndexBase
+        final SolutionMappingsIndexBase solMHashTable = new SolutionMappingsHashTableBasedOnOneVar(var2);
+        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+                var2, y1,
+                var3, z1) );
+        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+                var2, y1,
+                var3, z2) );
+        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+                var2, y2,
+                var3, z3) );
+        final Iterable<SolutionMapping> allSolMap = solMHashTable.getAllSolutionMappings();
+
+        // iterate over the subset of solution mappings that have a given value for var2
+        final Iterable<SolutionMapping> solMapAfterFilter1 = new SolutionMappingsIterableWithOneVarFilter( allSolMap, var2, y1 );
+        final Iterator<SolutionMapping> it1 = solMapAfterFilter1.iterator();
+        assertTrue( it1.hasNext() );
+        final Binding bIt1 = it1.next().asJenaBinding();
+        assertEquals( 2, bIt1.size() );
+
+        assertTrue( it1.hasNext() );
+        final Binding bIt2 = it1.next().asJenaBinding();
+        assertEquals( 2, bIt2.size() );
+
+        assertFalse( it1.hasNext() );
+
+        // no solution mappings that have p for var3
+        final Iterable<SolutionMapping> solMapAfterFilter2 = new SolutionMappingsIterableWithOneVarFilter( allSolMap, var3, p );
+        final Iterator<SolutionMapping> it2 = solMapAfterFilter2.iterator();
+
+        assertFalse( it2.hasNext() );
+
+        // return all solution mappings: no solution mappings that have value for var1
+        final Iterable<SolutionMapping> solMapAfterFilter3 = new SolutionMappingsIterableWithOneVarFilter( allSolMap, var1, y1 );
+        final Iterator<SolutionMapping> it3 = solMapAfterFilter3.iterator();
+        assertTrue( it3.hasNext() );
+        final Binding bIt31 = it3.next().asJenaBinding();
+        assertEquals( 2, bIt31.size() );
+
+        assertTrue( it3.hasNext() );
+        final Binding bIt32 = it3.next().asJenaBinding();
+        assertEquals( 2, bIt32.size() );
+
+        assertTrue( it3.hasNext() );
+        final Binding bIt33 = it3.next().asJenaBinding();
+        assertEquals( 2, bIt33.size() );
+
+        assertFalse( it3.hasNext() );
+    }
+}

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithOneVarFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithOneVarFilterTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.*;
 public class SolutionMappingsIterableWithOneVarFilterTest extends TestsForSolutionMappingsIterableWithFilter
 {
     @Test
-    public void solMappingsIterableWithOneVarFilter_subset() {
+    public void subset() {
         // iterate over the subset of solution mappings that y1 for var2
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithOneVarFilter( getSolMapListWithTwoVar(), var2, y1 ).iterator();
 
@@ -20,7 +20,7 @@ public class SolutionMappingsIterableWithOneVarFilterTest extends TestsForSoluti
     }
 
     @Test
-    public void solMappingsIterableWithOneVarFilter_noMatching() {
+    public void noMatch() {
         // no solution mappings that have p for var3
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithOneVarFilter( getSolMapListWithTwoVar(), var3, p ).iterator();
 
@@ -28,7 +28,7 @@ public class SolutionMappingsIterableWithOneVarFilterTest extends TestsForSoluti
     }
 
     @Test
-    public void solMappingsIterableWithOneVarFilter_all() {
+    public void all() {
         // return all solution mappings: no solution mappings that have value for var1
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithOneVarFilter( getSolMapListWithTwoVar(), var1, y1 ).iterator();
 

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithOneVarFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithOneVarFilterTest.java
@@ -18,10 +18,14 @@ public class SolutionMappingsIterableWithOneVarFilterTest {
         assertTrue( it1.hasNext() );
         final Binding bIt1 = it1.next().asJenaBinding();
         assertEquals( 2, bIt1.size() );
+        assertEquals( "http://example.org/y1", bIt1.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z1", bIt1.get(solMaps.var3).getURI() );
 
         assertTrue( it1.hasNext() );
         final Binding bIt2 = it1.next().asJenaBinding();
         assertEquals( 2, bIt2.size() );
+        assertEquals("http://example.org/y1", bIt2.get(solMaps.var2).getURI());
+        assertEquals("http://example.org/z2", bIt2.get(solMaps.var3).getURI());
 
         assertFalse( it1.hasNext() );
     }
@@ -47,14 +51,20 @@ public class SolutionMappingsIterableWithOneVarFilterTest {
         assertTrue( it3.hasNext() );
         final Binding bIt31 = it3.next().asJenaBinding();
         assertEquals( 2, bIt31.size() );
+        assertEquals( "http://example.org/y1", bIt31.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z1", bIt31.get(solMaps.var3).getURI() );
 
         assertTrue( it3.hasNext() );
         final Binding bIt32 = it3.next().asJenaBinding();
         assertEquals( 2, bIt32.size() );
+        assertEquals("http://example.org/y1", bIt32.get(solMaps.var2).getURI());
+        assertEquals("http://example.org/z2", bIt32.get(solMaps.var3).getURI());
 
         assertTrue( it3.hasNext() );
         final Binding bIt33 = it3.next().asJenaBinding();
         assertEquals( 2, bIt33.size() );
+        assertEquals("http://example.org/y2", bIt33.get(solMaps.var2).getURI());
+        assertEquals("http://example.org/z3", bIt33.get(solMaps.var3).getURI());
 
         assertFalse( it3.hasNext() );
     }

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithSolMapFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithSolMapFilterTest.java
@@ -44,7 +44,7 @@ public class SolutionMappingsIterableWithSolMapFilterTest {
         final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
         final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y1, solMaps.var1, solMaps.x1);
 
-        // two solution mappings that are compatible with sm3 (var2, y1, var1, x1)
+        // two solution mappings that are compatible with sm3 (var2, y1, var1, x1).
         final Iterable<SolutionMapping> solMapAfterFilter3 = new SolutionMappingsIterableWithSolMapFilter( solMaps.getSolMapListWithTwoVar(), sm3 );
         final Iterator<SolutionMapping> it3 = solMapAfterFilter3.iterator();
 

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithSolMapFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithSolMapFilterTest.java
@@ -21,6 +21,8 @@ public class SolutionMappingsIterableWithSolMapFilterTest {
         assertTrue( it1.hasNext() );
         final Binding bIt1 = it1.next().asJenaBinding();
         assertEquals( 2, bIt1.size() );
+        assertEquals( "http://example.org/y1", bIt1.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z1", bIt1.get(solMaps.var3).getURI() );
 
         assertFalse( it1.hasNext() );
     }
@@ -49,10 +51,14 @@ public class SolutionMappingsIterableWithSolMapFilterTest {
         assertTrue( it3.hasNext() );
         final Binding bIt31 = it3.next().asJenaBinding();
         assertEquals( 2, bIt31.size() );
+        assertEquals( "http://example.org/y1", bIt31.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z1", bIt31.get(solMaps.var3).getURI() );
 
         assertTrue( it3.hasNext() );
         final Binding bIt32 = it3.next().asJenaBinding();
         assertEquals( 2, bIt32.size() );
+        assertEquals("http://example.org/y1", bIt32.get(solMaps.var2).getURI());
+        assertEquals("http://example.org/z2", bIt32.get(solMaps.var3).getURI());
 
         assertFalse( it3.hasNext() );
     }
@@ -69,14 +75,20 @@ public class SolutionMappingsIterableWithSolMapFilterTest {
         assertTrue( it4.hasNext() );
         final Binding bIt41 = it4.next().asJenaBinding();
         assertEquals( 2, bIt41.size() );
+        assertEquals( "http://example.org/y1", bIt41.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z1", bIt41.get(solMaps.var3).getURI() );
 
         assertTrue( it4.hasNext() );
         final Binding bIt42 = it4.next().asJenaBinding();
         assertEquals( 2, bIt42.size() );
+        assertEquals("http://example.org/y1", bIt42.get(solMaps.var2).getURI());
+        assertEquals("http://example.org/z2", bIt42.get(solMaps.var3).getURI());
 
         assertTrue( it4.hasNext() );
         final Binding bIt43 = it4.next().asJenaBinding();
         assertEquals( 2, bIt43.size() );
+        assertEquals("http://example.org/y2", bIt43.get(solMaps.var2).getURI());
+        assertEquals("http://example.org/z3", bIt43.get(solMaps.var3).getURI());
 
         assertFalse( it4.hasNext() );
     }

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithSolMapFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithSolMapFilterTest.java
@@ -9,87 +9,81 @@ import java.util.Iterator;
 
 import static org.junit.Assert.*;
 
-public class SolutionMappingsIterableWithSolMapFilterTest {
+public class SolutionMappingsIterableWithSolMapFilterTest extends TestsForSolutionMappingsIterableWithFilter
+{
     @Test
     public void solutionMappingsIterableWithSolMapFilter_sm1() {
-        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
-        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y1, solMaps.var3, solMaps.z1);
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var2, y1, var3, z1);
 
-        // iterate over the subset of solution mappings that are compatible with sm1 (var2, y1, var3, z1)
-        final Iterable<SolutionMapping> solMapAfterFilter1 = new SolutionMappingsIterableWithSolMapFilter( solMaps.getSolMapListWithTwoVar(), sm1 );
-        final Iterator<SolutionMapping> it1 = solMapAfterFilter1.iterator();
-        assertTrue( it1.hasNext() );
-        final Binding bIt1 = it1.next().asJenaBinding();
-        assertEquals( 2, bIt1.size() );
-        assertEquals( "http://example.org/y1", bIt1.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z1", bIt1.get(solMaps.var3).getURI() );
+        // iterate over the subset of solution mappings that are compatible with sm (var2, y1, var3, z1)
+        final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithSolMapFilter( getSolMapListWithTwoVar(), sm ).iterator();
 
-        assertFalse( it1.hasNext() );
+        assertTrue( it.hasNext() );
+        final Binding b = it.next().asJenaBinding();
+        assertEquals( 2, b.size() );
+        assertEquals( "http://example.org/y1", b.get(var2).getURI() );
+        assertEquals( "http://example.org/z1", b.get(var3).getURI() );
+
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void solutionMappingsIterableWithSolMapFilter_sm2() {
-        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
-        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y2, solMaps.var3, solMaps.z1);
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var2, y2, var3, z1);
 
-        // no solution mappings that are compatible with sm00 (var2, y2, var3, z1)
-        final Iterable<SolutionMapping> solMapAfterFilter2 = new SolutionMappingsIterableWithSolMapFilter( solMaps.getSolMapListWithTwoVar(), sm2 );
-        final Iterator<SolutionMapping> it2 = solMapAfterFilter2.iterator();
+        // no solution mappings that are compatible with sm (var2, y2, var3, z1)
+        final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithSolMapFilter( getSolMapListWithTwoVar(), sm ).iterator();
 
-        assertFalse( it2.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void solutionMappingsIterableWithSolMapFilter_sm3() {
-        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
-        final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y1, solMaps.var1, solMaps.x1);
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var2, y1, var1, x1);
 
-        // two solution mappings that are compatible with sm3 (var2, y1, var1, x1).
-        final Iterable<SolutionMapping> solMapAfterFilter3 = new SolutionMappingsIterableWithSolMapFilter( solMaps.getSolMapListWithTwoVar(), sm3 );
-        final Iterator<SolutionMapping> it3 = solMapAfterFilter3.iterator();
+        // two solution mappings that are compatible with sm (var2, y1, var1, x1).
+        final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithSolMapFilter( getSolMapListWithTwoVar(), sm ).iterator();
 
-        assertTrue( it3.hasNext() );
-        final Binding bIt31 = it3.next().asJenaBinding();
-        assertEquals( 2, bIt31.size() );
-        assertEquals( "http://example.org/y1", bIt31.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z1", bIt31.get(solMaps.var3).getURI() );
+        assertTrue( it.hasNext() );
+        final Binding b1 = it.next().asJenaBinding();
+        assertEquals( 2, b1.size() );
+        assertEquals( "http://example.org/y1", b1.get(var2).getURI() );
+        assertEquals( "http://example.org/z1", b1.get(var3).getURI() );
 
-        assertTrue( it3.hasNext() );
-        final Binding bIt32 = it3.next().asJenaBinding();
-        assertEquals( 2, bIt32.size() );
-        assertEquals("http://example.org/y1", bIt32.get(solMaps.var2).getURI());
-        assertEquals("http://example.org/z2", bIt32.get(solMaps.var3).getURI());
+        assertTrue( it.hasNext() );
+        final Binding b2 = it.next().asJenaBinding();
+        assertEquals( 2, b2.size() );
+        assertEquals("http://example.org/y1", b2.get(var2).getURI());
+        assertEquals("http://example.org/z2", b2.get(var3).getURI());
 
-        assertFalse( it3.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void solutionMappingsIterableWithSolMapFilter_sm4() {
-        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
-        final SolutionMapping sm4 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x1);
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var1, x1);
 
-        // all solution mappings that are compatible with sm4 (var1, x1)
-        final Iterable<SolutionMapping> solMapAfterFilter4 = new SolutionMappingsIterableWithSolMapFilter( solMaps.getSolMapListWithTwoVar(), sm4 );
-        final Iterator<SolutionMapping> it4 = solMapAfterFilter4.iterator();
+        // all solution mappings that are compatible with sm (var1, x1)
+        final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithSolMapFilter( getSolMapListWithTwoVar(), sm ).iterator();
 
-        assertTrue( it4.hasNext() );
-        final Binding bIt41 = it4.next().asJenaBinding();
-        assertEquals( 2, bIt41.size() );
-        assertEquals( "http://example.org/y1", bIt41.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z1", bIt41.get(solMaps.var3).getURI() );
+        assertTrue( it.hasNext() );
+        final Binding b1 = it.next().asJenaBinding();
+        assertEquals( 2, b1.size() );
+        assertEquals( "http://example.org/y1", b1.get(var2).getURI() );
+        assertEquals( "http://example.org/z1", b1.get(var3).getURI() );
 
-        assertTrue( it4.hasNext() );
-        final Binding bIt42 = it4.next().asJenaBinding();
-        assertEquals( 2, bIt42.size() );
-        assertEquals("http://example.org/y1", bIt42.get(solMaps.var2).getURI());
-        assertEquals("http://example.org/z2", bIt42.get(solMaps.var3).getURI());
+        assertTrue( it.hasNext() );
+        final Binding b2 = it.next().asJenaBinding();
+        assertEquals( 2, b2.size() );
+        assertEquals("http://example.org/y1", b2.get(var2).getURI());
+        assertEquals("http://example.org/z2", b2.get(var3).getURI());
 
-        assertTrue( it4.hasNext() );
-        final Binding bIt43 = it4.next().asJenaBinding();
-        assertEquals( 2, bIt43.size() );
-        assertEquals("http://example.org/y2", bIt43.get(solMaps.var2).getURI());
-        assertEquals("http://example.org/z3", bIt43.get(solMaps.var3).getURI());
+        assertTrue( it.hasNext() );
+        final Binding b3 = it.next().asJenaBinding();
+        assertEquals( 2, b3.size() );
+        assertEquals("http://example.org/y2", b3.get(var2).getURI());
+        assertEquals("http://example.org/z3", b3.get(var3).getURI());
 
-        assertFalse( it4.hasNext() );
+        assertFalse( it.hasNext() );
     }
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithSolMapFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithSolMapFilterTest.java
@@ -1,14 +1,9 @@
 package se.liu.ida.hefquin.engine.data.utils;
 
-import org.apache.jena.graph.Node;
-import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.junit.Test;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
-import se.liu.ida.hefquin.engine.datastructures.impl.SolutionMappingsHashTableBasedOnOneVar;
-import se.liu.ida.hefquin.engine.datastructures.impl.SolutionMappingsIndexBase;
 
 import java.util.Iterator;
 
@@ -16,50 +11,39 @@ import static org.junit.Assert.*;
 
 public class SolutionMappingsIterableWithSolMapFilterTest {
     @Test
-    public void hashTableWithOneInputVariable() {
-        final Var var1 = Var.alloc("v1");
-        final Var var2 = Var.alloc("v2");
-        final Var var3 = Var.alloc("v3");
+    public void solutionMappingsIterableWithSolMapFilter_sm1() {
+        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
+        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y1, solMaps.var3, solMaps.z1);
 
-        final Node x1 = NodeFactory.createURI("http://example.org/x1");
-        final Node y1 = NodeFactory.createURI("http://example.org/y1");
-        final Node y2 = NodeFactory.createURI("http://example.org/y2");
-        final Node z1 = NodeFactory.createURI("http://example.org/z1");
-        final Node z2 = NodeFactory.createURI("http://example.org/z2");
-        final Node z3 = NodeFactory.createURI("http://example.org/z3");
-
-        // create SolutionMappingsIndexBase
-        final SolutionMappingsIndexBase solMHashTable = new SolutionMappingsHashTableBasedOnOneVar(var2);
-
-        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(var2, y1, var3, z1);
-        solMHashTable.add(sm1);
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var2, y1,
-                var3, z2) );
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var2, y2,
-                var3, z3) );
-        final Iterable<SolutionMapping> allSolMap = solMHashTable.getAllSolutionMappings();
-
-        // iterate over the subset of solution mappings that are compatible with sm1
-        final Iterable<SolutionMapping> solMapAfterFilter1 = new SolutionMappingsIterableWithSolMapFilter( allSolMap, sm1 );
+        // iterate over the subset of solution mappings that are compatible with sm1 (var2, y1, var3, z1)
+        final Iterable<SolutionMapping> solMapAfterFilter1 = new SolutionMappingsIterableWithSolMapFilter( solMaps.getSolMapListWithTwoVar(), sm1 );
         final Iterator<SolutionMapping> it1 = solMapAfterFilter1.iterator();
         assertTrue( it1.hasNext() );
         final Binding bIt1 = it1.next().asJenaBinding();
         assertEquals( 2, bIt1.size() );
 
         assertFalse( it1.hasNext() );
+    }
 
-        // no solution mappings that are compatible with sm00
-        final SolutionMapping sm00 = SolutionMappingUtils.createSolutionMapping(var2, y2, var3, z1);
-        final Iterable<SolutionMapping> solMapAfterFilter2 = new SolutionMappingsIterableWithSolMapFilter( allSolMap, sm00 );
+    @Test
+    public void solutionMappingsIterableWithSolMapFilter_sm2() {
+        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
+        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y2, solMaps.var3, solMaps.z1);
+
+        // no solution mappings that are compatible with sm00 (var2, y2, var3, z1)
+        final Iterable<SolutionMapping> solMapAfterFilter2 = new SolutionMappingsIterableWithSolMapFilter( solMaps.getSolMapListWithTwoVar(), sm2 );
         final Iterator<SolutionMapping> it2 = solMapAfterFilter2.iterator();
 
         assertFalse( it2.hasNext() );
+    }
 
-        // two solution mappings that are compatible with sm01
-        final SolutionMapping sm01 = SolutionMappingUtils.createSolutionMapping(var2, y1, var1, x1);
-        final Iterable<SolutionMapping> solMapAfterFilter3 = new SolutionMappingsIterableWithSolMapFilter( allSolMap, sm01 );
+    @Test
+    public void solutionMappingsIterableWithSolMapFilter_sm3() {
+        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
+        final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y1, solMaps.var1, solMaps.x1);
+
+        // two solution mappings that are compatible with sm3 (var2, y1, var1, x1)
+        final Iterable<SolutionMapping> solMapAfterFilter3 = new SolutionMappingsIterableWithSolMapFilter( solMaps.getSolMapListWithTwoVar(), sm3 );
         final Iterator<SolutionMapping> it3 = solMapAfterFilter3.iterator();
 
         assertTrue( it3.hasNext() );
@@ -71,10 +55,15 @@ public class SolutionMappingsIterableWithSolMapFilterTest {
         assertEquals( 2, bIt32.size() );
 
         assertFalse( it3.hasNext() );
+    }
 
-        // two solution mappings that are compatible with sm02
-        final SolutionMapping sm02 = SolutionMappingUtils.createSolutionMapping(var1, x1);
-        final Iterable<SolutionMapping> solMapAfterFilter4 = new SolutionMappingsIterableWithSolMapFilter( allSolMap, sm02 );
+    @Test
+    public void solutionMappingsIterableWithSolMapFilter_sm4() {
+        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
+        final SolutionMapping sm4 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x1);
+
+        // all solution mappings that are compatible with sm4 (var1, x1)
+        final Iterable<SolutionMapping> solMapAfterFilter4 = new SolutionMappingsIterableWithSolMapFilter( solMaps.getSolMapListWithTwoVar(), sm4 );
         final Iterator<SolutionMapping> it4 = solMapAfterFilter4.iterator();
 
         assertTrue( it4.hasNext() );

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithSolMapFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithSolMapFilterTest.java
@@ -1,6 +1,5 @@
 package se.liu.ida.hefquin.engine.data.utils;
 
-import org.apache.jena.sparql.engine.binding.Binding;
 import org.junit.Test;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
@@ -13,25 +12,19 @@ public class SolutionMappingsIterableWithSolMapFilterTest extends TestsForSoluti
 {
     @Test
     public void solutionMappingsIterableWithSolMapFilter_sm1() {
-        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var2, y1, var3, z1);
-
         // iterate over the subset of solution mappings that are compatible with sm (var2, y1, var3, z1)
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var2, y1, var3, z1);
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithSolMapFilter( getSolMapListWithTwoVar(), sm ).iterator();
 
-        assertTrue( it.hasNext() );
-        final Binding b = it.next().asJenaBinding();
-        assertEquals( 2, b.size() );
-        assertEquals( "http://example.org/y1", b.get(var2).getURI() );
-        assertEquals( "http://example.org/z1", b.get(var3).getURI() );
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z1", var3 );
 
         assertFalse( it.hasNext() );
     }
 
     @Test
     public void solutionMappingsIterableWithSolMapFilter_sm2() {
-        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var2, y2, var3, z1);
-
         // no solution mappings that are compatible with sm (var2, y2, var3, z1)
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var2, y2, var3, z1);
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithSolMapFilter( getSolMapListWithTwoVar(), sm ).iterator();
 
         assertFalse( it.hasNext() );
@@ -39,50 +32,25 @@ public class SolutionMappingsIterableWithSolMapFilterTest extends TestsForSoluti
 
     @Test
     public void solutionMappingsIterableWithSolMapFilter_sm3() {
-        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var2, y1, var1, x1);
-
         // two solution mappings that are compatible with sm (var2, y1, var1, x1).
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var2, y1, var1, x1);
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithSolMapFilter( getSolMapListWithTwoVar(), sm ).iterator();
 
-        assertTrue( it.hasNext() );
-        final Binding b1 = it.next().asJenaBinding();
-        assertEquals( 2, b1.size() );
-        assertEquals( "http://example.org/y1", b1.get(var2).getURI() );
-        assertEquals( "http://example.org/z1", b1.get(var3).getURI() );
-
-        assertTrue( it.hasNext() );
-        final Binding b2 = it.next().asJenaBinding();
-        assertEquals( 2, b2.size() );
-        assertEquals("http://example.org/y1", b2.get(var2).getURI());
-        assertEquals("http://example.org/z2", b2.get(var3).getURI());
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z1", var3 );
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z2", var3 );
 
         assertFalse( it.hasNext() );
     }
 
     @Test
     public void solutionMappingsIterableWithSolMapFilter_sm4() {
-        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var1, x1);
-
         // all solution mappings that are compatible with sm (var1, x1)
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var1, x1);
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithSolMapFilter( getSolMapListWithTwoVar(), sm ).iterator();
 
-        assertTrue( it.hasNext() );
-        final Binding b1 = it.next().asJenaBinding();
-        assertEquals( 2, b1.size() );
-        assertEquals( "http://example.org/y1", b1.get(var2).getURI() );
-        assertEquals( "http://example.org/z1", b1.get(var3).getURI() );
-
-        assertTrue( it.hasNext() );
-        final Binding b2 = it.next().asJenaBinding();
-        assertEquals( 2, b2.size() );
-        assertEquals("http://example.org/y1", b2.get(var2).getURI());
-        assertEquals("http://example.org/z2", b2.get(var3).getURI());
-
-        assertTrue( it.hasNext() );
-        final Binding b3 = it.next().asJenaBinding();
-        assertEquals( 2, b3.size() );
-        assertEquals("http://example.org/y2", b3.get(var2).getURI());
-        assertEquals("http://example.org/z3", b3.get(var3).getURI());
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z1", var3 );
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z2", var3 );
+        assertHasNext( it, "http://example.org/y2", var2, "http://example.org/z3", var3 );
 
         assertFalse( it.hasNext() );
     }

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithSolMapFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithSolMapFilterTest.java
@@ -1,0 +1,94 @@
+package se.liu.ida.hefquin.engine.data.utils;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.junit.Test;
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
+import se.liu.ida.hefquin.engine.datastructures.impl.SolutionMappingsHashTableBasedOnOneVar;
+import se.liu.ida.hefquin.engine.datastructures.impl.SolutionMappingsIndexBase;
+
+import java.util.Iterator;
+
+import static org.junit.Assert.*;
+
+public class SolutionMappingsIterableWithSolMapFilterTest {
+    @Test
+    public void hashTableWithOneInputVariable() {
+        final Var var1 = Var.alloc("v1");
+        final Var var2 = Var.alloc("v2");
+        final Var var3 = Var.alloc("v3");
+
+        final Node x1 = NodeFactory.createURI("http://example.org/x1");
+        final Node y1 = NodeFactory.createURI("http://example.org/y1");
+        final Node y2 = NodeFactory.createURI("http://example.org/y2");
+        final Node z1 = NodeFactory.createURI("http://example.org/z1");
+        final Node z2 = NodeFactory.createURI("http://example.org/z2");
+        final Node z3 = NodeFactory.createURI("http://example.org/z3");
+
+        // create SolutionMappingsIndexBase
+        final SolutionMappingsIndexBase solMHashTable = new SolutionMappingsHashTableBasedOnOneVar(var2);
+
+        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(var2, y1, var3, z1);
+        solMHashTable.add(sm1);
+        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+                var2, y1,
+                var3, z2) );
+        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+                var2, y2,
+                var3, z3) );
+        final Iterable<SolutionMapping> allSolMap = solMHashTable.getAllSolutionMappings();
+
+        // iterate over the subset of solution mappings that are compatible with sm1
+        final Iterable<SolutionMapping> solMapAfterFilter1 = new SolutionMappingsIterableWithSolMapFilter( allSolMap, sm1 );
+        final Iterator<SolutionMapping> it1 = solMapAfterFilter1.iterator();
+        assertTrue( it1.hasNext() );
+        final Binding bIt1 = it1.next().asJenaBinding();
+        assertEquals( 2, bIt1.size() );
+
+        assertFalse( it1.hasNext() );
+
+        // no solution mappings that are compatible with sm00
+        final SolutionMapping sm00 = SolutionMappingUtils.createSolutionMapping(var2, y2, var3, z1);
+        final Iterable<SolutionMapping> solMapAfterFilter2 = new SolutionMappingsIterableWithSolMapFilter( allSolMap, sm00 );
+        final Iterator<SolutionMapping> it2 = solMapAfterFilter2.iterator();
+
+        assertFalse( it2.hasNext() );
+
+        // two solution mappings that are compatible with sm01
+        final SolutionMapping sm01 = SolutionMappingUtils.createSolutionMapping(var2, y1, var1, x1);
+        final Iterable<SolutionMapping> solMapAfterFilter3 = new SolutionMappingsIterableWithSolMapFilter( allSolMap, sm01 );
+        final Iterator<SolutionMapping> it3 = solMapAfterFilter3.iterator();
+
+        assertTrue( it3.hasNext() );
+        final Binding bIt31 = it3.next().asJenaBinding();
+        assertEquals( 2, bIt31.size() );
+
+        assertTrue( it3.hasNext() );
+        final Binding bIt32 = it3.next().asJenaBinding();
+        assertEquals( 2, bIt32.size() );
+
+        assertFalse( it3.hasNext() );
+
+        // two solution mappings that are compatible with sm02
+        final SolutionMapping sm02 = SolutionMappingUtils.createSolutionMapping(var1, x1);
+        final Iterable<SolutionMapping> solMapAfterFilter4 = new SolutionMappingsIterableWithSolMapFilter( allSolMap, sm02 );
+        final Iterator<SolutionMapping> it4 = solMapAfterFilter4.iterator();
+
+        assertTrue( it4.hasNext() );
+        final Binding bIt41 = it4.next().asJenaBinding();
+        assertEquals( 2, bIt41.size() );
+
+        assertTrue( it4.hasNext() );
+        final Binding bIt42 = it4.next().asJenaBinding();
+        assertEquals( 2, bIt42.size() );
+
+        assertTrue( it4.hasNext() );
+        final Binding bIt43 = it4.next().asJenaBinding();
+        assertEquals( 2, bIt43.size() );
+
+        assertFalse( it4.hasNext() );
+    }
+}

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithThreeVarsFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithThreeVarsFilterTest.java
@@ -1,0 +1,103 @@
+package se.liu.ida.hefquin.engine.data.utils;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.junit.Test;
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
+import se.liu.ida.hefquin.engine.datastructures.impl.SolutionMappingsHashTableBasedOnOneVar;
+import se.liu.ida.hefquin.engine.datastructures.impl.SolutionMappingsIndexBase;
+
+import java.util.Iterator;
+
+import static org.junit.Assert.*;
+
+public class SolutionMappingsIterableWithThreeVarsFilterTest {
+    @Test
+    public void hashTableWithOneInputVariable() {
+        final Var var1 = Var.alloc("v1");
+        final Var var2 = Var.alloc("v2");
+        final Var var3 = Var.alloc("v3");
+        final Var var4 = Var.alloc("v4");
+        final Var var5 = Var.alloc("v4");
+        final Var var6 = Var.alloc("v4");
+
+        final Node x1 = NodeFactory.createURI("http://example.org/x1");
+        final Node x2 = NodeFactory.createURI("http://example.org/x2");
+        final Node y1 = NodeFactory.createURI("http://example.org/y1");
+        final Node y2 = NodeFactory.createURI("http://example.org/y2");
+        final Node z1 = NodeFactory.createURI("http://example.org/z1");
+        final Node z2 = NodeFactory.createURI("http://example.org/z2");
+        final Node p = NodeFactory.createURI("http://example.org/p");
+
+        // create SolutionMappingsIndexBase
+        final SolutionMappingsIndexBase solMHashTable = new SolutionMappingsHashTableBasedOnOneVar(var2);
+
+        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+                var1, x1,
+                var2, y1,
+                var3, z1) );
+        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+                var1, x1,
+                var2, y1,
+                var3, z2) );
+        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+                var1, x2,
+                var2, y2,
+                var3, z2) );
+        final Iterable<SolutionMapping> allSolMap = solMHashTable.getAllSolutionMappings();
+
+        // iterate over the subset of solution mappings that have a given value for var2 and vae3
+        final Iterable<SolutionMapping> solMapAfterFilter1 = new SolutionMappingsIterableWithThreeVarsFilter( allSolMap, var3, z1, var1, x1, var2, y1 );
+        final Iterator<SolutionMapping> it1 = solMapAfterFilter1.iterator();
+        assertTrue( it1.hasNext() );
+        final Binding bIt1 = it1.next().asJenaBinding();
+        assertEquals( 3, bIt1.size() );
+
+        assertFalse( it1.hasNext() );
+
+        // filter based on subset of variables
+        final Iterable<SolutionMapping> solMapAfterFilter2 = new SolutionMappingsIterableWithThreeVarsFilter( allSolMap, var2, y1, var1, x1, var4, p );
+        final Iterator<SolutionMapping> it2 = solMapAfterFilter2.iterator();
+        assertTrue( it2.hasNext() );
+        final Binding bIt21 = it2.next().asJenaBinding();
+        assertEquals( 3, bIt21.size() );
+
+        assertTrue( it2.hasNext() );
+        final Binding bIt22 = it2.next().asJenaBinding();
+        assertEquals( 3, bIt22.size() );
+
+        assertFalse( it2.hasNext() );
+
+        // no solution mappings that having (var1, x2, var2, y1, var3, z2)
+        final Iterable<SolutionMapping> solMapAfterFilter3 = new SolutionMappingsIterableWithThreeVarsFilter( allSolMap, var1, x2, var2, y1, var3, z2 );
+        final Iterator<SolutionMapping> it3 = solMapAfterFilter3.iterator();
+
+        assertFalse( it3.hasNext() );
+
+        // no solution mappings that having (var2, y1, var1, x2)
+        final Iterable<SolutionMapping> solMapAfterFilter4 = new SolutionMappingsIterableWithThreeVarsFilter( allSolMap, var2, y1, var1, x2, var4, p );
+        final Iterator<SolutionMapping> it4 = solMapAfterFilter4.iterator();
+
+        assertFalse( it4.hasNext() );
+
+        // return all solution mappings: no solution mappings that have value for var4 or var5 or var6
+        final Iterable<SolutionMapping> solMapAfterFilter5 = new SolutionMappingsIterableWithThreeVarsFilter( allSolMap, var5, y1, var6, x2, var4, p );
+        final Iterator<SolutionMapping> it5 = solMapAfterFilter5.iterator();
+        assertTrue( it5.hasNext() );
+        final Binding bIt51 = it5.next().asJenaBinding();
+        assertEquals( 3, bIt51.size() );
+
+        assertTrue( it5.hasNext() );
+        final Binding bIt52 = it5.next().asJenaBinding();
+        assertEquals( 3, bIt52.size() );
+
+        assertTrue( it5.hasNext() );
+        final Binding bIt53 = it5.next().asJenaBinding();
+        assertEquals( 3, bIt53.size() );
+
+        assertFalse( it5.hasNext() );
+    }
+}

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithThreeVarsFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithThreeVarsFilterTest.java
@@ -1,6 +1,5 @@
 package se.liu.ida.hefquin.engine.data.utils;
 
-import org.apache.jena.sparql.engine.binding.Binding;
 import org.junit.Test;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 import java.util.Iterator;
@@ -14,12 +13,7 @@ public class SolutionMappingsIterableWithThreeVarsFilterTest extends TestsForSol
         // iterate over the subset of solution mappings that have (var3, z1, var1, x1, var2, y1)
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithThreeVarsFilter( getSolMapListWithThreeVar(), var3, z1, var1, x1, var2, y1 ).iterator();
 
-        assertTrue( it.hasNext() );
-        final Binding b = it.next().asJenaBinding();
-        assertEquals( 3, b.size() );
-        assertEquals( "http://example.org/x1", b.get(var1).getURI() );
-        assertEquals( "http://example.org/y1", b.get(var2).getURI() );
-        assertEquals( "http://example.org/z1", b.get(var3).getURI() );
+        assertHasNext( it, "http://example.org/x1", var1, "http://example.org/y1", var2, "http://example.org/z1", var3 );
 
         assertFalse( it.hasNext() );
     }
@@ -37,32 +31,18 @@ public class SolutionMappingsIterableWithThreeVarsFilterTest extends TestsForSol
         // (var2, y1, var1, x1, var4, p): filter based on subset of variables
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithThreeVarsFilter( getSolMapListWithThreeVar(), var2, y1, var1, x1, var4, p ).iterator();
 
-        assertTrue( it.hasNext() );
-        final Binding b1 = it.next().asJenaBinding();
-        assertEquals( 3, b1.size() );
-        assertEquals( "http://example.org/x1", b1.get(var1).getURI() );
-        assertEquals( "http://example.org/y1", b1.get(var2).getURI() );
-        assertEquals( "http://example.org/z1", b1.get(var3).getURI() );
-
-        assertTrue( it.hasNext() );
-        final Binding b2 = it.next().asJenaBinding();
-        assertEquals( 3, b2.size() );
-        assertEquals( "http://example.org/x1", b2.get(var1).getURI() );
-        assertEquals( "http://example.org/y1", b2.get(var2).getURI() );
-        assertEquals( "http://example.org/z2", b2.get(var3).getURI() );
+        assertHasNext( it, "http://example.org/x1", var1, "http://example.org/y1", var2, "http://example.org/z1", var3 );
+        assertHasNext( it, "http://example.org/x1", var1, "http://example.org/y1", var2, "http://example.org/z2", var3 );
 
         assertFalse( it.hasNext() );
     }
 
     @Test
     public void solutionMappingsIterableWithThreeVarsFilter_filterWithTwoOfThreeVars_empty() {
-        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
-
         // (var2, y1, var1, x2, var4, p): no solution mappings that having (var2, y1, var1, x2)
-        final Iterable<SolutionMapping> solMapAfterFilter4 = new SolutionMappingsIterableWithThreeVarsFilter( solMaps.getSolMapListWithThreeVar(), solMaps.var2, solMaps.y1, solMaps.var1, solMaps.x2, solMaps.var4, solMaps.p );
-        final Iterator<SolutionMapping> it4 = solMapAfterFilter4.iterator();
+        final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithThreeVarsFilter( getSolMapListWithThreeVar(), var2, y1, var1, x2, var4, p).iterator();
 
-        assertFalse( it4.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
@@ -70,26 +50,9 @@ public class SolutionMappingsIterableWithThreeVarsFilterTest extends TestsForSol
         // (var5, y1, var6, x2, var4, p): return all solution mappings: no solution mappings that have value for var4 or var5 or var6
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithThreeVarsFilter( getSolMapListWithThreeVar(), var5, y1, var6, x2, var4, p ).iterator();
 
-        assertTrue( it.hasNext() );
-        final Binding b1 = it.next().asJenaBinding();
-        assertEquals( 3, b1.size() );
-        assertEquals( "http://example.org/x1", b1.get(var1).getURI() );
-        assertEquals( "http://example.org/y1", b1.get(var2).getURI() );
-        assertEquals( "http://example.org/z1", b1.get(var3).getURI() );
-
-        assertTrue( it.hasNext() );
-        final Binding b2 = it.next().asJenaBinding();
-        assertEquals( 3, b2.size() );
-        assertEquals( "http://example.org/x1", b2.get(var1).getURI() );
-        assertEquals( "http://example.org/y1", b2.get(var2).getURI() );
-        assertEquals( "http://example.org/z2", b2.get(var3).getURI() );
-
-        assertTrue( it.hasNext() );
-        final Binding b3 = it.next().asJenaBinding();
-        assertEquals( 3, b3.size() );
-        assertEquals( "http://example.org/x2", b3.get(var1).getURI() );
-        assertEquals( "http://example.org/y2", b3.get(var2).getURI() );
-        assertEquals( "http://example.org/z2", b3.get(var3).getURI() );
+        assertHasNext( it, "http://example.org/x1", var1, "http://example.org/y1", var2, "http://example.org/z1", var3 );
+        assertHasNext( it, "http://example.org/x1", var1, "http://example.org/y1", var2, "http://example.org/z2", var3 );
+        assertHasNext( it, "http://example.org/x2", var1, "http://example.org/y2", var2, "http://example.org/z2", var3 );
 
         assertFalse( it.hasNext() );
     }

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithThreeVarsFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithThreeVarsFilterTest.java
@@ -1,65 +1,44 @@
 package se.liu.ida.hefquin.engine.data.utils;
 
-import org.apache.jena.graph.Node;
-import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.junit.Test;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
-import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
-import se.liu.ida.hefquin.engine.datastructures.impl.SolutionMappingsHashTableBasedOnOneVar;
-import se.liu.ida.hefquin.engine.datastructures.impl.SolutionMappingsIndexBase;
-
 import java.util.Iterator;
 
 import static org.junit.Assert.*;
 
 public class SolutionMappingsIterableWithThreeVarsFilterTest {
     @Test
-    public void hashTableWithOneInputVariable() {
-        final Var var1 = Var.alloc("v1");
-        final Var var2 = Var.alloc("v2");
-        final Var var3 = Var.alloc("v3");
-        final Var var4 = Var.alloc("v4");
-        final Var var5 = Var.alloc("v4");
-        final Var var6 = Var.alloc("v4");
+    public void solutionMappingsIterableWithThreeVarsFilter_filterWithThreeVars_subset() {
+        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
 
-        final Node x1 = NodeFactory.createURI("http://example.org/x1");
-        final Node x2 = NodeFactory.createURI("http://example.org/x2");
-        final Node y1 = NodeFactory.createURI("http://example.org/y1");
-        final Node y2 = NodeFactory.createURI("http://example.org/y2");
-        final Node z1 = NodeFactory.createURI("http://example.org/z1");
-        final Node z2 = NodeFactory.createURI("http://example.org/z2");
-        final Node p = NodeFactory.createURI("http://example.org/p");
-
-        // create SolutionMappingsIndexBase
-        final SolutionMappingsIndexBase solMHashTable = new SolutionMappingsHashTableBasedOnOneVar(var2);
-
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var1, x1,
-                var2, y1,
-                var3, z1) );
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var1, x1,
-                var2, y1,
-                var3, z2) );
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var1, x2,
-                var2, y2,
-                var3, z2) );
-        final Iterable<SolutionMapping> allSolMap = solMHashTable.getAllSolutionMappings();
-
-        // iterate over the subset of solution mappings that have a given value for var2 and vae3
-        final Iterable<SolutionMapping> solMapAfterFilter1 = new SolutionMappingsIterableWithThreeVarsFilter( allSolMap, var3, z1, var1, x1, var2, y1 );
+        // iterate over the subset of solution mappings that have (var3, z1, var1, x1, var2, y1)
+        final Iterable<SolutionMapping> solMapAfterFilter1 = new SolutionMappingsIterableWithThreeVarsFilter( solMaps.getSolMapListWithThreeVar(), solMaps.var3, solMaps.z1, solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y1 );
         final Iterator<SolutionMapping> it1 = solMapAfterFilter1.iterator();
         assertTrue( it1.hasNext() );
         final Binding bIt1 = it1.next().asJenaBinding();
         assertEquals( 3, bIt1.size() );
 
         assertFalse( it1.hasNext() );
+    }
 
-        // filter based on subset of variables
-        final Iterable<SolutionMapping> solMapAfterFilter2 = new SolutionMappingsIterableWithThreeVarsFilter( allSolMap, var2, y1, var1, x1, var4, p );
+    @Test
+    public void solutionMappingsIterableWithThreeVarsFilter_filterWithThreeVars_empty() {
+        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
+
+        // no solution mappings that having (var1, x2, var2, y1, var3, z2)
+        final Iterable<SolutionMapping> solMapAfterFilter3 = new SolutionMappingsIterableWithThreeVarsFilter( solMaps.getSolMapListWithThreeVar(), solMaps.var1, solMaps.x2, solMaps.var2, solMaps.y1, solMaps.var3, solMaps.z2 );
+        final Iterator<SolutionMapping> it3 = solMapAfterFilter3.iterator();
+
+        assertFalse( it3.hasNext() );
+    }
+
+    @Test
+    public void solutionMappingsIterableWithThreeVarsFilter_filterWithTwoOfThreeVars_subset() {
+        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
+
+        // (var2, y1, var1, x1, var4, p): filter based on subset of variables (var2, y1, var1, x1)
+        final Iterable<SolutionMapping> solMapAfterFilter2 = new SolutionMappingsIterableWithThreeVarsFilter( solMaps.getSolMapListWithThreeVar(), solMaps.var2, solMaps.y1, solMaps.var1, solMaps.x1, solMaps.var4, solMaps.p );
         final Iterator<SolutionMapping> it2 = solMapAfterFilter2.iterator();
         assertTrue( it2.hasNext() );
         final Binding bIt21 = it2.next().asJenaBinding();
@@ -70,21 +49,25 @@ public class SolutionMappingsIterableWithThreeVarsFilterTest {
         assertEquals( 3, bIt22.size() );
 
         assertFalse( it2.hasNext() );
+    }
 
-        // no solution mappings that having (var1, x2, var2, y1, var3, z2)
-        final Iterable<SolutionMapping> solMapAfterFilter3 = new SolutionMappingsIterableWithThreeVarsFilter( allSolMap, var1, x2, var2, y1, var3, z2 );
-        final Iterator<SolutionMapping> it3 = solMapAfterFilter3.iterator();
+    @Test
+    public void solutionMappingsIterableWithThreeVarsFilter_filterWithTwoOfThreeVars_empty() {
+        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
 
-        assertFalse( it3.hasNext() );
-
-        // no solution mappings that having (var2, y1, var1, x2)
-        final Iterable<SolutionMapping> solMapAfterFilter4 = new SolutionMappingsIterableWithThreeVarsFilter( allSolMap, var2, y1, var1, x2, var4, p );
+        // (var2, y1, var1, x2, var4, p): no solution mappings that having (var2, y1, var1, x2)
+        final Iterable<SolutionMapping> solMapAfterFilter4 = new SolutionMappingsIterableWithThreeVarsFilter( solMaps.getSolMapListWithThreeVar(), solMaps.var2, solMaps.y1, solMaps.var1, solMaps.x2, solMaps.var4, solMaps.p );
         final Iterator<SolutionMapping> it4 = solMapAfterFilter4.iterator();
 
         assertFalse( it4.hasNext() );
+    }
 
-        // return all solution mappings: no solution mappings that have value for var4 or var5 or var6
-        final Iterable<SolutionMapping> solMapAfterFilter5 = new SolutionMappingsIterableWithThreeVarsFilter( allSolMap, var5, y1, var6, x2, var4, p );
+    @Test
+    public void solutionMappingsIterableWithThreeVarsFilter_filterWithNoneOfThreeVars_all() {
+        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
+
+        // (var5, y1, var6, x2, var4, p): return all solution mappings: no solution mappings that have value for var4 or var5 or var6
+        final Iterable<SolutionMapping> solMapAfterFilter5 = new SolutionMappingsIterableWithThreeVarsFilter( solMaps.getSolMapListWithThreeVar(), solMaps.var5, solMaps.y1, solMaps.var6, solMaps.x2, solMaps.var4, solMaps.p );
         final Iterator<SolutionMapping> it5 = solMapAfterFilter5.iterator();
         assertTrue( it5.hasNext() );
         final Binding bIt51 = it5.next().asJenaBinding();

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithThreeVarsFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithThreeVarsFilterTest.java
@@ -18,6 +18,9 @@ public class SolutionMappingsIterableWithThreeVarsFilterTest {
         assertTrue( it1.hasNext() );
         final Binding bIt1 = it1.next().asJenaBinding();
         assertEquals( 3, bIt1.size() );
+        assertEquals( "http://example.org/x1", bIt1.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y1", bIt1.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z1", bIt1.get(solMaps.var3).getURI() );
 
         assertFalse( it1.hasNext() );
     }
@@ -37,16 +40,22 @@ public class SolutionMappingsIterableWithThreeVarsFilterTest {
     public void solutionMappingsIterableWithThreeVarsFilter_filterWithTwoOfThreeVars_subset() {
         final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
 
-        // (var2, y1, var1, x1, var4, p): filter based on subset of variables (var2, y1, var1, x1)
+        // (var2, y1, var1, x1, var4, p): filter based on subset of variables
         final Iterable<SolutionMapping> solMapAfterFilter2 = new SolutionMappingsIterableWithThreeVarsFilter( solMaps.getSolMapListWithThreeVar(), solMaps.var2, solMaps.y1, solMaps.var1, solMaps.x1, solMaps.var4, solMaps.p );
         final Iterator<SolutionMapping> it2 = solMapAfterFilter2.iterator();
         assertTrue( it2.hasNext() );
         final Binding bIt21 = it2.next().asJenaBinding();
         assertEquals( 3, bIt21.size() );
+        assertEquals( "http://example.org/x1", bIt21.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y1", bIt21.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z1", bIt21.get(solMaps.var3).getURI() );
 
         assertTrue( it2.hasNext() );
         final Binding bIt22 = it2.next().asJenaBinding();
         assertEquals( 3, bIt22.size() );
+        assertEquals( "http://example.org/x1", bIt22.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y1", bIt22.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z2", bIt22.get(solMaps.var3).getURI() );
 
         assertFalse( it2.hasNext() );
     }
@@ -72,14 +81,23 @@ public class SolutionMappingsIterableWithThreeVarsFilterTest {
         assertTrue( it5.hasNext() );
         final Binding bIt51 = it5.next().asJenaBinding();
         assertEquals( 3, bIt51.size() );
+        assertEquals( "http://example.org/x1", bIt51.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y1", bIt51.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z1", bIt51.get(solMaps.var3).getURI() );
 
         assertTrue( it5.hasNext() );
         final Binding bIt52 = it5.next().asJenaBinding();
         assertEquals( 3, bIt52.size() );
+        assertEquals( "http://example.org/x1", bIt52.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y1", bIt52.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z2", bIt52.get(solMaps.var3).getURI() );
 
         assertTrue( it5.hasNext() );
         final Binding bIt53 = it5.next().asJenaBinding();
         assertEquals( 3, bIt53.size() );
+        assertEquals( "http://example.org/x2", bIt53.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y2", bIt53.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z2", bIt53.get(solMaps.var3).getURI() );
 
         assertFalse( it5.hasNext() );
     }

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithThreeVarsFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithThreeVarsFilterTest.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.*;
 public class SolutionMappingsIterableWithThreeVarsFilterTest extends TestsForSolutionMappingsIterableWithFilter
 {
     @Test
-    public void solutionMappingsIterableWithThreeVarsFilter_filterWithThreeVars_subset() {
+    public void filterWithThreeVars_subset() {
         // iterate over the subset of solution mappings that have (var3, z1, var1, x1, var2, y1)
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithThreeVarsFilter( getSolMapListWithThreeVar(), var3, z1, var1, x1, var2, y1 ).iterator();
 
@@ -19,7 +19,7 @@ public class SolutionMappingsIterableWithThreeVarsFilterTest extends TestsForSol
     }
 
     @Test
-    public void solutionMappingsIterableWithThreeVarsFilter_filterWithThreeVars_empty() {
+    public void filterWithThreeVars_empty() {
         // no solution mappings that having (var1, x2, var2, y1, var3, z2)
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithThreeVarsFilter( getSolMapListWithThreeVar(), var1, x2, var2, y1, var3, z2 ).iterator();
 
@@ -27,7 +27,7 @@ public class SolutionMappingsIterableWithThreeVarsFilterTest extends TestsForSol
     }
 
     @Test
-    public void solutionMappingsIterableWithThreeVarsFilter_filterWithTwoOfThreeVars_subset() {
+    public void filterWithTwoOfThreeVars_subset() {
         // (var2, y1, var1, x1, var4, p): filter based on subset of variables
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithThreeVarsFilter( getSolMapListWithThreeVar(), var2, y1, var1, x1, var4, p ).iterator();
 
@@ -38,7 +38,7 @@ public class SolutionMappingsIterableWithThreeVarsFilterTest extends TestsForSol
     }
 
     @Test
-    public void solutionMappingsIterableWithThreeVarsFilter_filterWithTwoOfThreeVars_empty() {
+    public void filterWithTwoOfThreeVars_empty() {
         // (var2, y1, var1, x2, var4, p): no solution mappings that having (var2, y1, var1, x2)
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithThreeVarsFilter( getSolMapListWithThreeVar(), var2, y1, var1, x2, var4, p).iterator();
 
@@ -46,7 +46,7 @@ public class SolutionMappingsIterableWithThreeVarsFilterTest extends TestsForSol
     }
 
     @Test
-    public void solutionMappingsIterableWithThreeVarsFilter_filterWithNoneOfThreeVars_all() {
+    public void filterWithNoneOfThreeVars_all() {
         // (var5, y1, var6, x2, var4, p): return all solution mappings: no solution mappings that have value for var4 or var5 or var6
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithThreeVarsFilter( getSolMapListWithThreeVar(), var5, y1, var6, x2, var4, p ).iterator();
 

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithThreeVarsFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithThreeVarsFilterTest.java
@@ -7,57 +7,51 @@ import java.util.Iterator;
 
 import static org.junit.Assert.*;
 
-public class SolutionMappingsIterableWithThreeVarsFilterTest {
+public class SolutionMappingsIterableWithThreeVarsFilterTest extends TestsForSolutionMappingsIterableWithFilter
+{
     @Test
     public void solutionMappingsIterableWithThreeVarsFilter_filterWithThreeVars_subset() {
-        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
-
         // iterate over the subset of solution mappings that have (var3, z1, var1, x1, var2, y1)
-        final Iterable<SolutionMapping> solMapAfterFilter1 = new SolutionMappingsIterableWithThreeVarsFilter( solMaps.getSolMapListWithThreeVar(), solMaps.var3, solMaps.z1, solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y1 );
-        final Iterator<SolutionMapping> it1 = solMapAfterFilter1.iterator();
-        assertTrue( it1.hasNext() );
-        final Binding bIt1 = it1.next().asJenaBinding();
-        assertEquals( 3, bIt1.size() );
-        assertEquals( "http://example.org/x1", bIt1.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y1", bIt1.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z1", bIt1.get(solMaps.var3).getURI() );
+        final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithThreeVarsFilter( getSolMapListWithThreeVar(), var3, z1, var1, x1, var2, y1 ).iterator();
 
-        assertFalse( it1.hasNext() );
+        assertTrue( it.hasNext() );
+        final Binding b = it.next().asJenaBinding();
+        assertEquals( 3, b.size() );
+        assertEquals( "http://example.org/x1", b.get(var1).getURI() );
+        assertEquals( "http://example.org/y1", b.get(var2).getURI() );
+        assertEquals( "http://example.org/z1", b.get(var3).getURI() );
+
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void solutionMappingsIterableWithThreeVarsFilter_filterWithThreeVars_empty() {
-        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
-
         // no solution mappings that having (var1, x2, var2, y1, var3, z2)
-        final Iterable<SolutionMapping> solMapAfterFilter3 = new SolutionMappingsIterableWithThreeVarsFilter( solMaps.getSolMapListWithThreeVar(), solMaps.var1, solMaps.x2, solMaps.var2, solMaps.y1, solMaps.var3, solMaps.z2 );
-        final Iterator<SolutionMapping> it3 = solMapAfterFilter3.iterator();
+        final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithThreeVarsFilter( getSolMapListWithThreeVar(), var1, x2, var2, y1, var3, z2 ).iterator();
 
-        assertFalse( it3.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void solutionMappingsIterableWithThreeVarsFilter_filterWithTwoOfThreeVars_subset() {
-        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
-
         // (var2, y1, var1, x1, var4, p): filter based on subset of variables
-        final Iterable<SolutionMapping> solMapAfterFilter2 = new SolutionMappingsIterableWithThreeVarsFilter( solMaps.getSolMapListWithThreeVar(), solMaps.var2, solMaps.y1, solMaps.var1, solMaps.x1, solMaps.var4, solMaps.p );
-        final Iterator<SolutionMapping> it2 = solMapAfterFilter2.iterator();
-        assertTrue( it2.hasNext() );
-        final Binding bIt21 = it2.next().asJenaBinding();
-        assertEquals( 3, bIt21.size() );
-        assertEquals( "http://example.org/x1", bIt21.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y1", bIt21.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z1", bIt21.get(solMaps.var3).getURI() );
+        final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithThreeVarsFilter( getSolMapListWithThreeVar(), var2, y1, var1, x1, var4, p ).iterator();
 
-        assertTrue( it2.hasNext() );
-        final Binding bIt22 = it2.next().asJenaBinding();
-        assertEquals( 3, bIt22.size() );
-        assertEquals( "http://example.org/x1", bIt22.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y1", bIt22.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z2", bIt22.get(solMaps.var3).getURI() );
+        assertTrue( it.hasNext() );
+        final Binding b1 = it.next().asJenaBinding();
+        assertEquals( 3, b1.size() );
+        assertEquals( "http://example.org/x1", b1.get(var1).getURI() );
+        assertEquals( "http://example.org/y1", b1.get(var2).getURI() );
+        assertEquals( "http://example.org/z1", b1.get(var3).getURI() );
 
-        assertFalse( it2.hasNext() );
+        assertTrue( it.hasNext() );
+        final Binding b2 = it.next().asJenaBinding();
+        assertEquals( 3, b2.size() );
+        assertEquals( "http://example.org/x1", b2.get(var1).getURI() );
+        assertEquals( "http://example.org/y1", b2.get(var2).getURI() );
+        assertEquals( "http://example.org/z2", b2.get(var3).getURI() );
+
+        assertFalse( it.hasNext() );
     }
 
     @Test
@@ -73,32 +67,30 @@ public class SolutionMappingsIterableWithThreeVarsFilterTest {
 
     @Test
     public void solutionMappingsIterableWithThreeVarsFilter_filterWithNoneOfThreeVars_all() {
-        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
-
         // (var5, y1, var6, x2, var4, p): return all solution mappings: no solution mappings that have value for var4 or var5 or var6
-        final Iterable<SolutionMapping> solMapAfterFilter5 = new SolutionMappingsIterableWithThreeVarsFilter( solMaps.getSolMapListWithThreeVar(), solMaps.var5, solMaps.y1, solMaps.var6, solMaps.x2, solMaps.var4, solMaps.p );
-        final Iterator<SolutionMapping> it5 = solMapAfterFilter5.iterator();
-        assertTrue( it5.hasNext() );
-        final Binding bIt51 = it5.next().asJenaBinding();
-        assertEquals( 3, bIt51.size() );
-        assertEquals( "http://example.org/x1", bIt51.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y1", bIt51.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z1", bIt51.get(solMaps.var3).getURI() );
+        final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithThreeVarsFilter( getSolMapListWithThreeVar(), var5, y1, var6, x2, var4, p ).iterator();
 
-        assertTrue( it5.hasNext() );
-        final Binding bIt52 = it5.next().asJenaBinding();
-        assertEquals( 3, bIt52.size() );
-        assertEquals( "http://example.org/x1", bIt52.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y1", bIt52.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z2", bIt52.get(solMaps.var3).getURI() );
+        assertTrue( it.hasNext() );
+        final Binding b1 = it.next().asJenaBinding();
+        assertEquals( 3, b1.size() );
+        assertEquals( "http://example.org/x1", b1.get(var1).getURI() );
+        assertEquals( "http://example.org/y1", b1.get(var2).getURI() );
+        assertEquals( "http://example.org/z1", b1.get(var3).getURI() );
 
-        assertTrue( it5.hasNext() );
-        final Binding bIt53 = it5.next().asJenaBinding();
-        assertEquals( 3, bIt53.size() );
-        assertEquals( "http://example.org/x2", bIt53.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y2", bIt53.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z2", bIt53.get(solMaps.var3).getURI() );
+        assertTrue( it.hasNext() );
+        final Binding b2 = it.next().asJenaBinding();
+        assertEquals( 3, b2.size() );
+        assertEquals( "http://example.org/x1", b2.get(var1).getURI() );
+        assertEquals( "http://example.org/y1", b2.get(var2).getURI() );
+        assertEquals( "http://example.org/z2", b2.get(var3).getURI() );
 
-        assertFalse( it5.hasNext() );
+        assertTrue( it.hasNext() );
+        final Binding b3 = it.next().asJenaBinding();
+        assertEquals( 3, b3.size() );
+        assertEquals( "http://example.org/x2", b3.get(var1).getURI() );
+        assertEquals( "http://example.org/y2", b3.get(var2).getURI() );
+        assertEquals( "http://example.org/z2", b3.get(var3).getURI() );
+
+        assertFalse( it.hasNext() );
     }
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithTwoVarsFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithTwoVarsFilterTest.java
@@ -19,6 +19,8 @@ public class SolutionMappingsIterableWithTwoVarsFilterTest {
         assertTrue( it1.hasNext() );
         final Binding bIt1 = it1.next().asJenaBinding();
         assertEquals( 2, bIt1.size() );
+        assertEquals( "http://example.org/y1", bIt1.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z1", bIt1.get(solMaps.var3).getURI() );
 
         assertFalse( it1.hasNext() );
     }
@@ -44,10 +46,14 @@ public class SolutionMappingsIterableWithTwoVarsFilterTest {
         assertTrue( it3.hasNext() );
         final Binding bIt31 = it3.next().asJenaBinding();
         assertEquals( 2, bIt31.size() );
+        assertEquals( "http://example.org/y1", bIt31.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z1", bIt31.get(solMaps.var3).getURI() );
 
         assertTrue( it3.hasNext() );
         final Binding bIt32 = it3.next().asJenaBinding();
         assertEquals( 2, bIt32.size() );
+        assertEquals("http://example.org/y1", bIt32.get(solMaps.var2).getURI());
+        assertEquals("http://example.org/z2", bIt32.get(solMaps.var3).getURI());
 
         assertFalse( it3.hasNext() );
     }
@@ -62,14 +68,20 @@ public class SolutionMappingsIterableWithTwoVarsFilterTest {
         assertTrue( it4.hasNext() );
         final Binding bIt41 = it4.next().asJenaBinding();
         assertEquals( 2, bIt41.size() );
+        assertEquals( "http://example.org/y1", bIt41.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z1", bIt41.get(solMaps.var3).getURI() );
 
         assertTrue( it4.hasNext() );
         final Binding bIt42 = it4.next().asJenaBinding();
         assertEquals( 2, bIt42.size() );
+        assertEquals("http://example.org/y1", bIt42.get(solMaps.var2).getURI());
+        assertEquals("http://example.org/z2", bIt42.get(solMaps.var3).getURI());
 
         assertTrue( it4.hasNext() );
         final Binding bIt43 = it4.next().asJenaBinding();
         assertEquals( 2, bIt43.size() );
+        assertEquals("http://example.org/y2", bIt43.get(solMaps.var2).getURI());
+        assertEquals("http://example.org/z3", bIt43.get(solMaps.var3).getURI());
 
         assertFalse( it4.hasNext() );
     }

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithTwoVarsFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithTwoVarsFilterTest.java
@@ -1,14 +1,8 @@
 package se.liu.ida.hefquin.engine.data.utils;
 
-import org.apache.jena.graph.Node;
-import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.junit.Test;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
-import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
-import se.liu.ida.hefquin.engine.datastructures.impl.SolutionMappingsHashTableBasedOnOneVar;
-import se.liu.ida.hefquin.engine.datastructures.impl.SolutionMappingsIndexBase;
 
 import java.util.Iterator;
 
@@ -16,49 +10,36 @@ import static org.junit.Assert.*;
 
 public class SolutionMappingsIterableWithTwoVarsFilterTest {
     @Test
-    public void hashTableWithOneInputVariable() {
-        final Var var1 = Var.alloc("v1");
-        final Var var2 = Var.alloc("v2");
-        final Var var3 = Var.alloc("v3");
-        final Var var4 = Var.alloc("v4");
+    public void solutionMappingsIterableWithTwoVarsFilter_filterWithTwoVars_subset() {
+        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
 
-        final Node y1 = NodeFactory.createURI("http://example.org/y1");
-        final Node y2 = NodeFactory.createURI("http://example.org/y2");
-        final Node z1 = NodeFactory.createURI("http://example.org/z1");
-        final Node z2 = NodeFactory.createURI("http://example.org/z2");
-        final Node z3 = NodeFactory.createURI("http://example.org/z3");
-        final Node p = NodeFactory.createURI("http://example.org/p");
-
-        // create SolutionMappingsIndexBase
-        final SolutionMappingsIndexBase solMHashTable = new SolutionMappingsHashTableBasedOnOneVar(var2);
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var2, y1,
-                var3, z1) );
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var2, y1,
-                var3, z2) );
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var2, y2,
-                var3, z3) );
-        final Iterable<SolutionMapping> allSolMap = solMHashTable.getAllSolutionMappings();
-
-        // iterate over the subset of solution mappings that have a given value for var2 and var3
-        final Iterable<SolutionMapping> solMapAfterFilter1 = new SolutionMappingsIterableWithTwoVarsFilter( allSolMap, var2, y1, var3, z1 );
+        // iterate over the subset of solution mappings that have (var2, y1, var3, z1)
+        final Iterable<SolutionMapping> solMapAfterFilter1 = new SolutionMappingsIterableWithTwoVarsFilter( solMaps.getSolMapListWithTwoVar(), solMaps.var2, solMaps.y1, solMaps.var3, solMaps.z1 );
         final Iterator<SolutionMapping> it1 = solMapAfterFilter1.iterator();
         assertTrue( it1.hasNext() );
         final Binding bIt1 = it1.next().asJenaBinding();
         assertEquals( 2, bIt1.size() );
 
         assertFalse( it1.hasNext() );
+    }
+
+    @Test
+    public void solutionMappingsIterableWithTwoVarsFilter_filterWithTwoVar_empty() {
+        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
 
         // no solution mappings that having (var2, y2, var3, z1)
-        final Iterable<SolutionMapping> solMapAfterFilter2 = new SolutionMappingsIterableWithTwoVarsFilter( allSolMap, var2, y2, var3, z1 );
+        final Iterable<SolutionMapping> solMapAfterFilter2 = new SolutionMappingsIterableWithTwoVarsFilter( solMaps.getSolMapListWithTwoVar(), solMaps.var2, solMaps.y2, solMaps.var3, solMaps.z1 );
         final Iterator<SolutionMapping> it2 = solMapAfterFilter2.iterator();
 
         assertFalse( it2.hasNext() );
+    }
 
-        // (var1, p, var2, y1): iterate over the subset of solution mappings that have a given value for var2
-        final Iterable<SolutionMapping> solMapAfterFilter3 = new SolutionMappingsIterableWithTwoVarsFilter( allSolMap, var1, p, var2, y1);
+    @Test
+    public void solutionMappingsIterableWithTwoVarsFilter_filterWithOneOfTwoVars() {
+        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
+
+        // (var1, p, var2, y1): iterate over the subset of solution mappings that have y1 for var2
+        final Iterable<SolutionMapping> solMapAfterFilter3 = new SolutionMappingsIterableWithTwoVarsFilter( solMaps.getSolMapListWithTwoVar(), solMaps.var1, solMaps.p, solMaps.var2, solMaps.y1);
         final Iterator<SolutionMapping> it3 = solMapAfterFilter3.iterator();
         assertTrue( it3.hasNext() );
         final Binding bIt31 = it3.next().asJenaBinding();
@@ -69,9 +50,14 @@ public class SolutionMappingsIterableWithTwoVarsFilterTest {
         assertEquals( 2, bIt32.size() );
 
         assertFalse( it3.hasNext() );
+    }
+
+    @Test
+    public void solutionMappingsIterableWithTwoVarsFilter_filterWithNonOfTwoVar() {
+        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
 
         // return all solution mappings: no solution mappings that have value for var1, var4
-        final Iterable<SolutionMapping> solMapAfterFilter4 = new SolutionMappingsIterableWithTwoVarsFilter( allSolMap, var1, p, var4, p);
+        final Iterable<SolutionMapping> solMapAfterFilter4 = new SolutionMappingsIterableWithTwoVarsFilter( solMaps.getSolMapListWithTwoVar(), solMaps.var1, solMaps.p, solMaps.var4, solMaps.p);
         final Iterator<SolutionMapping> it4 = solMapAfterFilter4.iterator();
         assertTrue( it4.hasNext() );
         final Binding bIt41 = it4.next().asJenaBinding();

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithTwoVarsFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithTwoVarsFilterTest.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.*;
 public class SolutionMappingsIterableWithTwoVarsFilterTest extends TestsForSolutionMappingsIterableWithFilter
 {
     @Test
-    public void solutionMappingsIterableWithTwoVarsFilter_filterWithTwoVars_subset() {
+    public void filterWithTwoVars_subset() {
         // iterate over the subset of solution mappings that have (var2, y1, var3, z1)
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithTwoVarsFilter( getSolMapListWithTwoVar(), var2, y1, var3, z1 ).iterator();
 
@@ -20,7 +20,7 @@ public class SolutionMappingsIterableWithTwoVarsFilterTest extends TestsForSolut
     }
 
     @Test
-    public void solutionMappingsIterableWithTwoVarsFilter_filterWithTwoVar_empty() {
+    public void filterWithTwoVar_empty() {
         // no solution mappings that having (var2, y2, var3, z1)
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithTwoVarsFilter( getSolMapListWithTwoVar(), var2, y2, var3, z1 ).iterator();
 
@@ -28,7 +28,7 @@ public class SolutionMappingsIterableWithTwoVarsFilterTest extends TestsForSolut
     }
 
     @Test
-    public void solutionMappingsIterableWithTwoVarsFilter_filterWithOneOfTwoVars() {
+    public void filterWithOneOfTwoVars() {
         // (var1, p, var2, y1): iterate over the subset of solution mappings that have y1 for var2
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithTwoVarsFilter( getSolMapListWithTwoVar(), var1, p, var2, y1).iterator();
 
@@ -39,7 +39,7 @@ public class SolutionMappingsIterableWithTwoVarsFilterTest extends TestsForSolut
     }
 
     @Test
-    public void solutionMappingsIterableWithTwoVarsFilter_filterWithNonOfTwoVar() {
+    public void filterWithNonOfTwoVar() {
         // return all solution mappings: no solution mappings that have value for var1, var4
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithTwoVarsFilter( getSolMapListWithTwoVar(), var1, p, var4, p).iterator();
 

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithTwoVarsFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithTwoVarsFilterTest.java
@@ -1,0 +1,90 @@
+package se.liu.ida.hefquin.engine.data.utils;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.junit.Test;
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
+import se.liu.ida.hefquin.engine.datastructures.impl.SolutionMappingsHashTableBasedOnOneVar;
+import se.liu.ida.hefquin.engine.datastructures.impl.SolutionMappingsIndexBase;
+
+import java.util.Iterator;
+
+import static org.junit.Assert.*;
+
+public class SolutionMappingsIterableWithTwoVarsFilterTest {
+    @Test
+    public void hashTableWithOneInputVariable() {
+        final Var var1 = Var.alloc("v1");
+        final Var var2 = Var.alloc("v2");
+        final Var var3 = Var.alloc("v3");
+        final Var var4 = Var.alloc("v4");
+
+        final Node y1 = NodeFactory.createURI("http://example.org/y1");
+        final Node y2 = NodeFactory.createURI("http://example.org/y2");
+        final Node z1 = NodeFactory.createURI("http://example.org/z1");
+        final Node z2 = NodeFactory.createURI("http://example.org/z2");
+        final Node z3 = NodeFactory.createURI("http://example.org/z3");
+        final Node p = NodeFactory.createURI("http://example.org/p");
+
+        // create SolutionMappingsIndexBase
+        final SolutionMappingsIndexBase solMHashTable = new SolutionMappingsHashTableBasedOnOneVar(var2);
+        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+                var2, y1,
+                var3, z1) );
+        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+                var2, y1,
+                var3, z2) );
+        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+                var2, y2,
+                var3, z3) );
+        final Iterable<SolutionMapping> allSolMap = solMHashTable.getAllSolutionMappings();
+
+        // iterate over the subset of solution mappings that have a given value for var2 and var3
+        final Iterable<SolutionMapping> solMapAfterFilter1 = new SolutionMappingsIterableWithTwoVarsFilter( allSolMap, var2, y1, var3, z1 );
+        final Iterator<SolutionMapping> it1 = solMapAfterFilter1.iterator();
+        assertTrue( it1.hasNext() );
+        final Binding bIt1 = it1.next().asJenaBinding();
+        assertEquals( 2, bIt1.size() );
+
+        assertFalse( it1.hasNext() );
+
+        // no solution mappings that having (var2, y2, var3, z1)
+        final Iterable<SolutionMapping> solMapAfterFilter2 = new SolutionMappingsIterableWithTwoVarsFilter( allSolMap, var2, y2, var3, z1 );
+        final Iterator<SolutionMapping> it2 = solMapAfterFilter2.iterator();
+
+        assertFalse( it2.hasNext() );
+
+        // (var1, p, var2, y1): iterate over the subset of solution mappings that have a given value for var2
+        final Iterable<SolutionMapping> solMapAfterFilter3 = new SolutionMappingsIterableWithTwoVarsFilter( allSolMap, var1, p, var2, y1);
+        final Iterator<SolutionMapping> it3 = solMapAfterFilter3.iterator();
+        assertTrue( it3.hasNext() );
+        final Binding bIt31 = it3.next().asJenaBinding();
+        assertEquals( 2, bIt31.size() );
+
+        assertTrue( it3.hasNext() );
+        final Binding bIt32 = it3.next().asJenaBinding();
+        assertEquals( 2, bIt32.size() );
+
+        assertFalse( it3.hasNext() );
+
+        // return all solution mappings: no solution mappings that have value for var1, var4
+        final Iterable<SolutionMapping> solMapAfterFilter4 = new SolutionMappingsIterableWithTwoVarsFilter( allSolMap, var1, p, var4, p);
+        final Iterator<SolutionMapping> it4 = solMapAfterFilter4.iterator();
+        assertTrue( it4.hasNext() );
+        final Binding bIt41 = it4.next().asJenaBinding();
+        assertEquals( 2, bIt41.size() );
+
+        assertTrue( it4.hasNext() );
+        final Binding bIt42 = it4.next().asJenaBinding();
+        assertEquals( 2, bIt42.size() );
+
+        assertTrue( it4.hasNext() );
+        final Binding bIt43 = it4.next().asJenaBinding();
+        assertEquals( 2, bIt43.size() );
+
+        assertFalse( it4.hasNext() );
+    }
+}

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithTwoVarsFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithTwoVarsFilterTest.java
@@ -8,81 +8,73 @@ import java.util.Iterator;
 
 import static org.junit.Assert.*;
 
-public class SolutionMappingsIterableWithTwoVarsFilterTest {
+public class SolutionMappingsIterableWithTwoVarsFilterTest extends TestsForSolutionMappingsIterableWithFilter
+{
     @Test
     public void solutionMappingsIterableWithTwoVarsFilter_filterWithTwoVars_subset() {
-        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
-
         // iterate over the subset of solution mappings that have (var2, y1, var3, z1)
-        final Iterable<SolutionMapping> solMapAfterFilter1 = new SolutionMappingsIterableWithTwoVarsFilter( solMaps.getSolMapListWithTwoVar(), solMaps.var2, solMaps.y1, solMaps.var3, solMaps.z1 );
-        final Iterator<SolutionMapping> it1 = solMapAfterFilter1.iterator();
-        assertTrue( it1.hasNext() );
-        final Binding bIt1 = it1.next().asJenaBinding();
-        assertEquals( 2, bIt1.size() );
-        assertEquals( "http://example.org/y1", bIt1.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z1", bIt1.get(solMaps.var3).getURI() );
+        final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithTwoVarsFilter( getSolMapListWithTwoVar(), var2, y1, var3, z1 ).iterator();
 
-        assertFalse( it1.hasNext() );
+        assertTrue( it.hasNext() );
+        final Binding b = it.next().asJenaBinding();
+        assertEquals( 2, b.size() );
+        assertEquals( "http://example.org/y1", b.get(var2).getURI() );
+        assertEquals( "http://example.org/z1", b.get(var3).getURI() );
+
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void solutionMappingsIterableWithTwoVarsFilter_filterWithTwoVar_empty() {
-        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
-
         // no solution mappings that having (var2, y2, var3, z1)
-        final Iterable<SolutionMapping> solMapAfterFilter2 = new SolutionMappingsIterableWithTwoVarsFilter( solMaps.getSolMapListWithTwoVar(), solMaps.var2, solMaps.y2, solMaps.var3, solMaps.z1 );
-        final Iterator<SolutionMapping> it2 = solMapAfterFilter2.iterator();
+        final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithTwoVarsFilter( getSolMapListWithTwoVar(), var2, y2, var3, z1 ).iterator();
 
-        assertFalse( it2.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void solutionMappingsIterableWithTwoVarsFilter_filterWithOneOfTwoVars() {
-        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
-
         // (var1, p, var2, y1): iterate over the subset of solution mappings that have y1 for var2
-        final Iterable<SolutionMapping> solMapAfterFilter3 = new SolutionMappingsIterableWithTwoVarsFilter( solMaps.getSolMapListWithTwoVar(), solMaps.var1, solMaps.p, solMaps.var2, solMaps.y1);
-        final Iterator<SolutionMapping> it3 = solMapAfterFilter3.iterator();
-        assertTrue( it3.hasNext() );
-        final Binding bIt31 = it3.next().asJenaBinding();
-        assertEquals( 2, bIt31.size() );
-        assertEquals( "http://example.org/y1", bIt31.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z1", bIt31.get(solMaps.var3).getURI() );
+        final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithTwoVarsFilter( getSolMapListWithTwoVar(), var1, p, var2, y1).iterator();
 
-        assertTrue( it3.hasNext() );
-        final Binding bIt32 = it3.next().asJenaBinding();
-        assertEquals( 2, bIt32.size() );
-        assertEquals("http://example.org/y1", bIt32.get(solMaps.var2).getURI());
-        assertEquals("http://example.org/z2", bIt32.get(solMaps.var3).getURI());
+        assertTrue( it.hasNext() );
+        final Binding b1 = it.next().asJenaBinding();
+        assertEquals( 2, b1.size() );
+        assertEquals( "http://example.org/y1", b1.get(var2).getURI() );
+        assertEquals( "http://example.org/z1", b1.get(var3).getURI() );
 
-        assertFalse( it3.hasNext() );
+        assertTrue( it.hasNext() );
+        final Binding b2 = it.next().asJenaBinding();
+        assertEquals( 2, b2.size() );
+        assertEquals("http://example.org/y1", b2.get(var2).getURI());
+        assertEquals("http://example.org/z2", b2.get(var3).getURI());
+
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void solutionMappingsIterableWithTwoVarsFilter_filterWithNonOfTwoVar() {
-        final TestsForSolutionMappingsIterableWithFilter solMaps= new TestsForSolutionMappingsIterableWithFilter();
-
         // return all solution mappings: no solution mappings that have value for var1, var4
-        final Iterable<SolutionMapping> solMapAfterFilter4 = new SolutionMappingsIterableWithTwoVarsFilter( solMaps.getSolMapListWithTwoVar(), solMaps.var1, solMaps.p, solMaps.var4, solMaps.p);
-        final Iterator<SolutionMapping> it4 = solMapAfterFilter4.iterator();
-        assertTrue( it4.hasNext() );
-        final Binding bIt41 = it4.next().asJenaBinding();
-        assertEquals( 2, bIt41.size() );
-        assertEquals( "http://example.org/y1", bIt41.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z1", bIt41.get(solMaps.var3).getURI() );
+        final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithTwoVarsFilter( getSolMapListWithTwoVar(), var1, p, var4, p).iterator();
 
-        assertTrue( it4.hasNext() );
-        final Binding bIt42 = it4.next().asJenaBinding();
-        assertEquals( 2, bIt42.size() );
-        assertEquals("http://example.org/y1", bIt42.get(solMaps.var2).getURI());
-        assertEquals("http://example.org/z2", bIt42.get(solMaps.var3).getURI());
+        assertTrue( it.hasNext() );
+        final Binding b1 = it.next().asJenaBinding();
+        assertEquals( 2, b1.size() );
+        assertEquals( "http://example.org/y1", b1.get(var2).getURI() );
+        assertEquals( "http://example.org/z1", b1.get(var3).getURI() );
 
-        assertTrue( it4.hasNext() );
-        final Binding bIt43 = it4.next().asJenaBinding();
-        assertEquals( 2, bIt43.size() );
-        assertEquals("http://example.org/y2", bIt43.get(solMaps.var2).getURI());
-        assertEquals("http://example.org/z3", bIt43.get(solMaps.var3).getURI());
+        assertTrue( it.hasNext() );
+        final Binding b2 = it.next().asJenaBinding();
+        assertEquals( 2, b2.size() );
+        assertEquals("http://example.org/y1", b2.get(var2).getURI());
+        assertEquals("http://example.org/z2", b2.get(var3).getURI());
 
-        assertFalse( it4.hasNext() );
+        assertTrue( it.hasNext() );
+        final Binding b3 = it.next().asJenaBinding();
+        assertEquals( 2, b3.size() );
+        assertEquals("http://example.org/y2", b3.get(var2).getURI());
+        assertEquals("http://example.org/z3", b3.get(var3).getURI());
+
+        assertFalse( it.hasNext() );
     }
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithTwoVarsFilterTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingsIterableWithTwoVarsFilterTest.java
@@ -1,6 +1,5 @@
 package se.liu.ida.hefquin.engine.data.utils;
 
-import org.apache.jena.sparql.engine.binding.Binding;
 import org.junit.Test;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 
@@ -15,11 +14,7 @@ public class SolutionMappingsIterableWithTwoVarsFilterTest extends TestsForSolut
         // iterate over the subset of solution mappings that have (var2, y1, var3, z1)
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithTwoVarsFilter( getSolMapListWithTwoVar(), var2, y1, var3, z1 ).iterator();
 
-        assertTrue( it.hasNext() );
-        final Binding b = it.next().asJenaBinding();
-        assertEquals( 2, b.size() );
-        assertEquals( "http://example.org/y1", b.get(var2).getURI() );
-        assertEquals( "http://example.org/z1", b.get(var3).getURI() );
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z1", var3 );
 
         assertFalse( it.hasNext() );
     }
@@ -37,17 +32,8 @@ public class SolutionMappingsIterableWithTwoVarsFilterTest extends TestsForSolut
         // (var1, p, var2, y1): iterate over the subset of solution mappings that have y1 for var2
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithTwoVarsFilter( getSolMapListWithTwoVar(), var1, p, var2, y1).iterator();
 
-        assertTrue( it.hasNext() );
-        final Binding b1 = it.next().asJenaBinding();
-        assertEquals( 2, b1.size() );
-        assertEquals( "http://example.org/y1", b1.get(var2).getURI() );
-        assertEquals( "http://example.org/z1", b1.get(var3).getURI() );
-
-        assertTrue( it.hasNext() );
-        final Binding b2 = it.next().asJenaBinding();
-        assertEquals( 2, b2.size() );
-        assertEquals("http://example.org/y1", b2.get(var2).getURI());
-        assertEquals("http://example.org/z2", b2.get(var3).getURI());
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z1", var3 );
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z2", var3 );
 
         assertFalse( it.hasNext() );
     }
@@ -57,23 +43,9 @@ public class SolutionMappingsIterableWithTwoVarsFilterTest extends TestsForSolut
         // return all solution mappings: no solution mappings that have value for var1, var4
         final Iterator<SolutionMapping> it = new SolutionMappingsIterableWithTwoVarsFilter( getSolMapListWithTwoVar(), var1, p, var4, p).iterator();
 
-        assertTrue( it.hasNext() );
-        final Binding b1 = it.next().asJenaBinding();
-        assertEquals( 2, b1.size() );
-        assertEquals( "http://example.org/y1", b1.get(var2).getURI() );
-        assertEquals( "http://example.org/z1", b1.get(var3).getURI() );
-
-        assertTrue( it.hasNext() );
-        final Binding b2 = it.next().asJenaBinding();
-        assertEquals( 2, b2.size() );
-        assertEquals("http://example.org/y1", b2.get(var2).getURI());
-        assertEquals("http://example.org/z2", b2.get(var3).getURI());
-
-        assertTrue( it.hasNext() );
-        final Binding b3 = it.next().asJenaBinding();
-        assertEquals( 2, b3.size() );
-        assertEquals("http://example.org/y2", b3.get(var2).getURI());
-        assertEquals("http://example.org/z3", b3.get(var3).getURI());
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z1", var3 );
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z2", var3 );
+        assertHasNext( it, "http://example.org/y2", var2, "http://example.org/z3", var3 );
 
         assertFalse( it.hasNext() );
     }

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/TestsForSolutionMappingsIterableWithFilter.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/TestsForSolutionMappingsIterableWithFilter.java
@@ -22,8 +22,8 @@ public class TestsForSolutionMappingsIterableWithFilter
 	final Var var2 = Var.alloc("v2");
 	final Var var3 = Var.alloc("v3");
 	final Var var4 = Var.alloc("v4");
-	final Var var5 = Var.alloc("v4");
-	final Var var6 = Var.alloc("v4");
+	final Var var5 = Var.alloc("v5");
+	final Var var6 = Var.alloc("v6");
 
 	final Node x1 = NodeFactory.createURI("http://example.org/x1");
 	final Node x2 = NodeFactory.createURI("http://example.org/x2");

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/TestsForSolutionMappingsIterableWithFilter.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/TestsForSolutionMappingsIterableWithFilter.java
@@ -3,8 +3,13 @@ package se.liu.ida.hefquin.engine.data.utils;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.binding.Binding;
+
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import java.util.*;
 
@@ -50,4 +55,33 @@ public class TestsForSolutionMappingsIterableWithFilter
 
 		return solMapList;
 	}
+
+	protected void assertHasNext( final Iterator<SolutionMapping> it,
+	                              final String expectedURIforV1, final Var v1,
+	                              final String expectedURIforV2, final Var v2 )
+	{
+		assertTrue( it.hasNext() );
+
+        final Binding b = it.next().asJenaBinding();
+        assertEquals( 2, b.size() );
+
+        assertEquals( expectedURIforV1, b.get(v1).getURI() );
+        assertEquals( expectedURIforV2, b.get(v2).getURI() );
+	}
+
+	protected void assertHasNext( final Iterator<SolutionMapping> it,
+	                              final String expectedURIforV1, final Var v1,
+	                              final String expectedURIforV2, final Var v2,
+	                              final String expectedURIforV3, final Var v3 )
+	{
+		assertTrue( it.hasNext() );
+
+        final Binding b = it.next().asJenaBinding();
+        assertEquals( 3, b.size() );
+
+        assertEquals( expectedURIforV1, b.get(v1).getURI() );
+        assertEquals( expectedURIforV2, b.get(v2).getURI() );
+        assertEquals( expectedURIforV3, b.get(v3).getURI() );
+	}
+
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/TestsForSolutionMappingsIterableWithFilter.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/TestsForSolutionMappingsIterableWithFilter.java
@@ -3,20 +3,17 @@ package se.liu.ida.hefquin.engine.data.utils;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.sparql.core.Var;
-import org.apache.jena.sparql.engine.binding.Binding;
 
+import se.liu.ida.hefquin.engine.EngineTestBase;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import java.util.*;
 
 /**
  * This is a class with helper functions for testing SolutionMappingsIterableWithFilter
  */
-public class TestsForSolutionMappingsIterableWithFilter
+public abstract class TestsForSolutionMappingsIterableWithFilter extends EngineTestBase
 {
 	final Var var1 = Var.alloc("v1");
 	final Var var2 = Var.alloc("v2");
@@ -54,34 +51,6 @@ public class TestsForSolutionMappingsIterableWithFilter
 		solMapList.add(SolutionMappingUtils.createSolutionMapping(var1, x2, var2, y2, var3, z2));
 
 		return solMapList;
-	}
-
-	protected void assertHasNext( final Iterator<SolutionMapping> it,
-	                              final String expectedURIforV1, final Var v1,
-	                              final String expectedURIforV2, final Var v2 )
-	{
-		assertTrue( it.hasNext() );
-
-        final Binding b = it.next().asJenaBinding();
-        assertEquals( 2, b.size() );
-
-        assertEquals( expectedURIforV1, b.get(v1).getURI() );
-        assertEquals( expectedURIforV2, b.get(v2).getURI() );
-	}
-
-	protected void assertHasNext( final Iterator<SolutionMapping> it,
-	                              final String expectedURIforV1, final Var v1,
-	                              final String expectedURIforV2, final Var v2,
-	                              final String expectedURIforV3, final Var v3 )
-	{
-		assertTrue( it.hasNext() );
-
-        final Binding b = it.next().asJenaBinding();
-        assertEquals( 3, b.size() );
-
-        assertEquals( expectedURIforV1, b.get(v1).getURI() );
-        assertEquals( expectedURIforV2, b.get(v2).getURI() );
-        assertEquals( expectedURIforV3, b.get(v3).getURI() );
 	}
 
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/TestsForSolutionMappingsIterableWithFilter.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/TestsForSolutionMappingsIterableWithFilter.java
@@ -1,0 +1,53 @@
+package se.liu.ida.hefquin.engine.data.utils;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.Var;
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
+
+import java.util.*;
+
+/**
+ * This is a class with helper functions for testing SolutionMappingsIterableWithFilter
+ */
+public class TestsForSolutionMappingsIterableWithFilter
+{
+	final Var var1 = Var.alloc("v1");
+	final Var var2 = Var.alloc("v2");
+	final Var var3 = Var.alloc("v3");
+	final Var var4 = Var.alloc("v4");
+	final Var var5 = Var.alloc("v4");
+	final Var var6 = Var.alloc("v4");
+
+	final Node x1 = NodeFactory.createURI("http://example.org/x1");
+	final Node x2 = NodeFactory.createURI("http://example.org/x2");
+	final Node y1 = NodeFactory.createURI("http://example.org/y1");
+	final Node y2 = NodeFactory.createURI("http://example.org/y2");
+	final Node z1 = NodeFactory.createURI("http://example.org/z1");
+	final Node z2 = NodeFactory.createURI("http://example.org/z2");
+	final Node z3 = NodeFactory.createURI("http://example.org/z3");
+	final Node p = NodeFactory.createURI("http://example.org/p");
+
+	protected List<SolutionMapping> getSolMapListWithTwoVar()
+	{
+		// create a List of SolutionMappings with two variables
+		final List<SolutionMapping> solMapList = new ArrayList<>();
+		solMapList.add(SolutionMappingUtils.createSolutionMapping(var2, y1, var3, z1));
+		solMapList.add(SolutionMappingUtils.createSolutionMapping(var2, y1, var3, z2));
+		solMapList.add(SolutionMappingUtils.createSolutionMapping(var2, y2, var3, z3));
+
+		return solMapList;
+	}
+
+	protected List<SolutionMapping> getSolMapListWithThreeVar()
+	{
+		// create a List of SolutionMappings with three variables
+		final List<SolutionMapping> solMapList = new ArrayList<>();
+		solMapList.add(SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1, var3, z1));
+		solMapList.add(SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1, var3, z2));
+		solMapList.add(SolutionMappingUtils.createSolutionMapping(var1, x2, var2, y2, var3, z2));
+
+		return solMapList;
+	}
+}

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnOneVarTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnOneVarTest.java
@@ -4,6 +4,7 @@ import org.apache.jena.sparql.engine.binding.Binding;
 import org.junit.Test;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
+import se.liu.ida.hefquin.engine.datastructures.SolutionMappingsIndex;
 
 import java.util.*;
 
@@ -11,9 +12,9 @@ import static org.junit.Assert.*;
 
 public class SolutionMappingsHashTableBasedOnOneVarTest extends TestsForSolutionMappingsIndex {
     @Test
-    public void hashTableWithOneInputVariable_basic() {
+    public void basic() {
         // test method: isEmpty(), contains(), add(), size(), clear()
-        final SolutionMappingsIndexBase solMHashTable = createHashTableBasedOneVar();
+        final SolutionMappingsIndex solMHashTable = createHashTableBasedOneVar();
 
         assertFalse(solMHashTable.isEmpty());
         assertEquals( 3, solMHashTable.size() );
@@ -27,7 +28,7 @@ public class SolutionMappingsHashTableBasedOnOneVarTest extends TestsForSolution
     }
 
     @Test
-    public void hashTableWithOneInputVariable_getAllSolMaps() {
+    public void getAllSolMaps() {
         // test getAllSolutionMappings()
         final Iterator<SolutionMapping> it = createHashTableBasedOneVar().getAllSolutionMappings().iterator();
 
@@ -47,7 +48,7 @@ public class SolutionMappingsHashTableBasedOnOneVarTest extends TestsForSolution
     }
 
     @Test
-    public void hashTableWithOneInputVariable_findSolutionMappings1() {
+    public void findSolutionMappings1() {
         // findSolutionMappings(var2, y2): return one matching solution mapping (hash table is built based on var2)
         final Iterator<SolutionMapping> it = createHashTableBasedOneVar().findSolutionMappings(var2, y2).iterator();
 
@@ -57,7 +58,7 @@ public class SolutionMappingsHashTableBasedOnOneVarTest extends TestsForSolution
     }
 
     @Test
-    public void hashTableWithOneInputVariable_findSolutionMappings2() {
+    public void findSolutionMappings2() {
         //findSolutionMappings(var3, z3): return one matching solution mapping (hash table is not built based on var3)
         final Iterator<SolutionMapping> it = createHashTableBasedOneVar().findSolutionMappings(var3, z3).iterator();
 
@@ -67,7 +68,7 @@ public class SolutionMappingsHashTableBasedOnOneVarTest extends TestsForSolution
     }
 
     @Test
-    public void hashTableWithOneInputVariable_findSolutionMappings3() {
+    public void findSolutionMappings3() {
         // findSolutionMappings(var3, z3, var2, y2): matching one solution mapping
         final Iterator<SolutionMapping> it = createHashTableBasedOneVar().findSolutionMappings(var3, z3, var2, y2).iterator();
 
@@ -77,7 +78,7 @@ public class SolutionMappingsHashTableBasedOnOneVarTest extends TestsForSolution
     }
 
     @Test
-    public void hashTableWithOneInputVariable_findSolutionMappings4() {
+    public void findSolutionMappings4() {
         // findSolutionMappings(var2, y2, var3, z1): no matching solution mappings
         final Iterator<SolutionMapping> it = createHashTableBasedOneVar().findSolutionMappings(var2, y2, var3, z1).iterator();
 
@@ -85,7 +86,7 @@ public class SolutionMappingsHashTableBasedOnOneVarTest extends TestsForSolution
     }
 
     @Test
-    public void hashTableWithOneInputVariable_findSolutionMappings5() {
+    public void findSolutionMappings5() {
         // findSolutionMappings(var1, x1, var2, y2, var3, z3)
         final Iterator<SolutionMapping> it = createHashTableBasedOneVar().findSolutionMappings(var1, x1, var2, y2, var3, z3).iterator();
 
@@ -95,7 +96,7 @@ public class SolutionMappingsHashTableBasedOnOneVarTest extends TestsForSolution
     }
 
     @Test
-    public void hashTableWithOneInputVariable_getJoinPartners1() {
+    public void getJoinPartners1() {
         // getJoinPartners(): one join variable with two join partners
         final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1);
         final Iterator<SolutionMapping> it = createHashTableBasedOneVar().getJoinPartners(sm).iterator();
@@ -123,7 +124,7 @@ public class SolutionMappingsHashTableBasedOnOneVarTest extends TestsForSolution
     }
 
     @Test
-    public void hashTableWithOneInputVariable_getJoinPartners2() {
+    public void getJoinPartners2() {
         // getJoinPartners(): one join variable. Return two solution mappings without post matching
         final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var2, y1, var3, z2);
         final Iterator<SolutionMapping> it = createHashTableBasedOneVar().getJoinPartners(sm).iterator();
@@ -151,7 +152,7 @@ public class SolutionMappingsHashTableBasedOnOneVarTest extends TestsForSolution
     }
 
     @Test
-    public void hashTableWithOneInputVariable_getJoinPartners3() {
+    public void getJoinPartners3() {
         // getJoinPartners(): do not contain the join variable. Return all solution mappings if no postingMatching is applied.
         final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var3, z3);
         final Iterator<SolutionMapping> it = createHashTableBasedOneVar().getJoinPartners(sm).iterator();
@@ -172,7 +173,7 @@ public class SolutionMappingsHashTableBasedOnOneVarTest extends TestsForSolution
     }
 
     @Test
-    public void hashTableWithOneInputVariable_getJoinPartners4() {
+    public void getJoinPartners4() {
         // getJoinPartners(): one join variable but without join partner
         final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var1, x2, var2, y3);
         final Iterator<SolutionMapping> it = createHashTableBasedOneVar().getJoinPartners(sm).iterator();

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnOneVarTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnOneVarTest.java
@@ -1,0 +1,184 @@
+package se.liu.ida.hefquin.engine.datastructures.impl;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.junit.Test;
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class SolutionMappingsHashTableBasedOnOneVarTest {
+    @Test
+    public void hashTableWithOneInputVariable() {
+        final Var var1 = Var.alloc("v1");
+        final Var var2 = Var.alloc("v2");
+        final Var var3 = Var.alloc("v3");
+
+        final Node x1 = NodeFactory.createURI("http://example.org/x1");
+        final Node x2 = NodeFactory.createURI("http://example.org/x2");
+        final Node y1 = NodeFactory.createURI("http://example.org/y1");
+        final Node y2 = NodeFactory.createURI("http://example.org/y2");
+        final Node y3 = NodeFactory.createURI("http://example.org/y3");
+        final Node z1 = NodeFactory.createURI("http://example.org/z1");
+        final Node z2 = NodeFactory.createURI("http://example.org/z2");
+        final Node z3 = NodeFactory.createURI("http://example.org/z3");
+
+        // create SolutionMappingsIndexBase, test method: isEmpty(), contains(), add(), size()
+        final SolutionMappingsIndexBase solMHashTable = new SolutionMappingsHashTableBasedOnOneVar(var2);
+        assertTrue(solMHashTable.isEmpty());
+
+        final SolutionMapping sm0 = SolutionMappingUtils.createSolutionMapping(var2, y1, var3, z1);
+        assertFalse(solMHashTable.contains(sm0));
+        solMHashTable.add(sm0);
+        assertTrue(solMHashTable.contains(sm0));
+
+        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+                var2, y1,
+                var3, z2) );
+        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+                var2, y2,
+                var3, z3) );
+        assertFalse(solMHashTable.isEmpty());
+        assertEquals( 3, solMHashTable.size() );
+
+        // test getAllSolutionMappings()
+        final Iterator<SolutionMapping> it = solMHashTable.getAllSolutionMappings().iterator();
+        assertTrue( it.hasNext() );
+        final Binding b1 = it.next().asJenaBinding();
+        assertEquals( 2, b1.size() );
+
+        assertTrue( it.hasNext() );
+        final Binding b2 = it.next().asJenaBinding();
+        assertEquals( 2, b2.size() );
+
+        assertTrue( it.hasNext() );
+        final Binding b3 = it.next().asJenaBinding();
+        assertEquals( 2, b3.size() );
+
+        assertFalse( it.hasNext() );
+
+        //---------------------------------------
+        // findSolutionMappings(var2, y2): return one matching solution mapping (hash table is built based on var2)
+        final Iterable<SolutionMapping> solMapVar2= solMHashTable.findSolutionMappings(var2, y2);
+        for ( final SolutionMapping sm: solMapVar2 ){
+            final Binding bsm = sm.asJenaBinding();
+            if ( bsm.get(var2).getURI().equals("http://example.org/y2") ) {
+                assertEquals( "http://example.org/z3", bsm.get(var3).getURI() );
+            }
+            else {
+                fail( "Unexpected URI for ?v2: " + bsm.get(var2).getURI() );
+            }
+        }
+
+        // findSolutionMappings(var3, z3): return one matching solution mapping (hash table is not built based on var3)
+        Iterable<SolutionMapping> solMapVar3 = solMHashTable.findSolutionMappings(var3, z3);
+        final Iterator<SolutionMapping> itVar3 = solMapVar3.iterator();
+
+        assertTrue( itVar3.hasNext() );
+        final Binding bItVar3 = itVar3.next().asJenaBinding();
+        assertEquals( 2, bItVar3.size() );
+
+        assertFalse( itVar3.hasNext() );
+
+        // findSolutionMappings(var3, z3, var2, y2): matching one solution mapping
+        final Iterable<SolutionMapping> solMapVar32= solMHashTable.findSolutionMappings(var3, z3, var2, y2);
+        final Iterator<SolutionMapping> itVar32 = solMapVar32.iterator();
+
+        assertTrue( itVar32.hasNext() );
+        final Binding bItVar32 = itVar32.next().asJenaBinding();
+        assertEquals( 2, bItVar32.size() );
+
+        assertFalse( itVar32.hasNext() );
+
+        // findSolutionMappings(var2, y2, var3, z1): no matching solution mappings
+        final Iterable<SolutionMapping> solMapVar23= solMHashTable.findSolutionMappings(var2, y2, var3, z1);
+        final Iterator<SolutionMapping> itVar23 = solMapVar23.iterator();
+
+        assertFalse( itVar23.hasNext() );
+
+        // findSolutionMappings(var1, x1, var2, y2, var3, z3): one matching solution mapping
+        final Iterable<SolutionMapping> solMapVar123= solMHashTable.findSolutionMappings(var1, x1, var2, y2, var3, z3);
+        final Iterator<SolutionMapping> itVar123 = solMapVar123.iterator();
+
+        assertTrue( itVar123.hasNext() );
+        final Binding bItVar132 = itVar123.next().asJenaBinding();
+        assertEquals( 2, bItVar132.size() );
+
+        assertFalse( itVar123.hasNext() );
+
+        //----------------------------
+        // getJoinPartners(): one join variable with two join partners
+        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1);
+        Iterable<SolutionMapping> matchSolMap1 = solMHashTable.getJoinPartners(sm1);
+
+        final Set<Binding> result = new HashSet<>();
+        final Iterator<SolutionMapping> it1 = matchSolMap1.iterator();
+        assertTrue( it1.hasNext() );
+        result.add( it1.next().asJenaBinding() );
+        assertTrue( it1.hasNext() );
+        result.add( it1.next().asJenaBinding() );
+        assertFalse( it1.hasNext() );
+
+        for ( final Binding b: result ) {
+            assertEquals( 2, b.size() );
+            if ( b.get(var3).getURI().equals("http://example.org/z1") ) {
+                assertEquals( "http://example.org/y1", b.get(var2).getURI() );
+            }
+            else if ( b.get(var3).getURI().equals("http://example.org/z2") ) {
+                assertEquals( "http://example.org/y1", b.get(var2).getURI() );
+            }
+            else {
+                fail( "Unexpected URI for ?v3: " + b.get(var3).getURI() );
+            }
+        }
+
+        // getJoinPartners(): one join variable. Return two solution mappings after filtering
+        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(var2, y1, var3, z2);
+        final Iterable<SolutionMapping> matchSolMap2 = solMHashTable.getJoinPartners(sm2);
+        final Iterator<SolutionMapping> itVar2 = matchSolMap2.iterator();
+
+        assertTrue( itVar2.hasNext() );
+        final Binding bItVar21 = itVar2.next().asJenaBinding();
+        assertEquals( 2, bItVar21.size() );
+
+        assertTrue( itVar2.hasNext() );
+        final Binding bItVar22 = itVar2.next().asJenaBinding();
+        assertEquals( 2, bItVar22.size() );
+
+        assertFalse( itVar2.hasNext() );
+
+        // getJoinPartners(): do not contain the join variable. Return all solution mappings if no postingMatching is applied.
+        final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(var3, z3);
+        Iterable<SolutionMapping> matchSolMap3 = solMHashTable.getJoinPartners(sm3);
+        final Iterator<SolutionMapping> it3 = matchSolMap3.iterator();
+
+        assertTrue( it3.hasNext() );
+        final Binding bIt31 = it3.next().asJenaBinding();
+        assertEquals( 2, bIt31.size() );
+
+        assertTrue( it3.hasNext() );
+        final Binding bIt32 = it3.next().asJenaBinding();
+        assertEquals( 2, bIt32.size() );
+
+        assertTrue( it3.hasNext() );
+        final Binding bIt33 = it3.next().asJenaBinding();
+        assertEquals( 2, bIt33.size() );
+
+        assertFalse( it3.hasNext() );
+
+        // getJoinPartners(): one join variable but without join partner
+        final SolutionMapping sm4 = SolutionMappingUtils.createSolutionMapping(var1, x2, var2, y3);
+        Iterable<SolutionMapping> matchSolMap4 = solMHashTable.getJoinPartners(sm4);
+        final Iterator<SolutionMapping> it4 = matchSolMap4.iterator();
+        assertFalse( it4.hasNext() );
+
+        // clear()
+        solMHashTable.clear();
+        assertTrue(solMHashTable.isEmpty());
+    }
+}

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnOneVarTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnOneVarTest.java
@@ -76,7 +76,7 @@ public class SolutionMappingsHashTableBasedOnOneVarTest {
         }
 
         // findSolutionMappings(var3, z3): return one matching solution mapping (hash table is not built based on var3)
-        Iterable<SolutionMapping> solMapVar3 = solMHashTable.findSolutionMappings(var3, z3);
+        final Iterable<SolutionMapping> solMapVar3 = solMHashTable.findSolutionMappings(var3, z3);
         final Iterator<SolutionMapping> itVar3 = solMapVar3.iterator();
 
         assertTrue( itVar3.hasNext() );
@@ -114,7 +114,7 @@ public class SolutionMappingsHashTableBasedOnOneVarTest {
         //----------------------------
         // getJoinPartners(): one join variable with two join partners
         final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1);
-        Iterable<SolutionMapping> matchSolMap1 = solMHashTable.getJoinPartners(sm1);
+        final Iterable<SolutionMapping> matchSolMap1 = solMHashTable.getJoinPartners(sm1);
 
         final Set<Binding> result = new HashSet<>();
         final Iterator<SolutionMapping> it1 = matchSolMap1.iterator();
@@ -154,7 +154,7 @@ public class SolutionMappingsHashTableBasedOnOneVarTest {
 
         // getJoinPartners(): do not contain the join variable. Return all solution mappings if no postingMatching is applied.
         final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(var3, z3);
-        Iterable<SolutionMapping> matchSolMap3 = solMHashTable.getJoinPartners(sm3);
+        final Iterable<SolutionMapping> matchSolMap3 = solMHashTable.getJoinPartners(sm3);
         final Iterator<SolutionMapping> it3 = matchSolMap3.iterator();
 
         assertTrue( it3.hasNext() );
@@ -173,7 +173,7 @@ public class SolutionMappingsHashTableBasedOnOneVarTest {
 
         // getJoinPartners(): one join variable but without join partner
         final SolutionMapping sm4 = SolutionMappingUtils.createSolutionMapping(var1, x2, var2, y3);
-        Iterable<SolutionMapping> matchSolMap4 = solMHashTable.getJoinPartners(sm4);
+        final Iterable<SolutionMapping> matchSolMap4 = solMHashTable.getJoinPartners(sm4);
         final Iterator<SolutionMapping> it4 = matchSolMap4.iterator();
         assertFalse( it4.hasNext() );
 

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnOneVarTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnOneVarTest.java
@@ -1,8 +1,5 @@
 package se.liu.ida.hefquin.engine.datastructures.impl;
 
-import org.apache.jena.graph.Node;
-import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.junit.Test;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
@@ -14,37 +11,26 @@ import static org.junit.Assert.*;
 
 public class SolutionMappingsHashTableBasedOnOneVarTest {
     @Test
-    public void hashTableWithOneInputVariable() {
-        final Var var1 = Var.alloc("v1");
-        final Var var2 = Var.alloc("v2");
-        final Var var3 = Var.alloc("v3");
+    public void hashTableWithOneInputVariable_basic() {
+        // test method: isEmpty(), contains(), add(), size(), clear()
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
 
-        final Node x1 = NodeFactory.createURI("http://example.org/x1");
-        final Node x2 = NodeFactory.createURI("http://example.org/x2");
-        final Node y1 = NodeFactory.createURI("http://example.org/y1");
-        final Node y2 = NodeFactory.createURI("http://example.org/y2");
-        final Node y3 = NodeFactory.createURI("http://example.org/y3");
-        final Node z1 = NodeFactory.createURI("http://example.org/z1");
-        final Node z2 = NodeFactory.createURI("http://example.org/z2");
-        final Node z3 = NodeFactory.createURI("http://example.org/z3");
-
-        // create SolutionMappingsIndexBase, test method: isEmpty(), contains(), add(), size()
-        final SolutionMappingsIndexBase solMHashTable = new SolutionMappingsHashTableBasedOnOneVar(var2);
-        assertTrue(solMHashTable.isEmpty());
-
-        final SolutionMapping sm0 = SolutionMappingUtils.createSolutionMapping(var2, y1, var3, z1);
-        assertFalse(solMHashTable.contains(sm0));
-        solMHashTable.add(sm0);
-        assertTrue(solMHashTable.contains(sm0));
-
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var2, y1,
-                var3, z2) );
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var2, y2,
-                var3, z3) );
         assertFalse(solMHashTable.isEmpty());
         assertEquals( 3, solMHashTable.size() );
+
+		final SolutionMapping sm0 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y1, solMaps.var3, solMaps.z1);
+        assertTrue(solMHashTable.contains(sm0));
+
+        solMHashTable.clear();
+        assertTrue(solMHashTable.isEmpty());
+        assertFalse(solMHashTable.contains(sm0));
+    }
+
+    @Test
+    public void hashTableWithOneInputVariable_getAllSolMaps() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
 
         // test getAllSolutionMappings()
         final Iterator<SolutionMapping> it = solMHashTable.getAllSolutionMappings().iterator();
@@ -61,22 +47,33 @@ public class SolutionMappingsHashTableBasedOnOneVarTest {
         assertEquals( 2, b3.size() );
 
         assertFalse( it.hasNext() );
+    }
 
-        //---------------------------------------
+    @Test
+    public void hashTableWithOneInputVariable_findSolutionMappings1() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
+
         // findSolutionMappings(var2, y2): return one matching solution mapping (hash table is built based on var2)
-        final Iterable<SolutionMapping> solMapVar2= solMHashTable.findSolutionMappings(var2, y2);
+        final Iterable<SolutionMapping> solMapVar2= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y2);
         for ( final SolutionMapping sm: solMapVar2 ){
             final Binding bsm = sm.asJenaBinding();
-            if ( bsm.get(var2).getURI().equals("http://example.org/y2") ) {
-                assertEquals( "http://example.org/z3", bsm.get(var3).getURI() );
+            if ( bsm.get(solMaps.var2).getURI().equals("http://example.org/y2") ) {
+                assertEquals( "http://example.org/z3", bsm.get(solMaps.var3).getURI() );
             }
             else {
-                fail( "Unexpected URI for ?v2: " + bsm.get(var2).getURI() );
+                fail( "Unexpected URI for ?v2: " + bsm.get(solMaps.var2).getURI() );
             }
         }
+    }
+
+    @Test
+    public void hashTableWithOneInputVariable_findSolutionMappings2() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
 
         // findSolutionMappings(var3, z3): return one matching solution mapping (hash table is not built based on var3)
-        final Iterable<SolutionMapping> solMapVar3 = solMHashTable.findSolutionMappings(var3, z3);
+        final Iterable<SolutionMapping> solMapVar3 = solMHashTable.findSolutionMappings(solMaps.var3, solMaps.z3);
         final Iterator<SolutionMapping> itVar3 = solMapVar3.iterator();
 
         assertTrue( itVar3.hasNext() );
@@ -84,9 +81,15 @@ public class SolutionMappingsHashTableBasedOnOneVarTest {
         assertEquals( 2, bItVar3.size() );
 
         assertFalse( itVar3.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithOneInputVariable_findSolutionMappings3() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
 
         // findSolutionMappings(var3, z3, var2, y2): matching one solution mapping
-        final Iterable<SolutionMapping> solMapVar32= solMHashTable.findSolutionMappings(var3, z3, var2, y2);
+        final Iterable<SolutionMapping> solMapVar32= solMHashTable.findSolutionMappings(solMaps.var3, solMaps.z3, solMaps.var2, solMaps.y2);
         final Iterator<SolutionMapping> itVar32 = solMapVar32.iterator();
 
         assertTrue( itVar32.hasNext() );
@@ -94,15 +97,27 @@ public class SolutionMappingsHashTableBasedOnOneVarTest {
         assertEquals( 2, bItVar32.size() );
 
         assertFalse( itVar32.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithOneInputVariable_findSolutionMappings4() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
 
         // findSolutionMappings(var2, y2, var3, z1): no matching solution mappings
-        final Iterable<SolutionMapping> solMapVar23= solMHashTable.findSolutionMappings(var2, y2, var3, z1);
+        final Iterable<SolutionMapping> solMapVar23= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y2, solMaps.var3, solMaps.z1);
         final Iterator<SolutionMapping> itVar23 = solMapVar23.iterator();
 
         assertFalse( itVar23.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithOneInputVariable_findSolutionMappings5() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
 
         // findSolutionMappings(var1, x1, var2, y2, var3, z3): one matching solution mapping
-        final Iterable<SolutionMapping> solMapVar123= solMHashTable.findSolutionMappings(var1, x1, var2, y2, var3, z3);
+        final Iterable<SolutionMapping> solMapVar123= solMHashTable.findSolutionMappings(solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y2, solMaps.var3, solMaps.z3);
         final Iterator<SolutionMapping> itVar123 = solMapVar123.iterator();
 
         assertTrue( itVar123.hasNext() );
@@ -110,10 +125,15 @@ public class SolutionMappingsHashTableBasedOnOneVarTest {
         assertEquals( 2, bItVar132.size() );
 
         assertFalse( itVar123.hasNext() );
+    }
 
-        //----------------------------
+    @Test
+    public void hashTableWithOneInputVariable_getJoinPartners1() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
+
         // getJoinPartners(): one join variable with two join partners
-        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1);
+        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y1);
         final Iterable<SolutionMapping> matchSolMap1 = solMHashTable.getJoinPartners(sm1);
 
         final Set<Binding> result = new HashSet<>();
@@ -126,19 +146,25 @@ public class SolutionMappingsHashTableBasedOnOneVarTest {
 
         for ( final Binding b: result ) {
             assertEquals( 2, b.size() );
-            if ( b.get(var3).getURI().equals("http://example.org/z1") ) {
-                assertEquals( "http://example.org/y1", b.get(var2).getURI() );
+            if ( b.get(solMaps.var3).getURI().equals("http://example.org/z1") ) {
+                assertEquals( "http://example.org/y1", b.get(solMaps.var2).getURI() );
             }
-            else if ( b.get(var3).getURI().equals("http://example.org/z2") ) {
-                assertEquals( "http://example.org/y1", b.get(var2).getURI() );
+            else if ( b.get(solMaps.var3).getURI().equals("http://example.org/z2") ) {
+                assertEquals( "http://example.org/y1", b.get(solMaps.var2).getURI() );
             }
             else {
-                fail( "Unexpected URI for ?v3: " + b.get(var3).getURI() );
+                fail( "Unexpected URI for ?v3: " + b.get(solMaps.var3).getURI() );
             }
         }
+    }
+
+    @Test
+    public void hashTableWithOneInputVariable_getJoinPartners2() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
 
         // getJoinPartners(): one join variable. Return two solution mappings after filtering
-        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(var2, y1, var3, z2);
+        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y1, solMaps.var3, solMaps.z2);
         final Iterable<SolutionMapping> matchSolMap2 = solMHashTable.getJoinPartners(sm2);
         final Iterator<SolutionMapping> itVar2 = matchSolMap2.iterator();
 
@@ -151,9 +177,15 @@ public class SolutionMappingsHashTableBasedOnOneVarTest {
         assertEquals( 2, bItVar22.size() );
 
         assertFalse( itVar2.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithOneInputVariable_getJoinPartners3() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
 
         // getJoinPartners(): do not contain the join variable. Return all solution mappings if no postingMatching is applied.
-        final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(var3, z3);
+        final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(solMaps.var3, solMaps.z3);
         final Iterable<SolutionMapping> matchSolMap3 = solMHashTable.getJoinPartners(sm3);
         final Iterator<SolutionMapping> it3 = matchSolMap3.iterator();
 
@@ -170,15 +202,17 @@ public class SolutionMappingsHashTableBasedOnOneVarTest {
         assertEquals( 2, bIt33.size() );
 
         assertFalse( it3.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithOneInputVariable_getJoinPartners4() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
 
         // getJoinPartners(): one join variable but without join partner
-        final SolutionMapping sm4 = SolutionMappingUtils.createSolutionMapping(var1, x2, var2, y3);
+        final SolutionMapping sm4 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x2, solMaps.var2, solMaps.y3);
         final Iterable<SolutionMapping> matchSolMap4 = solMHashTable.getJoinPartners(sm4);
         final Iterator<SolutionMapping> it4 = matchSolMap4.iterator();
         assertFalse( it4.hasNext() );
-
-        // clear()
-        solMHashTable.clear();
-        assertTrue(solMHashTable.isEmpty());
     }
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnOneVarTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnOneVarTest.java
@@ -9,31 +9,28 @@ import java.util.*;
 
 import static org.junit.Assert.*;
 
-public class SolutionMappingsHashTableBasedOnOneVarTest {
+public class SolutionMappingsHashTableBasedOnOneVarTest extends TestsForSolutionMappingsIndex {
     @Test
     public void hashTableWithOneInputVariable_basic() {
         // test method: isEmpty(), contains(), add(), size(), clear()
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
+        final SolutionMappingsIndexBase solMHashTable = createHashTableBasedOneVar();
 
         assertFalse(solMHashTable.isEmpty());
         assertEquals( 3, solMHashTable.size() );
 
-		final SolutionMapping sm0 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y1, solMaps.var3, solMaps.z1);
-        assertTrue(solMHashTable.contains(sm0));
+		final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var2, y1, var3, z1);
+        assertTrue(solMHashTable.contains(sm));
 
         solMHashTable.clear();
         assertTrue(solMHashTable.isEmpty());
-        assertFalse(solMHashTable.contains(sm0));
+        assertFalse(solMHashTable.contains(sm));
     }
 
     @Test
     public void hashTableWithOneInputVariable_getAllSolMaps() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
-
         // test getAllSolutionMappings()
-        final Iterator<SolutionMapping> it = solMHashTable.getAllSolutionMappings().iterator();
+        final Iterator<SolutionMapping> it = createHashTableBasedOneVar().getAllSolutionMappings().iterator();
+
         assertTrue( it.hasNext() );
         final Binding b1 = it.next().asJenaBinding();
         assertEquals( 2, b1.size() );
@@ -51,147 +48,103 @@ public class SolutionMappingsHashTableBasedOnOneVarTest {
 
     @Test
     public void hashTableWithOneInputVariable_findSolutionMappings1() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
-
         // findSolutionMappings(var2, y2): return one matching solution mapping (hash table is built based on var2)
-        final Iterable<SolutionMapping> solMapVar2= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y2);
-        final Iterator<SolutionMapping> itVar2 = solMapVar2.iterator();
+        final Iterator<SolutionMapping> it = createHashTableBasedOneVar().findSolutionMappings(var2, y2).iterator();
 
-        assertTrue( itVar2.hasNext() );
-        final Binding bItVar2 = itVar2.next().asJenaBinding();
-        assertEquals( 2, bItVar2.size() );
-        assertEquals("http://example.org/y2", bItVar2.get(solMaps.var2).getURI());
-        assertEquals("http://example.org/z3", bItVar2.get(solMaps.var3).getURI());
+        assertHasNext( it, "http://example.org/y2", var2, "http://example.org/z3", var3 );
 
-        assertFalse( itVar2.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithOneInputVariable_findSolutionMappings2() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
+        //findSolutionMappings(var3, z3): return one matching solution mapping (hash table is not built based on var3)
+        final Iterator<SolutionMapping> it = createHashTableBasedOneVar().findSolutionMappings(var3, z3).iterator();
 
-        // findSolutionMappings(var3, z3): return one matching solution mapping (hash table is not built based on var3)
-        final Iterable<SolutionMapping> solMapVar3 = solMHashTable.findSolutionMappings(solMaps.var3, solMaps.z3);
-        final Iterator<SolutionMapping> itVar3 = solMapVar3.iterator();
+        assertHasNext( it, "http://example.org/y2", var2, "http://example.org/z3", var3 );
 
-        assertTrue( itVar3.hasNext() );
-        final Binding bItVar3 = itVar3.next().asJenaBinding();
-        assertEquals( 2, bItVar3.size() );
-        assertEquals("http://example.org/y2", bItVar3.get(solMaps.var2).getURI());
-        assertEquals("http://example.org/z3", bItVar3.get(solMaps.var3).getURI());
-
-        assertFalse( itVar3.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithOneInputVariable_findSolutionMappings3() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
-
         // findSolutionMappings(var3, z3, var2, y2): matching one solution mapping
-        final Iterable<SolutionMapping> solMapVar32= solMHashTable.findSolutionMappings(solMaps.var3, solMaps.z3, solMaps.var2, solMaps.y2);
-        final Iterator<SolutionMapping> itVar32 = solMapVar32.iterator();
+        final Iterator<SolutionMapping> it = createHashTableBasedOneVar().findSolutionMappings(var3, z3, var2, y2).iterator();
 
-        assertTrue( itVar32.hasNext() );
-        final Binding bItVar32 = itVar32.next().asJenaBinding();
-        assertEquals( 2, bItVar32.size() );
-        assertEquals("http://example.org/y2", bItVar32.get(solMaps.var2).getURI());
-        assertEquals("http://example.org/z3", bItVar32.get(solMaps.var3).getURI());
+        assertHasNext( it, "http://example.org/y2", var2, "http://example.org/z3", var3 );
 
-        assertFalse( itVar32.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithOneInputVariable_findSolutionMappings4() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
-
         // findSolutionMappings(var2, y2, var3, z1): no matching solution mappings
-        final Iterable<SolutionMapping> solMapVar23= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y2, solMaps.var3, solMaps.z1);
-        final Iterator<SolutionMapping> itVar23 = solMapVar23.iterator();
+        final Iterator<SolutionMapping> it = createHashTableBasedOneVar().findSolutionMappings(var2, y2, var3, z1).iterator();
 
-        assertFalse( itVar23.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithOneInputVariable_findSolutionMappings5() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
-
         // findSolutionMappings(var1, x1, var2, y2, var3, z3)
-        final Iterable<SolutionMapping> solMapVar123= solMHashTable.findSolutionMappings(solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y2, solMaps.var3, solMaps.z3);
-        final Iterator<SolutionMapping> itVar123 = solMapVar123.iterator();
+        final Iterator<SolutionMapping> it = createHashTableBasedOneVar().findSolutionMappings(var1, x1, var2, y2, var3, z3).iterator();
 
-        assertTrue( itVar123.hasNext() );
-        final Binding bItVar132 = itVar123.next().asJenaBinding();
-        assertEquals( 2, bItVar132.size() );
-        assertEquals("http://example.org/y2", bItVar132.get(solMaps.var2).getURI());
-        assertEquals("http://example.org/z3", bItVar132.get(solMaps.var3).getURI());
+        assertHasNext( it, "http://example.org/y2", var2, "http://example.org/z3", var3 );
 
-        assertFalse( itVar123.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithOneInputVariable_getJoinPartners1() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
-
         // getJoinPartners(): one join variable with two join partners
-        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y1);
-        final Iterable<SolutionMapping> matchSolMap1 = solMHashTable.getJoinPartners(sm1);
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1);
+        final Iterator<SolutionMapping> it = createHashTableBasedOneVar().getJoinPartners(sm).iterator();
 
         final Set<Binding> result = new HashSet<>();
-        final Iterator<SolutionMapping> it1 = matchSolMap1.iterator();
-        assertTrue( it1.hasNext() );
-        result.add( it1.next().asJenaBinding() );
-        assertTrue( it1.hasNext() );
-        result.add( it1.next().asJenaBinding() );
-        assertFalse( it1.hasNext() );
+        //final Iterator<SolutionMapping> it1 = matchSolMap1.iterator();
+        assertTrue( it.hasNext() );
+        result.add( it.next().asJenaBinding() );
+        assertTrue( it.hasNext() );
+        result.add( it.next().asJenaBinding() );
+        assertFalse( it.hasNext() );
 
         for ( final Binding b: result ) {
             assertEquals( 2, b.size() );
-            if ( b.get(solMaps.var3).getURI().equals("http://example.org/z1") ) {
-                assertEquals( "http://example.org/y1", b.get(solMaps.var2).getURI() );
+            if ( b.get(var3).getURI().equals("http://example.org/z1") ) {
+                assertEquals( "http://example.org/y1", b.get(var2).getURI() );
             }
-            else if ( b.get(solMaps.var3).getURI().equals("http://example.org/z2") ) {
-                assertEquals( "http://example.org/y1", b.get(solMaps.var2).getURI() );
+            else if ( b.get(var3).getURI().equals("http://example.org/z2") ) {
+                assertEquals( "http://example.org/y1", b.get(var2).getURI() );
             }
             else {
-                fail( "Unexpected URI for ?v3: " + b.get(solMaps.var3).getURI() );
+                fail( "Unexpected URI for ?v3: " + b.get(var3).getURI() );
             }
         }
     }
 
     @Test
     public void hashTableWithOneInputVariable_getJoinPartners2() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
-
         // getJoinPartners(): one join variable. Return two solution mappings without post matching
-        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y1, solMaps.var3, solMaps.z2);
-        final Iterable<SolutionMapping> matchSolMap2 = solMHashTable.getJoinPartners(sm2);
-        final Iterator<SolutionMapping> itVar2 = matchSolMap2.iterator();
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var2, y1, var3, z2);
+        final Iterator<SolutionMapping> it = createHashTableBasedOneVar().getJoinPartners(sm).iterator();
 
         final Set<Binding> result = new HashSet<>();
-        assertTrue( itVar2.hasNext() );
-        result.add( itVar2.next().asJenaBinding() );
-        assertTrue( itVar2.hasNext() );
-        result.add( itVar2.next().asJenaBinding() );
-        assertFalse( itVar2.hasNext() );
+        assertTrue( it.hasNext() );
+        result.add( it.next().asJenaBinding() );
+        assertTrue( it.hasNext() );
+        result.add( it.next().asJenaBinding() );
+        assertFalse( it.hasNext() );
 
         for ( final Binding b: result ) {
             assertEquals( 2, b.size() );
-            // (var2, y1, var3, z1) should be removed after post matching
-            if ( b.get(solMaps.var3).getURI().equals("http://example.org/z1") ) {
-                assertEquals( "http://example.org/y1", b.get(solMaps.var2).getURI() );
+            if ( b.get(var3).getURI().equals("http://example.org/z1") ) {
+                assertEquals( "http://example.org/y1", b.get(var2).getURI() );
             }
-            else if ( b.get(solMaps.var3).getURI().equals("http://example.org/z2") ) {
-                assertEquals( "http://example.org/y1", b.get(solMaps.var2).getURI() );
+            else if ( b.get(var3).getURI().equals("http://example.org/z2") ) {
+                assertEquals( "http://example.org/y1", b.get(var2).getURI() );
             }
             else {
-                fail( "Unexpected URI for ?v3: " + b.get(solMaps.var3).getURI() );
+                fail( "Unexpected URI for ?v3: " + b.get(var3).getURI() );
             }
         }
 
@@ -199,38 +152,31 @@ public class SolutionMappingsHashTableBasedOnOneVarTest {
 
     @Test
     public void hashTableWithOneInputVariable_getJoinPartners3() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
-
         // getJoinPartners(): do not contain the join variable. Return all solution mappings if no postingMatching is applied.
-        final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(solMaps.var3, solMaps.z3);
-        final Iterable<SolutionMapping> matchSolMap3 = solMHashTable.getJoinPartners(sm3);
-        final Iterator<SolutionMapping> it3 = matchSolMap3.iterator();
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var3, z3);
+        final Iterator<SolutionMapping> it = createHashTableBasedOneVar().getJoinPartners(sm).iterator();
 
-        assertTrue( it3.hasNext() );
-        final Binding bIt31 = it3.next().asJenaBinding();
-        assertEquals( 2, bIt31.size() );
+        assertTrue( it.hasNext() );
+        final Binding b1 = it.next().asJenaBinding();
+        assertEquals( 2, b1.size() );
 
-        assertTrue( it3.hasNext() );
-        final Binding bIt32 = it3.next().asJenaBinding();
-        assertEquals( 2, bIt32.size() );
+        assertTrue( it.hasNext() );
+        final Binding b2 = it.next().asJenaBinding();
+        assertEquals( 2, b2.size() );
 
-        assertTrue( it3.hasNext() );
-        final Binding bIt33 = it3.next().asJenaBinding();
-        assertEquals( 2, bIt33.size() );
+        assertTrue( it.hasNext() );
+        final Binding b3 = it.next().asJenaBinding();
+        assertEquals( 2, b3.size() );
 
-        assertFalse( it3.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithOneInputVariable_getJoinPartners4() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
-
         // getJoinPartners(): one join variable but without join partner
-        final SolutionMapping sm4 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x2, solMaps.var2, solMaps.y3);
-        final Iterable<SolutionMapping> matchSolMap4 = solMHashTable.getJoinPartners(sm4);
-        final Iterator<SolutionMapping> it4 = matchSolMap4.iterator();
-        assertFalse( it4.hasNext() );
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var1, x2, var2, y3);
+        final Iterator<SolutionMapping> it = createHashTableBasedOneVar().getJoinPartners(sm).iterator();
+
+        assertFalse( it.hasNext() );
     }
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnOneVarTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnOneVarTest.java
@@ -56,15 +56,15 @@ public class SolutionMappingsHashTableBasedOnOneVarTest {
 
         // findSolutionMappings(var2, y2): return one matching solution mapping (hash table is built based on var2)
         final Iterable<SolutionMapping> solMapVar2= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y2);
-        for ( final SolutionMapping sm: solMapVar2 ){
-            final Binding bsm = sm.asJenaBinding();
-            if ( bsm.get(solMaps.var2).getURI().equals("http://example.org/y2") ) {
-                assertEquals( "http://example.org/z3", bsm.get(solMaps.var3).getURI() );
-            }
-            else {
-                fail( "Unexpected URI for ?v2: " + bsm.get(solMaps.var2).getURI() );
-            }
-        }
+        final Iterator<SolutionMapping> itVar2 = solMapVar2.iterator();
+
+        assertTrue( itVar2.hasNext() );
+        final Binding bItVar2 = itVar2.next().asJenaBinding();
+        assertEquals( 2, bItVar2.size() );
+        assertEquals("http://example.org/y2", bItVar2.get(solMaps.var2).getURI());
+        assertEquals("http://example.org/z3", bItVar2.get(solMaps.var3).getURI());
+
+        assertFalse( itVar2.hasNext() );
     }
 
     @Test
@@ -79,6 +79,8 @@ public class SolutionMappingsHashTableBasedOnOneVarTest {
         assertTrue( itVar3.hasNext() );
         final Binding bItVar3 = itVar3.next().asJenaBinding();
         assertEquals( 2, bItVar3.size() );
+        assertEquals("http://example.org/y2", bItVar3.get(solMaps.var2).getURI());
+        assertEquals("http://example.org/z3", bItVar3.get(solMaps.var3).getURI());
 
         assertFalse( itVar3.hasNext() );
     }
@@ -95,6 +97,8 @@ public class SolutionMappingsHashTableBasedOnOneVarTest {
         assertTrue( itVar32.hasNext() );
         final Binding bItVar32 = itVar32.next().asJenaBinding();
         assertEquals( 2, bItVar32.size() );
+        assertEquals("http://example.org/y2", bItVar32.get(solMaps.var2).getURI());
+        assertEquals("http://example.org/z3", bItVar32.get(solMaps.var3).getURI());
 
         assertFalse( itVar32.hasNext() );
     }
@@ -116,13 +120,15 @@ public class SolutionMappingsHashTableBasedOnOneVarTest {
         final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
         final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
 
-        // findSolutionMappings(var1, x1, var2, y2, var3, z3): one matching solution mapping
+        // findSolutionMappings(var1, x1, var2, y2, var3, z3)
         final Iterable<SolutionMapping> solMapVar123= solMHashTable.findSolutionMappings(solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y2, solMaps.var3, solMaps.z3);
         final Iterator<SolutionMapping> itVar123 = solMapVar123.iterator();
 
         assertTrue( itVar123.hasNext() );
         final Binding bItVar132 = itVar123.next().asJenaBinding();
         assertEquals( 2, bItVar132.size() );
+        assertEquals("http://example.org/y2", bItVar132.get(solMaps.var2).getURI());
+        assertEquals("http://example.org/z3", bItVar132.get(solMaps.var3).getURI());
 
         assertFalse( itVar123.hasNext() );
     }
@@ -163,20 +169,32 @@ public class SolutionMappingsHashTableBasedOnOneVarTest {
         final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
         final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
 
-        // getJoinPartners(): one join variable. Return two solution mappings after filtering
+        // getJoinPartners(): one join variable. Return two solution mappings without post matching
         final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y1, solMaps.var3, solMaps.z2);
         final Iterable<SolutionMapping> matchSolMap2 = solMHashTable.getJoinPartners(sm2);
         final Iterator<SolutionMapping> itVar2 = matchSolMap2.iterator();
 
+        final Set<Binding> result = new HashSet<>();
         assertTrue( itVar2.hasNext() );
-        final Binding bItVar21 = itVar2.next().asJenaBinding();
-        assertEquals( 2, bItVar21.size() );
-
+        result.add( itVar2.next().asJenaBinding() );
         assertTrue( itVar2.hasNext() );
-        final Binding bItVar22 = itVar2.next().asJenaBinding();
-        assertEquals( 2, bItVar22.size() );
-
+        result.add( itVar2.next().asJenaBinding() );
         assertFalse( itVar2.hasNext() );
+
+        for ( final Binding b: result ) {
+            assertEquals( 2, b.size() );
+            // (var2, y1, var3, z1) should be removed after post matching
+            if ( b.get(solMaps.var3).getURI().equals("http://example.org/z1") ) {
+                assertEquals( "http://example.org/y1", b.get(solMaps.var2).getURI() );
+            }
+            else if ( b.get(solMaps.var3).getURI().equals("http://example.org/z2") ) {
+                assertEquals( "http://example.org/y1", b.get(solMaps.var2).getURI() );
+            }
+            else {
+                fail( "Unexpected URI for ?v3: " + b.get(solMaps.var3).getURI() );
+            }
+        }
+
     }
 
     @Test

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnTwoVarsTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnTwoVarsTest.java
@@ -4,6 +4,7 @@ import org.apache.jena.sparql.engine.binding.Binding;
 import org.junit.Test;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
+import se.liu.ida.hefquin.engine.datastructures.SolutionMappingsIndex;
 
 import java.util.*;
 
@@ -11,9 +12,9 @@ import static org.junit.Assert.*;
 
 public class SolutionMappingsHashTableBasedOnTwoVarsTest extends TestsForSolutionMappingsIndex {
     @Test
-    public void hashTableWithTwoInputVariable_basic() {
+    public void basic() {
         // test method: isEmpty(), contains(), add(), size(), clear()
-        final SolutionMappingsIndexBase solMHashTable = createHashTableBasedTwoVars();
+        final SolutionMappingsIndex solMHashTable = createHashTableBasedTwoVars();
 
         assertFalse(solMHashTable.isEmpty());
         assertEquals( 3, solMHashTable.size() );
@@ -27,7 +28,7 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest extends TestsForSolutio
     }
 
     @Test
-    public void hashTableWithTwoInputVariable_getAllSolMaps() {
+    public void getAllSolMaps() {
         // test getAllSolutionMappings()
         final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().getAllSolutionMappings().iterator();
 
@@ -47,7 +48,7 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest extends TestsForSolutio
     }
 
     @Test
-    public void hashTableWithTwoInputVariable_findSolutionMappings1() {
+    public void findSolutionMappings1() {
         // findSolutionMappings(var2, y2): one matching solution mapping
         final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().findSolutionMappings(var2, y2).iterator();
 
@@ -57,7 +58,7 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest extends TestsForSolutio
     }
 
     @Test
-    public void hashTableWithTwoInputVariable_findSolutionMappings2() {
+    public void findSolutionMappings2() {
         // findSolutionMappings(var3, z1): return one matching solution mapping (hash table is not built based on var3)
         final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().findSolutionMappings(var3, z1).iterator();
 
@@ -67,7 +68,7 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest extends TestsForSolutio
     }
 
     @Test
-    public void hashTableWithTwoInputVariable_findSolutionMappings3() {
+    public void findSolutionMappings3() {
         // findSolutionMappings(var1, x2, var2, y2): return one matching solution mapping (hash table is built based on (var1, var2))
         final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().findSolutionMappings(var1, x2, var2, y2).iterator();
 
@@ -87,7 +88,7 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest extends TestsForSolutio
     }
 
     @Test
-    public void hashTableWithTwoInputVariable_findSolutionMappings5() {
+    public void findSolutionMappings5() {
         // findSolutionMappings(var1, x1, var3, z1): return one matching solution mapping
         final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().findSolutionMappings(var1, x1, var3, z1).iterator();
 
@@ -97,7 +98,7 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest extends TestsForSolutio
     }
 
     @Test
-    public void hashTableWithTwoInputVariable_findSolutionMappings6() {
+    public void findSolutionMappings6() {
         // findSolutionMappings(var1, x1, var2, y1, var3, z1)
         final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().findSolutionMappings(var1, x1, var2, y1, var3, z1).iterator();
 
@@ -107,7 +108,7 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest extends TestsForSolutio
     }
 
     @Test
-    public void hashTableWithTwoInputVariable_findSolutionMappings7() {
+    public void findSolutionMappings7() {
         // findSolutionMappings(var1, x1, var2, y2, var3, z1): no matching solution mapping
         final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().findSolutionMappings(var1, x1, var2, y2, var3, z1).iterator();
 
@@ -115,7 +116,7 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest extends TestsForSolutio
     }
 
     @Test
-    public void hashTableWithTwoInputVariable_getJoinPartners1() {
+    public void getJoinPartners1() {
         // getJoinPartners(): two join variables with two join partners
         final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1);
         final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().getJoinPartners(sm).iterator();
@@ -147,7 +148,7 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest extends TestsForSolutio
     }
 
     @Test
-    public void hashTableWithTwoInputVariable_getJoinPartners2() {
+    public void getJoinPartners2() {
         // getJoinPartners(): two join variables but without join partner (case 1: subset matching)
         final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y2);
         final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().getJoinPartners(sm).iterator();
@@ -157,7 +158,7 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest extends TestsForSolutio
     }
 
     @Test
-    public void hashTableWithTwoInputVariable_getJoinPartners3() {
+    public void getJoinPartners3() {
         // getJoinPartners(): two join variables but without join partner (case 2: no matching)
         final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var1, x3, var2, y3);
         final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().getJoinPartners(sm).iterator();
@@ -166,7 +167,7 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest extends TestsForSolutio
     }
 
     @Test
-    public void hashTableWithTwoInputVariable_getJoinPartners4() {
+    public void getJoinPartners4() {
         // getJoinPartners(): do not contain complete join variables.
         final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var2, y2);
         final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().getJoinPartners(sm).iterator();
@@ -177,7 +178,7 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest extends TestsForSolutio
     }
 
     @Test
-    public void hashTableWithTwoInputVariable_getJoinPartners5() {
+    public void getJoinPartners5() {
         // getJoinPartners(): do not contain complete join variables. Find one join partner if not post matching
         final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var2, y2, var3, z1);
         final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().getJoinPartners(sm).iterator();
@@ -189,7 +190,7 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest extends TestsForSolutio
     }
 
     @Test
-    public void hashTableWithTwoInputVariable_getJoinPartners6() {
+    public void getJoinPartners6() {
         // getJoinPartners(): do not contain any join variable. Return all solution mappings if no post matching
         final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var3, z1);
         final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().getJoinPartners(sm).iterator();

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnTwoVarsTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnTwoVarsTest.java
@@ -1,8 +1,5 @@
 package se.liu.ida.hefquin.engine.datastructures.impl;
 
-import org.apache.jena.graph.Node;
-import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.junit.Test;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
@@ -14,39 +11,26 @@ import static org.junit.Assert.*;
 
 public class SolutionMappingsHashTableBasedOnTwoVarsTest {
     @Test
-    public void hashTableWithTwoInputVariable() {
-        final Var var1 = Var.alloc("v1");
-        final Var var2 = Var.alloc("v2");
-        final Var var3 = Var.alloc("v3");
+    public void hashTableWithTwoInputVariable_basic() {
+        // test method: isEmpty(), contains(), add(), size(), clear()
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
 
-        final Node x1 = NodeFactory.createURI("http://example.org/x1");
-        final Node x2 = NodeFactory.createURI("http://example.org/x2");
-        final Node x3 = NodeFactory.createURI("http://example.org/x3");
-        final Node y1 = NodeFactory.createURI("http://example.org/y1");
-        final Node y2 = NodeFactory.createURI("http://example.org/y2");
-        final Node y3 = NodeFactory.createURI("http://example.org/y3");
-        final Node z1 = NodeFactory.createURI("http://example.org/z1");
-        final Node z2 = NodeFactory.createURI("http://example.org/z2");
-
-        // create SolutionMappingsIndexBase, test method: isEmpty(), contains(), add(), size()
-        final SolutionMappingsIndexBase solMHashTable = new SolutionMappingsHashTableBasedOnTwoVars(var1, var2);
-        assertTrue(solMHashTable.isEmpty());
-
-        final SolutionMapping sm0 = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1, var3, z1);
-        assertFalse(solMHashTable.contains(sm0));
-        solMHashTable.add(sm0);
-        assertTrue(solMHashTable.contains(sm0));
-
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var1, x1,
-                var2, y1,
-                var3, z2) );
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var1, x2,
-                var2, y2,
-                var3, z2) );
         assertFalse(solMHashTable.isEmpty());
         assertEquals( 3, solMHashTable.size() );
+
+        final SolutionMapping sm0 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y1, solMaps.var3, solMaps.z1);
+        assertTrue(solMHashTable.contains(sm0));
+
+        solMHashTable.clear();
+        assertTrue(solMHashTable.isEmpty());
+        assertFalse(solMHashTable.contains(sm0));
+    }
+
+    @Test
+    public void hashTableWithTwoInputVariable_getAllSolMaps() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
 
         // test getAllSolutionMappings()
         final Iterator<SolutionMapping> it = solMHashTable.iterator();
@@ -63,10 +47,15 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
         assertEquals( 3, b3.size() );
 
         assertFalse( it.hasNext() );
+    }
 
-        //---------------------------------------
+    @Test
+    public void hashTableWithTwoInputVariable_findSolutionMappings1() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
+
         // findSolutionMappings(var2, y2): one matching solution mapping
-        final Iterable<SolutionMapping> solMapVar2= solMHashTable.findSolutionMappings(var2, y2);
+        final Iterable<SolutionMapping> solMapVar2= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y2);
         final Iterator<SolutionMapping> itVar2 = solMapVar2.iterator();
 
         assertTrue( itVar2.hasNext() );
@@ -74,9 +63,15 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
         assertEquals( 3, bItVar2.size() );
 
         assertFalse( itVar2.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithTwoInputVariable_findSolutionMappings2() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
 
         // findSolutionMappings(var3, z1): return one matching solution mapping (hash table is not built based on var3)
-        final Iterable<SolutionMapping> solMapVar3 = solMHashTable.findSolutionMappings(var3, z1);
+        final Iterable<SolutionMapping> solMapVar3 = solMHashTable.findSolutionMappings(solMaps.var3, solMaps.z1);
         final Iterator<SolutionMapping> itVar3 = solMapVar3.iterator();
 
         assertTrue( itVar3.hasNext() );
@@ -84,35 +79,53 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
         assertEquals( 3, bItVar3.size() );
 
         assertFalse( itVar3.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithTwoInputVariable_findSolutionMappings3() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
 
         // findSolutionMappings(var1, x2, var2, y2): return one matching solution mapping (hash table is built based on (var1, var2))
-        final Iterable<SolutionMapping> solMapVar13= solMHashTable.findSolutionMappings(var1, x2, var2, y2);
+        final Iterable<SolutionMapping> solMapVar13= solMHashTable.findSolutionMappings(solMaps.var1, solMaps.x2, solMaps.var2, solMaps.y2);
         for(final SolutionMapping sm: solMapVar13){
             final Binding bsm = sm.asJenaBinding();
-            if ( bsm.get(var3).getURI().equals("http://example.org/z2") ) {
-                assertEquals( "http://example.org/x2", bsm.get(var1).getURI() );
-                assertEquals( "http://example.org/y2", bsm.get(var2).getURI() );
+            if ( bsm.get(solMaps.var3).getURI().equals("http://example.org/z2") ) {
+                assertEquals( "http://example.org/x2", bsm.get(solMaps.var1).getURI() );
+                assertEquals( "http://example.org/y2", bsm.get(solMaps.var2).getURI() );
             }
             else {
-                fail( "Unexpected URI for ?v3: " + bsm.get(var3).getURI() );
+                fail( "Unexpected URI for ?v3: " + bsm.get(solMaps.var3).getURI() );
             }
         }
+    }
+
+    @Test
+    public void hashTableWithTwoInputVariable_findSolutionMappings4() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
 
         // findSolutionMappings(var2, y2, var1, x2), change order of var1 and var2
-        final Iterable<SolutionMapping> solMapVar21= solMHashTable.findSolutionMappings(var2, y2, var1, x2);
+        final Iterable<SolutionMapping> solMapVar21= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y2, solMaps.var1, solMaps.x2);
         for(final SolutionMapping sm: solMapVar21){
             final Binding bsm = sm.asJenaBinding();
-            if ( bsm.get(var3).getURI().equals("http://example.org/z2") ) {
-                assertEquals( "http://example.org/x2", bsm.get(var1).getURI() );
-                assertEquals( "http://example.org/y2", bsm.get(var2).getURI() );
+            if ( bsm.get(solMaps.var3).getURI().equals("http://example.org/z2") ) {
+                assertEquals( "http://example.org/x2", bsm.get(solMaps.var1).getURI() );
+                assertEquals( "http://example.org/y2", bsm.get(solMaps.var2).getURI() );
             }
             else {
-                fail( "Unexpected URI for ?v3: " + bsm.get(var3).getURI() );
+                fail( "Unexpected URI for ?v3: " + bsm.get(solMaps.var3).getURI() );
             }
         }
+    }
+
+    @Test
+    public void hashTableWithTwoInputVariable_findSolutionMappings5() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
 
         // findSolutionMappings(var1, x1, var3, z1): return one matching solution mapping
-        final Iterable<SolutionMapping> solMap13= solMHashTable.findSolutionMappings(var1, x1, var3, z1);
+        final Iterable<SolutionMapping> solMap13= solMHashTable.findSolutionMappings(solMaps.var1, solMaps.x1, solMaps.var3, solMaps.z1);
         final Iterator<SolutionMapping> itVar13 = solMap13.iterator();
 
         assertTrue( itVar13.hasNext() );
@@ -120,9 +133,15 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
         assertEquals( 3, bItVar13.size() );
 
         assertFalse( itVar13.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithTwoInputVariable_findSolutionMappings6() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
 
         // findSolutionMappings(var1, x1, var2, y1, var3, z1)
-        final Iterable<SolutionMapping> solMap123_1= solMHashTable.findSolutionMappings(var1, x1, var2, y1, var3, z1);
+        final Iterable<SolutionMapping> solMap123_1= solMHashTable.findSolutionMappings(solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y1, solMaps.var3, solMaps.z1);
         final Iterator<SolutionMapping> itVar123_1 = solMap123_1.iterator();
 
         assertTrue( itVar123_1.hasNext() );
@@ -130,16 +149,27 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
         assertEquals( 3, bItVar123_1.size() );
 
         assertFalse( itVar123_1.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithTwoInputVariable_findSolutionMappings7() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
 
         // findSolutionMappings(var1, x1, var2, y2, var3, z1): no matching solution mapping
-        final Iterable<SolutionMapping> solMap123_2= solMHashTable.findSolutionMappings(var1, x1, var2, y2, var3, z1);
+        final Iterable<SolutionMapping> solMap123_2= solMHashTable.findSolutionMappings(solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y2, solMaps.var3, solMaps.z1);
         final Iterator<SolutionMapping> itVar123_2 = solMap123_2.iterator();
 
         assertFalse( itVar123_2.hasNext() );
+    }
 
-        //----------------------------
+    @Test
+    public void hashTableWithTwoInputVariable_getJoinPartners1() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
+
         // getJoinPartners(): two join variables with two join partners
-        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1);
+        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y1);
         final Iterable<SolutionMapping> matchSolMap1 = solMHashTable.getJoinPartners(sm1);
 
         final Set<Binding> result = new HashSet<>();
@@ -154,34 +184,53 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
 
         for ( final Binding b: result ) {
             assertEquals( 3, b.size() );
-            if ( b.get(var3).getURI().equals("http://example.org/z1") ) {
-                assertEquals( "http://example.org/x1", b.get(var1).getURI() );
-                assertEquals( "http://example.org/y1", b.get(var2).getURI() );
+            if ( b.get(solMaps.var3).getURI().equals("http://example.org/z1") ) {
+                assertEquals( "http://example.org/x1", b.get(solMaps.var1).getURI() );
+                assertEquals( "http://example.org/y1", b.get(solMaps.var2).getURI() );
 
             }
-            else if ( b.get(var3).getURI().equals("http://example.org/z2") ) {
-                assertEquals( "http://example.org/x1", b.get(var1).getURI() );
-                assertEquals( "http://example.org/y1", b.get(var2).getURI() );
+            else if ( b.get(solMaps.var3).getURI().equals("http://example.org/z2") ) {
+                assertEquals( "http://example.org/x1", b.get(solMaps.var1).getURI() );
+                assertEquals( "http://example.org/y1", b.get(solMaps.var2).getURI() );
             }
             else {
-                fail( "Unexpected URI for ?v3: " + b.get(var3).getURI() );
+                fail( "Unexpected URI for ?v3: " + b.get(solMaps.var3).getURI() );
             }
         }
+    }
+
+    @Test
+    public void hashTableWithTwoInputVariable_getJoinPartners2() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
 
         // getJoinPartners(): two join variables but without join partner (case 1: subset matching)
-        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y2);
+        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y2);
         final Iterable<SolutionMapping> matchSolMap2 = solMHashTable.getJoinPartners(sm2);
         final Iterator<SolutionMapping> it2 = matchSolMap2.iterator();
         assertFalse( it2.hasNext() );
 
+    }
+
+    @Test
+    public void hashTableWithTwoInputVariable_getJoinPartners3() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
+
         // getJoinPartners(): two join variables but without join partner (case 2: no matching)
-        final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(var1, x3, var2, y3);
+        final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x3, solMaps.var2, solMaps.y3);
         final Iterable<SolutionMapping> matchSolMap3 = solMHashTable.getJoinPartners(sm3);
         final Iterator<SolutionMapping> it3 = matchSolMap3.iterator();
         assertFalse( it3.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithTwoInputVariable_getJoinPartners4() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
 
         // getJoinPartners(): do not contain complete join variables. Return one solution mappings after filtering
-        final SolutionMapping sm4 = SolutionMappingUtils.createSolutionMapping(var2, y2);
+        final SolutionMapping sm4 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y2);
         final Iterable<SolutionMapping> matchSolMap4 = solMHashTable.getJoinPartners(sm4);
         final Iterator<SolutionMapping> it4 = matchSolMap4.iterator();
         assertTrue( it4.hasNext() );
@@ -189,9 +238,15 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
         assertEquals( 3, bIt4.size() );
 
         assertFalse( it4.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithTwoInputVariable_getJoinPartners5() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
 
         // getJoinPartners(): do not contain complete join variables. Return (var1, x2, var2, y2, var3, z2) after filtering
-        final SolutionMapping sm5 = SolutionMappingUtils.createSolutionMapping(var2, y2, var3, z1);
+        final SolutionMapping sm5 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y2, solMaps.var3, solMaps.z1);
         final Iterable<SolutionMapping> matchSolMap5 = solMHashTable.getJoinPartners(sm5);
         final Iterator<SolutionMapping> it5 = matchSolMap5.iterator();
 
@@ -200,9 +255,15 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
         assertEquals( 3, bIt5.size() );
 
         assertFalse( it5.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithTwoInputVariable_getJoinPartners6() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
 
         // getJoinPartners(): do not contain any join variable. Return all solution mappings if no postingMatching is applied.
-        final SolutionMapping sm6 = SolutionMappingUtils.createSolutionMapping(var3, z1);
+        final SolutionMapping sm6 = SolutionMappingUtils.createSolutionMapping(solMaps.var3, solMaps.z1);
         final Iterable<SolutionMapping> matchSolMap6 = solMHashTable.getJoinPartners(sm6);
         final Iterator<SolutionMapping> it6 = matchSolMap6.iterator();
         assertTrue( it6.hasNext() );
@@ -218,9 +279,5 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
         assertEquals( 3, bIt63.size() );
 
         assertFalse( it6.hasNext() );
-
-        // clear()
-        solMHashTable.clear();
-        assertTrue(solMHashTable.isEmpty());
     }
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnTwoVarsTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnTwoVarsTest.java
@@ -9,31 +9,28 @@ import java.util.*;
 
 import static org.junit.Assert.*;
 
-public class SolutionMappingsHashTableBasedOnTwoVarsTest {
+public class SolutionMappingsHashTableBasedOnTwoVarsTest extends TestsForSolutionMappingsIndex {
     @Test
     public void hashTableWithTwoInputVariable_basic() {
         // test method: isEmpty(), contains(), add(), size(), clear()
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
+        final SolutionMappingsIndexBase solMHashTable = createHashTableBasedTwoVars();
 
         assertFalse(solMHashTable.isEmpty());
         assertEquals( 3, solMHashTable.size() );
 
-        final SolutionMapping sm0 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y1, solMaps.var3, solMaps.z1);
-        assertTrue(solMHashTable.contains(sm0));
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1, var3, z1);
+        assertTrue(solMHashTable.contains(sm));
 
         solMHashTable.clear();
         assertTrue(solMHashTable.isEmpty());
-        assertFalse(solMHashTable.contains(sm0));
+        assertFalse(solMHashTable.contains(sm));
     }
 
     @Test
     public void hashTableWithTwoInputVariable_getAllSolMaps() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
-
         // test getAllSolutionMappings()
-        final Iterator<SolutionMapping> it = solMHashTable.iterator();
+        final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().getAllSolutionMappings().iterator();
+
         assertTrue( it.hasNext() );
         final Binding b1 = it.next().asJenaBinding();
         assertEquals( 3, b1.size() );
@@ -51,252 +48,164 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
 
     @Test
     public void hashTableWithTwoInputVariable_findSolutionMappings1() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
-
         // findSolutionMappings(var2, y2): one matching solution mapping
-        final Iterable<SolutionMapping> solMapVar2= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y2);
-        final Iterator<SolutionMapping> itVar2 = solMapVar2.iterator();
+        final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().findSolutionMappings(var2, y2).iterator();
 
-        assertTrue( itVar2.hasNext() );
-        final Binding bItVar2 = itVar2.next().asJenaBinding();
-        assertEquals( 3, bItVar2.size() );
-        assertEquals( "http://example.org/x2", bItVar2.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y2", bItVar2.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z2", bItVar2.get(solMaps.var3).getURI() );
+        assertHasNext( it, "http://example.org/x2", var1, "http://example.org/y2", var2, "http://example.org/z2", var3 );
 
-        assertFalse( itVar2.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithTwoInputVariable_findSolutionMappings2() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
-
         // findSolutionMappings(var3, z1): return one matching solution mapping (hash table is not built based on var3)
-        final Iterable<SolutionMapping> solMapVar3 = solMHashTable.findSolutionMappings(solMaps.var3, solMaps.z1);
-        final Iterator<SolutionMapping> itVar3 = solMapVar3.iterator();
+        final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().findSolutionMappings(var3, z1).iterator();
 
-        assertTrue( itVar3.hasNext() );
-        final Binding bItVar3 = itVar3.next().asJenaBinding();
-        assertEquals( 3, bItVar3.size() );
-        assertEquals( "http://example.org/x1", bItVar3.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y1", bItVar3.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z1", bItVar3.get(solMaps.var3).getURI() );
+        assertHasNext( it, "http://example.org/x1", var1, "http://example.org/y1", var2, "http://example.org/z1", var3 );
 
-        assertFalse( itVar3.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithTwoInputVariable_findSolutionMappings3() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
-
         // findSolutionMappings(var1, x2, var2, y2): return one matching solution mapping (hash table is built based on (var1, var2))
-        final Iterable<SolutionMapping> solMapVar12= solMHashTable.findSolutionMappings(solMaps.var1, solMaps.x2, solMaps.var2, solMaps.y2);
-        final Iterator<SolutionMapping> itVar12 = solMapVar12.iterator();
+        final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().findSolutionMappings(var1, x2, var2, y2).iterator();
 
-        assertTrue( itVar12.hasNext() );
-        final Binding bItVar12 = itVar12.next().asJenaBinding();
-        assertEquals( 3, bItVar12.size() );
-        assertEquals( "http://example.org/x2", bItVar12.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y2", bItVar12.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z2", bItVar12.get(solMaps.var3).getURI() );
+        assertHasNext( it, "http://example.org/x2", var1, "http://example.org/y2", var2, "http://example.org/z2", var3 );
 
-        assertFalse( itVar12.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithTwoInputVariable_findSolutionMappings4() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
-
         // findSolutionMappings(var2, y2, var1, x2), change order of var1 and var2
-        final Iterable<SolutionMapping> solMapVar21= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y2, solMaps.var1, solMaps.x2);
-        final Iterator<SolutionMapping> itVar21 = solMapVar21.iterator();
+        final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().findSolutionMappings(var2, y2, var1, x2).iterator();
 
-        assertTrue( itVar21.hasNext() );
-        final Binding bItVar21 = itVar21.next().asJenaBinding();
-        assertEquals( 3, bItVar21.size() );
-        assertEquals( "http://example.org/x2", bItVar21.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y2", bItVar21.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z2", bItVar21.get(solMaps.var3).getURI() );
+        assertHasNext( it, "http://example.org/x2", var1, "http://example.org/y2", var2, "http://example.org/z2", var3 );
 
-        assertFalse( itVar21.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithTwoInputVariable_findSolutionMappings5() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
-
         // findSolutionMappings(var1, x1, var3, z1): return one matching solution mapping
-        final Iterable<SolutionMapping> solMap13= solMHashTable.findSolutionMappings(solMaps.var1, solMaps.x1, solMaps.var3, solMaps.z1);
-        final Iterator<SolutionMapping> itVar13 = solMap13.iterator();
+        final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().findSolutionMappings(var1, x1, var3, z1).iterator();
 
-        assertTrue( itVar13.hasNext() );
-        final Binding bItVar13 = itVar13.next().asJenaBinding();
-        assertEquals( 3, bItVar13.size() );
-        assertEquals( "http://example.org/x1", bItVar13.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y1", bItVar13.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z1", bItVar13.get(solMaps.var3).getURI() );
+        assertHasNext( it, "http://example.org/x1", var1, "http://example.org/y1", var2, "http://example.org/z1", var3 );
 
-        assertFalse( itVar13.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithTwoInputVariable_findSolutionMappings6() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
-
         // findSolutionMappings(var1, x1, var2, y1, var3, z1)
-        final Iterable<SolutionMapping> solMap123_1= solMHashTable.findSolutionMappings(solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y1, solMaps.var3, solMaps.z1);
-        final Iterator<SolutionMapping> itVar123_1 = solMap123_1.iterator();
+        final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().findSolutionMappings(var1, x1, var2, y1, var3, z1).iterator();
 
-        assertTrue( itVar123_1.hasNext() );
-        final Binding bItVar123_1 = itVar123_1.next().asJenaBinding();
-        assertEquals( 3, bItVar123_1.size() );
-        assertEquals( "http://example.org/x1", bItVar123_1.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y1", bItVar123_1.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z1", bItVar123_1.get(solMaps.var3).getURI() );
+        assertHasNext( it, "http://example.org/x1", var1, "http://example.org/y1", var2, "http://example.org/z1", var3 );
 
-        assertFalse( itVar123_1.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithTwoInputVariable_findSolutionMappings7() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
-
         // findSolutionMappings(var1, x1, var2, y2, var3, z1): no matching solution mapping
-        final Iterable<SolutionMapping> solMap123_2= solMHashTable.findSolutionMappings(solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y2, solMaps.var3, solMaps.z1);
-        final Iterator<SolutionMapping> itVar123_2 = solMap123_2.iterator();
+        final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().findSolutionMappings(var1, x1, var2, y2, var3, z1).iterator();
 
-        assertFalse( itVar123_2.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithTwoInputVariable_getJoinPartners1() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
-
         // getJoinPartners(): two join variables with two join partners
-        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y1);
-        final Iterable<SolutionMapping> matchSolMap1 = solMHashTable.getJoinPartners(sm1);
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1);
+        final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().getJoinPartners(sm).iterator();
 
         final Set<Binding> result = new HashSet<>();
-        final Iterator<SolutionMapping> it1 = matchSolMap1.iterator();
-        assertTrue( it1.hasNext() );
-        result.add( it1.next().asJenaBinding() );
+        assertTrue( it.hasNext() );
+        result.add( it.next().asJenaBinding() );
 
-        assertTrue( it1.hasNext() );
-        result.add( it1.next().asJenaBinding() );
+        assertTrue( it.hasNext() );
+        result.add( it.next().asJenaBinding() );
 
-        assertFalse( it1.hasNext() );
+        assertFalse( it.hasNext() );
 
         for ( final Binding b: result ) {
             assertEquals( 3, b.size() );
-            if ( b.get(solMaps.var3).getURI().equals("http://example.org/z1") ) {
-                assertEquals( "http://example.org/x1", b.get(solMaps.var1).getURI() );
-                assertEquals( "http://example.org/y1", b.get(solMaps.var2).getURI() );
+            if ( b.get(var3).getURI().equals("http://example.org/z1") ) {
+                assertEquals( "http://example.org/x1", b.get(var1).getURI() );
+                assertEquals( "http://example.org/y1", b.get(var2).getURI() );
 
             }
-            else if ( b.get(solMaps.var3).getURI().equals("http://example.org/z2") ) {
-                assertEquals( "http://example.org/x1", b.get(solMaps.var1).getURI() );
-                assertEquals( "http://example.org/y1", b.get(solMaps.var2).getURI() );
+            else if ( b.get(var3).getURI().equals("http://example.org/z2") ) {
+                assertEquals( "http://example.org/x1", b.get(var1).getURI() );
+                assertEquals( "http://example.org/y1", b.get(var2).getURI() );
             }
             else {
-                fail( "Unexpected URI for ?v3: " + b.get(solMaps.var3).getURI() );
+                fail( "Unexpected URI for ?v3: " + b.get(var3).getURI() );
             }
         }
     }
 
     @Test
     public void hashTableWithTwoInputVariable_getJoinPartners2() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
-
         // getJoinPartners(): two join variables but without join partner (case 1: subset matching)
-        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y2);
-        final Iterable<SolutionMapping> matchSolMap2 = solMHashTable.getJoinPartners(sm2);
-        final Iterator<SolutionMapping> it2 = matchSolMap2.iterator();
-        assertFalse( it2.hasNext() );
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y2);
+        final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().getJoinPartners(sm).iterator();
+
+        assertFalse( it.hasNext() );
 
     }
 
     @Test
     public void hashTableWithTwoInputVariable_getJoinPartners3() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
-
         // getJoinPartners(): two join variables but without join partner (case 2: no matching)
-        final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x3, solMaps.var2, solMaps.y3);
-        final Iterable<SolutionMapping> matchSolMap3 = solMHashTable.getJoinPartners(sm3);
-        final Iterator<SolutionMapping> it3 = matchSolMap3.iterator();
-        assertFalse( it3.hasNext() );
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var1, x3, var2, y3);
+        final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().getJoinPartners(sm).iterator();
+
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithTwoInputVariable_getJoinPartners4() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
-
         // getJoinPartners(): do not contain complete join variables.
-        final SolutionMapping sm4 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y2);
-        final Iterable<SolutionMapping> matchSolMap4 = solMHashTable.getJoinPartners(sm4);
-        final Iterator<SolutionMapping> it4 = matchSolMap4.iterator();
-        assertTrue( it4.hasNext() );
-        final Binding bIt4 = it4.next().asJenaBinding();
-        assertEquals( 3, bIt4.size() );
-        assertEquals( "http://example.org/x2", bIt4.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y2", bIt4.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z2", bIt4.get(solMaps.var3).getURI() );
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var2, y2);
+        final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().getJoinPartners(sm).iterator();
 
-        assertFalse( it4.hasNext() );
+        assertHasNext( it, "http://example.org/x2", var1, "http://example.org/y2", var2, "http://example.org/z2", var3 );
+
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithTwoInputVariable_getJoinPartners5() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
-
         // getJoinPartners(): do not contain complete join variables. Find one join partner if not post matching
-        final SolutionMapping sm5 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y2, solMaps.var3, solMaps.z1);
-        final Iterable<SolutionMapping> matchSolMap5 = solMHashTable.getJoinPartners(sm5);
-        final Iterator<SolutionMapping> it5 = matchSolMap5.iterator();
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var2, y2, var3, z1);
+        final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().getJoinPartners(sm).iterator();
 
         // (var1, x2, var2, y2, var3, z2) is not an 'actual' join partner, which will be removed after post-matching
-        assertTrue( it5.hasNext() );
-        final Binding bIt5 = it5.next().asJenaBinding();
-        assertEquals( 3, bIt5.size() );
-        assertEquals( "http://example.org/x2", bIt5.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y2", bIt5.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z2", bIt5.get(solMaps.var3).getURI() );
+        assertHasNext( it, "http://example.org/x2", var1, "http://example.org/y2", var2, "http://example.org/z2", var3 );
 
-        assertFalse( it5.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithTwoInputVariable_getJoinPartners6() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
-
         // getJoinPartners(): do not contain any join variable. Return all solution mappings if no post matching
-        final SolutionMapping sm6 = SolutionMappingUtils.createSolutionMapping(solMaps.var3, solMaps.z1);
-        final Iterable<SolutionMapping> matchSolMap6 = solMHashTable.getJoinPartners(sm6);
-        final Iterator<SolutionMapping> it6 = matchSolMap6.iterator();
-        assertTrue( it6.hasNext() );
-        final Binding bIt61 = it6.next().asJenaBinding();
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var3, z1);
+        final Iterator<SolutionMapping> it = createHashTableBasedTwoVars().getJoinPartners(sm).iterator();
+
+        assertTrue( it.hasNext() );
+        final Binding bIt61 = it.next().asJenaBinding();
         assertEquals( 3, bIt61.size() );
 
-        assertTrue( it6.hasNext() );
-        final Binding bIt62 = it6.next().asJenaBinding();
+        assertTrue( it.hasNext() );
+        final Binding bIt62 = it.next().asJenaBinding();
         assertEquals( 3, bIt62.size() );
 
-        assertTrue( it6.hasNext() );
-        final Binding bIt63 = it6.next().asJenaBinding();
+        assertTrue( it.hasNext() );
+        final Binding bIt63 = it.next().asJenaBinding();
         assertEquals( 3, bIt63.size() );
 
-        assertFalse( it6.hasNext() );
+        assertFalse( it.hasNext() );
     }
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnTwoVarsTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnTwoVarsTest.java
@@ -260,7 +260,7 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
         final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
         final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
 
-        // getJoinPartners(): do not contain complete join variables.
+        // getJoinPartners(): do not contain complete join variables. Find one join partner if not post matching
         final SolutionMapping sm5 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y2, solMaps.var3, solMaps.z1);
         final Iterable<SolutionMapping> matchSolMap5 = solMHashTable.getJoinPartners(sm5);
         final Iterator<SolutionMapping> it5 = matchSolMap5.iterator();
@@ -281,7 +281,7 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
         final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
         final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
 
-        // getJoinPartners(): do not contain any join variable. Return all solution mappings if no postingMatching is applied.
+        // getJoinPartners(): do not contain any join variable. Return all solution mappings if no post matching
         final SolutionMapping sm6 = SolutionMappingUtils.createSolutionMapping(solMaps.var3, solMaps.z1);
         final Iterable<SolutionMapping> matchSolMap6 = solMHashTable.getJoinPartners(sm6);
         final Iterator<SolutionMapping> it6 = matchSolMap6.iterator();

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnTwoVarsTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnTwoVarsTest.java
@@ -61,6 +61,9 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
         assertTrue( itVar2.hasNext() );
         final Binding bItVar2 = itVar2.next().asJenaBinding();
         assertEquals( 3, bItVar2.size() );
+        assertEquals( "http://example.org/x2", bItVar2.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y2", bItVar2.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z2", bItVar2.get(solMaps.var3).getURI() );
 
         assertFalse( itVar2.hasNext() );
     }
@@ -77,6 +80,9 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
         assertTrue( itVar3.hasNext() );
         final Binding bItVar3 = itVar3.next().asJenaBinding();
         assertEquals( 3, bItVar3.size() );
+        assertEquals( "http://example.org/x1", bItVar3.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y1", bItVar3.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z1", bItVar3.get(solMaps.var3).getURI() );
 
         assertFalse( itVar3.hasNext() );
     }
@@ -87,17 +93,17 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
         final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
 
         // findSolutionMappings(var1, x2, var2, y2): return one matching solution mapping (hash table is built based on (var1, var2))
-        final Iterable<SolutionMapping> solMapVar13= solMHashTable.findSolutionMappings(solMaps.var1, solMaps.x2, solMaps.var2, solMaps.y2);
-        for(final SolutionMapping sm: solMapVar13){
-            final Binding bsm = sm.asJenaBinding();
-            if ( bsm.get(solMaps.var3).getURI().equals("http://example.org/z2") ) {
-                assertEquals( "http://example.org/x2", bsm.get(solMaps.var1).getURI() );
-                assertEquals( "http://example.org/y2", bsm.get(solMaps.var2).getURI() );
-            }
-            else {
-                fail( "Unexpected URI for ?v3: " + bsm.get(solMaps.var3).getURI() );
-            }
-        }
+        final Iterable<SolutionMapping> solMapVar12= solMHashTable.findSolutionMappings(solMaps.var1, solMaps.x2, solMaps.var2, solMaps.y2);
+        final Iterator<SolutionMapping> itVar12 = solMapVar12.iterator();
+
+        assertTrue( itVar12.hasNext() );
+        final Binding bItVar12 = itVar12.next().asJenaBinding();
+        assertEquals( 3, bItVar12.size() );
+        assertEquals( "http://example.org/x2", bItVar12.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y2", bItVar12.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z2", bItVar12.get(solMaps.var3).getURI() );
+
+        assertFalse( itVar12.hasNext() );
     }
 
     @Test
@@ -107,16 +113,16 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
 
         // findSolutionMappings(var2, y2, var1, x2), change order of var1 and var2
         final Iterable<SolutionMapping> solMapVar21= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y2, solMaps.var1, solMaps.x2);
-        for(final SolutionMapping sm: solMapVar21){
-            final Binding bsm = sm.asJenaBinding();
-            if ( bsm.get(solMaps.var3).getURI().equals("http://example.org/z2") ) {
-                assertEquals( "http://example.org/x2", bsm.get(solMaps.var1).getURI() );
-                assertEquals( "http://example.org/y2", bsm.get(solMaps.var2).getURI() );
-            }
-            else {
-                fail( "Unexpected URI for ?v3: " + bsm.get(solMaps.var3).getURI() );
-            }
-        }
+        final Iterator<SolutionMapping> itVar21 = solMapVar21.iterator();
+
+        assertTrue( itVar21.hasNext() );
+        final Binding bItVar21 = itVar21.next().asJenaBinding();
+        assertEquals( 3, bItVar21.size() );
+        assertEquals( "http://example.org/x2", bItVar21.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y2", bItVar21.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z2", bItVar21.get(solMaps.var3).getURI() );
+
+        assertFalse( itVar21.hasNext() );
     }
 
     @Test
@@ -131,6 +137,9 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
         assertTrue( itVar13.hasNext() );
         final Binding bItVar13 = itVar13.next().asJenaBinding();
         assertEquals( 3, bItVar13.size() );
+        assertEquals( "http://example.org/x1", bItVar13.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y1", bItVar13.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z1", bItVar13.get(solMaps.var3).getURI() );
 
         assertFalse( itVar13.hasNext() );
     }
@@ -147,6 +156,9 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
         assertTrue( itVar123_1.hasNext() );
         final Binding bItVar123_1 = itVar123_1.next().asJenaBinding();
         assertEquals( 3, bItVar123_1.size() );
+        assertEquals( "http://example.org/x1", bItVar123_1.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y1", bItVar123_1.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z1", bItVar123_1.get(solMaps.var3).getURI() );
 
         assertFalse( itVar123_1.hasNext() );
     }
@@ -229,13 +241,16 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
         final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
         final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
 
-        // getJoinPartners(): do not contain complete join variables. Return one solution mappings after filtering
+        // getJoinPartners(): do not contain complete join variables.
         final SolutionMapping sm4 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y2);
         final Iterable<SolutionMapping> matchSolMap4 = solMHashTable.getJoinPartners(sm4);
         final Iterator<SolutionMapping> it4 = matchSolMap4.iterator();
         assertTrue( it4.hasNext() );
         final Binding bIt4 = it4.next().asJenaBinding();
         assertEquals( 3, bIt4.size() );
+        assertEquals( "http://example.org/x2", bIt4.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y2", bIt4.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z2", bIt4.get(solMaps.var3).getURI() );
 
         assertFalse( it4.hasNext() );
     }
@@ -245,14 +260,18 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
         final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
         final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
 
-        // getJoinPartners(): do not contain complete join variables. Return (var1, x2, var2, y2, var3, z2) after filtering
+        // getJoinPartners(): do not contain complete join variables.
         final SolutionMapping sm5 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y2, solMaps.var3, solMaps.z1);
         final Iterable<SolutionMapping> matchSolMap5 = solMHashTable.getJoinPartners(sm5);
         final Iterator<SolutionMapping> it5 = matchSolMap5.iterator();
 
+        // (var1, x2, var2, y2, var3, z2) is not an 'actual' join partner, which will be removed after post-matching
         assertTrue( it5.hasNext() );
         final Binding bIt5 = it5.next().asJenaBinding();
         assertEquals( 3, bIt5.size() );
+        assertEquals( "http://example.org/x2", bIt5.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y2", bIt5.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z2", bIt5.get(solMaps.var3).getURI() );
 
         assertFalse( it5.hasNext() );
     }

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnTwoVarsTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnTwoVarsTest.java
@@ -1,0 +1,226 @@
+package se.liu.ida.hefquin.engine.datastructures.impl;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.junit.Test;
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class SolutionMappingsHashTableBasedOnTwoVarsTest {
+    @Test
+    public void hashTableWithTwoInputVariable() {
+        final Var var1 = Var.alloc("v1");
+        final Var var2 = Var.alloc("v2");
+        final Var var3 = Var.alloc("v3");
+
+        final Node x1 = NodeFactory.createURI("http://example.org/x1");
+        final Node x2 = NodeFactory.createURI("http://example.org/x2");
+        final Node x3 = NodeFactory.createURI("http://example.org/x3");
+        final Node y1 = NodeFactory.createURI("http://example.org/y1");
+        final Node y2 = NodeFactory.createURI("http://example.org/y2");
+        final Node y3 = NodeFactory.createURI("http://example.org/y3");
+        final Node z1 = NodeFactory.createURI("http://example.org/z1");
+        final Node z2 = NodeFactory.createURI("http://example.org/z2");
+
+        // create SolutionMappingsIndexBase, test method: isEmpty(), contains(), add(), size()
+        final SolutionMappingsIndexBase solMHashTable = new SolutionMappingsHashTableBasedOnTwoVars(var1, var2);
+        assertTrue(solMHashTable.isEmpty());
+
+        final SolutionMapping sm0 = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1, var3, z1);
+        assertFalse(solMHashTable.contains(sm0));
+        solMHashTable.add(sm0);
+        assertTrue(solMHashTable.contains(sm0));
+
+        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+                var1, x1,
+                var2, y1,
+                var3, z2) );
+        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+                var1, x2,
+                var2, y2,
+                var3, z2) );
+        assertFalse(solMHashTable.isEmpty());
+        assertEquals( 3, solMHashTable.size() );
+
+        // test getAllSolutionMappings()
+        final Iterator<SolutionMapping> it = solMHashTable.iterator();
+        assertTrue( it.hasNext() );
+        final Binding b1 = it.next().asJenaBinding();
+        assertEquals( 3, b1.size() );
+
+        assertTrue( it.hasNext() );
+        final Binding b2 = it.next().asJenaBinding();
+        assertEquals( 3, b2.size() );
+
+        assertTrue( it.hasNext() );
+        final Binding b3 = it.next().asJenaBinding();
+        assertEquals( 3, b3.size() );
+
+        assertFalse( it.hasNext() );
+
+        //---------------------------------------
+        // findSolutionMappings(var2, y2): one matching solution mapping
+        final Iterable<SolutionMapping> solMapVar2= solMHashTable.findSolutionMappings(var2, y2);
+        final Iterator<SolutionMapping> itVar2 = solMapVar2.iterator();
+
+        assertTrue( itVar2.hasNext() );
+        final Binding bItVar2 = itVar2.next().asJenaBinding();
+        assertEquals( 3, bItVar2.size() );
+
+        assertFalse( itVar2.hasNext() );
+
+        // findSolutionMappings(var3, z1): return one matching solution mapping (hash table is not built based on var3)
+        Iterable<SolutionMapping> solMapVar3 = solMHashTable.findSolutionMappings(var3, z1);
+        final Iterator<SolutionMapping> itVar3 = solMapVar3.iterator();
+
+        assertTrue( itVar3.hasNext() );
+        final Binding bItVar3 = itVar3.next().asJenaBinding();
+        assertEquals( 3, bItVar3.size() );
+
+        assertFalse( itVar3.hasNext() );
+
+        // findSolutionMappings(var1, x2, var2, y2): return one matching solution mapping (hash table is built based on (var1, var2))
+        final Iterable<SolutionMapping> solMapVar13= solMHashTable.findSolutionMappings(var1, x2, var2, y2);
+        for(final SolutionMapping sm: solMapVar13){
+            final Binding bsm = sm.asJenaBinding();
+            if ( bsm.get(var3).getURI().equals("http://example.org/z2") ) {
+                assertEquals( "http://example.org/x2", bsm.get(var1).getURI() );
+                assertEquals( "http://example.org/y2", bsm.get(var2).getURI() );
+            }
+            else {
+                fail( "Unexpected URI for ?v3: " + bsm.get(var3).getURI() );
+            }
+        }
+
+        // findSolutionMappings(var2, y2, var1, x2), change order of var1 and var2
+        final Iterable<SolutionMapping> solMapVar21= solMHashTable.findSolutionMappings(var2, y2, var1, x2);
+        for(final SolutionMapping sm: solMapVar21){
+            final Binding bsm = sm.asJenaBinding();
+            if ( bsm.get(var3).getURI().equals("http://example.org/z2") ) {
+                assertEquals( "http://example.org/x2", bsm.get(var1).getURI() );
+                assertEquals( "http://example.org/y2", bsm.get(var2).getURI() );
+            }
+            else {
+                fail( "Unexpected URI for ?v3: " + bsm.get(var3).getURI() );
+            }
+        }
+
+        // findSolutionMappings(var1, x1, var3, z1): return one matching solution mapping
+        final Iterable<SolutionMapping> solMap13= solMHashTable.findSolutionMappings(var1, x1, var3, z1);
+        final Iterator<SolutionMapping> itVar13 = solMap13.iterator();
+
+        assertTrue( itVar13.hasNext() );
+        final Binding bItVar13 = itVar13.next().asJenaBinding();
+        assertEquals( 3, bItVar13.size() );
+
+        assertFalse( itVar13.hasNext() );
+
+        // findSolutionMappings(var1, x1, var2, y1, var3, z1)
+        final Iterable<SolutionMapping> solMap123_1= solMHashTable.findSolutionMappings(var1, x1, var2, y1, var3, z1);
+        final Iterator<SolutionMapping> itVar123_1 = solMap123_1.iterator();
+
+        assertTrue( itVar123_1.hasNext() );
+        final Binding bItVar123_1 = itVar123_1.next().asJenaBinding();
+        assertEquals( 3, bItVar123_1.size() );
+
+        assertFalse( itVar123_1.hasNext() );
+
+        // findSolutionMappings(var1, x1, var2, y2, var3, z1): no matching solution mapping
+        final Iterable<SolutionMapping> solMap123_2= solMHashTable.findSolutionMappings(var1, x1, var2, y2, var3, z1);
+        final Iterator<SolutionMapping> itVar123_2 = solMap123_2.iterator();
+
+        assertFalse( itVar123_2.hasNext() );
+
+        //----------------------------
+        // getJoinPartners(): two join variables with two join partners
+        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1);
+        Iterable<SolutionMapping> matchSolMap1 = solMHashTable.getJoinPartners(sm1);
+
+        final Set<Binding> result = new HashSet<>();
+        final Iterator<SolutionMapping> it1 = matchSolMap1.iterator();
+        assertTrue( it1.hasNext() );
+        result.add( it1.next().asJenaBinding() );
+
+        assertTrue( it1.hasNext() );
+        result.add( it1.next().asJenaBinding() );
+
+        assertFalse( it1.hasNext() );
+
+        for ( final Binding b: result ) {
+            assertEquals( 3, b.size() );
+            if ( b.get(var3).getURI().equals("http://example.org/z1") ) {
+                assertEquals( "http://example.org/x1", b.get(var1).getURI() );
+                assertEquals( "http://example.org/y1", b.get(var2).getURI() );
+
+            }
+            else if ( b.get(var3).getURI().equals("http://example.org/z2") ) {
+                assertEquals( "http://example.org/x1", b.get(var1).getURI() );
+                assertEquals( "http://example.org/y1", b.get(var2).getURI() );
+            }
+            else {
+                fail( "Unexpected URI for ?v3: " + b.get(var3).getURI() );
+            }
+        }
+
+        // getJoinPartners(): two join variables but without join partner (case 1: subset matching)
+        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y2);
+        Iterable<SolutionMapping> matchSolMap2 = solMHashTable.getJoinPartners(sm2);
+        final Iterator<SolutionMapping> it2 = matchSolMap2.iterator();
+        assertFalse( it2.hasNext() );
+
+        // getJoinPartners(): two join variables but without join partner (case 2: no matching)
+        final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(var1, x3, var2, y3);
+        Iterable<SolutionMapping> matchSolMap3 = solMHashTable.getJoinPartners(sm3);
+        final Iterator<SolutionMapping> it3 = matchSolMap3.iterator();
+        assertFalse( it3.hasNext() );
+
+        // getJoinPartners(): do not contain complete join variables. Return one solution mappings after filtering
+        final SolutionMapping sm4 = SolutionMappingUtils.createSolutionMapping(var2, y2);
+        Iterable<SolutionMapping> matchSolMap4 = solMHashTable.getJoinPartners(sm4);
+        final Iterator<SolutionMapping> it4 = matchSolMap4.iterator();
+        assertTrue( it4.hasNext() );
+        final Binding bIt4 = it4.next().asJenaBinding();
+        assertEquals( 3, bIt4.size() );
+
+        assertFalse( it4.hasNext() );
+
+        // getJoinPartners(): do not contain complete join variables. Return (var1, x2, var2, y2, var3, z2) after filtering
+        final SolutionMapping sm5 = SolutionMappingUtils.createSolutionMapping(var2, y2, var3, z1);
+        Iterable<SolutionMapping> matchSolMap5 = solMHashTable.getJoinPartners(sm5);
+        final Iterator<SolutionMapping> it5 = matchSolMap5.iterator();
+
+        assertTrue( it5.hasNext() );
+        final Binding bIt5 = it5.next().asJenaBinding();
+        assertEquals( 3, bIt5.size() );
+
+        assertFalse( it5.hasNext() );
+
+        // getJoinPartners(): do not contain any join variable. Return all solution mappings if no postingMatching is applied.
+        final SolutionMapping sm6 = SolutionMappingUtils.createSolutionMapping(var3, z1);
+        Iterable<SolutionMapping> matchSolMap6 = solMHashTable.getJoinPartners(sm6);
+        final Iterator<SolutionMapping> it6 = matchSolMap6.iterator();
+        assertTrue( it6.hasNext() );
+        final Binding bIt61 = it6.next().asJenaBinding();
+        assertEquals( 3, bIt61.size() );
+
+        assertTrue( it6.hasNext() );
+        final Binding bIt62 = it6.next().asJenaBinding();
+        assertEquals( 3, bIt62.size() );
+
+        assertTrue( it6.hasNext() );
+        final Binding bIt63 = it6.next().asJenaBinding();
+        assertEquals( 3, bIt63.size() );
+
+        assertFalse( it6.hasNext() );
+
+        // clear()
+        solMHashTable.clear();
+        assertTrue(solMHashTable.isEmpty());
+    }
+}

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnTwoVarsTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableBasedOnTwoVarsTest.java
@@ -76,7 +76,7 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
         assertFalse( itVar2.hasNext() );
 
         // findSolutionMappings(var3, z1): return one matching solution mapping (hash table is not built based on var3)
-        Iterable<SolutionMapping> solMapVar3 = solMHashTable.findSolutionMappings(var3, z1);
+        final Iterable<SolutionMapping> solMapVar3 = solMHashTable.findSolutionMappings(var3, z1);
         final Iterator<SolutionMapping> itVar3 = solMapVar3.iterator();
 
         assertTrue( itVar3.hasNext() );
@@ -140,7 +140,7 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
         //----------------------------
         // getJoinPartners(): two join variables with two join partners
         final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1);
-        Iterable<SolutionMapping> matchSolMap1 = solMHashTable.getJoinPartners(sm1);
+        final Iterable<SolutionMapping> matchSolMap1 = solMHashTable.getJoinPartners(sm1);
 
         final Set<Binding> result = new HashSet<>();
         final Iterator<SolutionMapping> it1 = matchSolMap1.iterator();
@@ -170,19 +170,19 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
 
         // getJoinPartners(): two join variables but without join partner (case 1: subset matching)
         final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y2);
-        Iterable<SolutionMapping> matchSolMap2 = solMHashTable.getJoinPartners(sm2);
+        final Iterable<SolutionMapping> matchSolMap2 = solMHashTable.getJoinPartners(sm2);
         final Iterator<SolutionMapping> it2 = matchSolMap2.iterator();
         assertFalse( it2.hasNext() );
 
         // getJoinPartners(): two join variables but without join partner (case 2: no matching)
         final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(var1, x3, var2, y3);
-        Iterable<SolutionMapping> matchSolMap3 = solMHashTable.getJoinPartners(sm3);
+        final Iterable<SolutionMapping> matchSolMap3 = solMHashTable.getJoinPartners(sm3);
         final Iterator<SolutionMapping> it3 = matchSolMap3.iterator();
         assertFalse( it3.hasNext() );
 
         // getJoinPartners(): do not contain complete join variables. Return one solution mappings after filtering
         final SolutionMapping sm4 = SolutionMappingUtils.createSolutionMapping(var2, y2);
-        Iterable<SolutionMapping> matchSolMap4 = solMHashTable.getJoinPartners(sm4);
+        final Iterable<SolutionMapping> matchSolMap4 = solMHashTable.getJoinPartners(sm4);
         final Iterator<SolutionMapping> it4 = matchSolMap4.iterator();
         assertTrue( it4.hasNext() );
         final Binding bIt4 = it4.next().asJenaBinding();
@@ -192,7 +192,7 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
 
         // getJoinPartners(): do not contain complete join variables. Return (var1, x2, var2, y2, var3, z2) after filtering
         final SolutionMapping sm5 = SolutionMappingUtils.createSolutionMapping(var2, y2, var3, z1);
-        Iterable<SolutionMapping> matchSolMap5 = solMHashTable.getJoinPartners(sm5);
+        final Iterable<SolutionMapping> matchSolMap5 = solMHashTable.getJoinPartners(sm5);
         final Iterator<SolutionMapping> it5 = matchSolMap5.iterator();
 
         assertTrue( it5.hasNext() );
@@ -203,7 +203,7 @@ public class SolutionMappingsHashTableBasedOnTwoVarsTest {
 
         // getJoinPartners(): do not contain any join variable. Return all solution mappings if no postingMatching is applied.
         final SolutionMapping sm6 = SolutionMappingUtils.createSolutionMapping(var3, z1);
-        Iterable<SolutionMapping> matchSolMap6 = solMHashTable.getJoinPartners(sm6);
+        final Iterable<SolutionMapping> matchSolMap6 = solMHashTable.getJoinPartners(sm6);
         final Iterator<SolutionMapping> it6 = matchSolMap6.iterator();
         assertTrue( it6.hasNext() );
         final Binding bIt61 = it6.next().asJenaBinding();

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableTest.java
@@ -5,6 +5,7 @@ import org.apache.jena.sparql.engine.binding.Binding;
 import org.junit.Test;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
+import se.liu.ida.hefquin.engine.datastructures.SolutionMappingsIndex;
 
 import java.util.*;
 
@@ -12,9 +13,9 @@ import static org.junit.Assert.*;
 
 public class SolutionMappingsHashTableTest extends TestsForSolutionMappingsIndex {
     @Test
-    public void hashTableWithThreeInputVariable_basic() {
+    public void basic() {
         // test method: isEmpty(), contains(), add(), size(), clear()
-        final SolutionMappingsIndexBase solMHashTable = createHashTableBasedThreeVars();
+        final SolutionMappingsIndex solMHashTable = createHashTableBasedThreeVars();
 
         assertFalse(solMHashTable.isEmpty());
         assertEquals( 3, solMHashTable.size() );
@@ -28,7 +29,7 @@ public class SolutionMappingsHashTableTest extends TestsForSolutionMappingsIndex
     }
 
     @Test
-    public void hashTableWithThreeInputVariable_getAllSolMaps() {
+    public void getAllSolMaps() {
         // test getAllSolutionMappings()
         final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().getAllSolutionMappings().iterator();
 
@@ -48,7 +49,7 @@ public class SolutionMappingsHashTableTest extends TestsForSolutionMappingsIndex
     }
 
     @Test
-    public void hashTableWithThreeInputVariable_findSolutionMappings1() {
+    public void findSolutionMappings1() {
         // findSolutionMappings(var2, y2): one matching solution mapping
         final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().findSolutionMappings(var2, y2).iterator();
 
@@ -58,7 +59,7 @@ public class SolutionMappingsHashTableTest extends TestsForSolutionMappingsIndex
     }
 
     @Test
-    public void hashTableWithThreeInputVariable_findSolutionMappings2() {
+    public void findSolutionMappings2() {
         // findSolutionMappings(var4, p): return all solution mappings
         final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().findSolutionMappings(var4, p).iterator();
 
@@ -78,7 +79,7 @@ public class SolutionMappingsHashTableTest extends TestsForSolutionMappingsIndex
     }
 
     @Test
-    public void hashTableWithThreeInputVariable_findSolutionMappings3() {
+    public void findSolutionMappings3() {
         // findSolutionMappings(var1, x1, var2, y1)
         final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().findSolutionMappings(var1, x1, var2, y1).iterator();
 
@@ -109,7 +110,7 @@ public class SolutionMappingsHashTableTest extends TestsForSolutionMappingsIndex
     }
 
     @Test
-    public void hashTableWithThreeInputVariable_findSolutionMappings4() {
+    public void findSolutionMappings4() {
         // findSolutionMappings(var2, y2, var1, x2), change order of var1 and var2
         final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().findSolutionMappings(var2, y2, var1, x2).iterator();
 
@@ -119,7 +120,7 @@ public class SolutionMappingsHashTableTest extends TestsForSolutionMappingsIndex
     }
 
     @Test
-    public void hashTableWithThreeInputVariable_findSolutionMappings5() {
+    public void findSolutionMappings5() {
         // findSolutionMappings(var2, y2, var4, p)
         final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().findSolutionMappings(var2, y2, var4, p).iterator();
         assertHasNext( it, "http://example.org/x2", var1, "http://example.org/y2", var2, "http://example.org/z2", var3 );
@@ -128,7 +129,7 @@ public class SolutionMappingsHashTableTest extends TestsForSolutionMappingsIndex
     }
 
     @Test
-    public void hashTableWithThreeInputVariable_findSolutionMappings6() {
+    public void findSolutionMappings6() {
         // findSolutionMappings(var2, y1, var1, x1, var3, z1)
         final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().findSolutionMappings(var2, y1, var1, x1, var3, z1).iterator();
         assertHasNext( it, "http://example.org/x1", var1, "http://example.org/y1", var2, "http://example.org/z1", var3 );
@@ -137,7 +138,7 @@ public class SolutionMappingsHashTableTest extends TestsForSolutionMappingsIndex
     }
 
     @Test
-    public void hashTableWithThreeInputVariable_findSolutionMappings7() {
+    public void findSolutionMappings7() {
         // findSolutionMappings(var2, y2, var1, x2, var4, p)
         final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().findSolutionMappings(var2, y2, var1, x2, var4, p).iterator();
 
@@ -147,7 +148,7 @@ public class SolutionMappingsHashTableTest extends TestsForSolutionMappingsIndex
     }
 
     @Test
-    public void hashTableWithThreeInputVariable_findSolutionMappings8() {
+    public void findSolutionMappings8() {
         // findSolutionMappings(var2, y1, var1, x1, var3, z1, var4, p)
         final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().findSolutionMappings(var2, y1, var1, x1, var3, z1).iterator();
 
@@ -157,7 +158,7 @@ public class SolutionMappingsHashTableTest extends TestsForSolutionMappingsIndex
     }
 
     @Test
-    public void hashTableWithThreeInputVariable_getJoinPartners1() {
+    public void getJoinPartners1() {
         // getJoinPartners(var2, y1, var1, x1, var3, z1): one join partner
         final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var2, y1, var1, x1, var3, z1);
         final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().getJoinPartners(sm).iterator();
@@ -168,7 +169,7 @@ public class SolutionMappingsHashTableTest extends TestsForSolutionMappingsIndex
     }
 
     @Test
-    public void hashTableWithThreeInputVariable_getJoinPartners2() {
+    public void getJoinPartners2() {
         // getJoinPartners(var2, y2, var1, x1, var3, z1): no join partner
         final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var2, y2, var1, x1, var3, z1);
         final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().getJoinPartners(sm).iterator();
@@ -177,7 +178,7 @@ public class SolutionMappingsHashTableTest extends TestsForSolutionMappingsIndex
     }
 
     @Test
-    public void hashTableWithThreeInputVariable_getJoinPartners3() {
+    public void getJoinPartners3() {
         // getJoinPartners(): do not contain complete join variables. Return all solution mappings (if no post-matching)
         final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var1, x2);
         final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().getJoinPartners(sm).iterator();
@@ -198,7 +199,7 @@ public class SolutionMappingsHashTableTest extends TestsForSolutionMappingsIndex
     }
 
     @Test
-    public void hashTableWithThreeInputVariable_getJoinPartners4() {
+    public void getJoinPartners4() {
         // getJoinPartners(): do not contain any join variable. Return all solution mappings (if no post-matching)
         final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var4, z2);
         final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().getJoinPartners(sm).iterator();

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableTest.java
@@ -69,9 +69,23 @@ public class SolutionMappingsHashTableTest {
             }
         }
 
-        // Find solution mappings with (var3, z3), UnsupportedOperationException
-        assertThrows(UnsupportedOperationException.class,
-                ()->{ solMHashTable.findSolutionMappings(var3, z3);});
+        // Find solution mappings with (var3, z3), getAllSolutionMappings()
+        Iterable<SolutionMapping> solMapVar3 = solMHashTable.findSolutionMappings(var3, z3);
+        final Iterator<SolutionMapping> itVar3 = solMapVar3.iterator();
+
+        assertTrue( itVar3.hasNext() );
+        final Binding bItVar31 = itVar3.next().asJenaBinding();
+        assertEquals( 2, bItVar31.size() );
+
+        assertTrue( itVar3.hasNext() );
+        final Binding bItVar32 = itVar3.next().asJenaBinding();
+        assertEquals( 2, bItVar32.size() );
+
+        assertTrue( itVar3.hasNext() );
+        final Binding bItVar33 = itVar3.next().asJenaBinding();
+        assertEquals( 2, bItVar33.size() );
+
+        assertFalse( itVar3.hasNext() );
 
         //----------------------------
         // Probe
@@ -276,7 +290,7 @@ public class SolutionMappingsHashTableTest {
 
         // getJoinPartners of sm5: do not contain complete join variables (compare with the sm4, this one needs double-check of compatible)
         final SolutionMapping sm5 = SolutionMappingUtils.createSolutionMapping(var1, x2);
-        Iterable<SolutionMapping> matchSolMap5 = solMHashTable.getJoinPartners(sm5);
+        Iterable<SolutionMapping> matchSolMap5 = new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm5);
         final Iterator<SolutionMapping> it5 = matchSolMap5.iterator();
         assertTrue( it5.hasNext() );
         final Binding bIt51 = it5.next().asJenaBinding();

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableTest.java
@@ -62,6 +62,9 @@ public class SolutionMappingsHashTableTest {
         assertTrue( itVar2.hasNext() );
         final Binding bItVar2 = itVar2.next().asJenaBinding();
         assertEquals( 3, bItVar2.size() );
+        assertEquals( "http://example.org/x2", bItVar2.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y2", bItVar2.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z2", bItVar2.get(solMaps.var3).getURI() );
 
         assertFalse( itVar2.hasNext() );
     }
@@ -97,16 +100,32 @@ public class SolutionMappingsHashTableTest {
 
         // findSolutionMappings(var1, x1, var2, y1)
         final Iterable<SolutionMapping> solMap12= solMHashTable.findSolutionMappings(solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y1);
-        final Iterator<SolutionMapping> itVar12 = solMap12.iterator();
-        assertTrue( itVar12.hasNext() );
-        final Binding bItVar121 = itVar12.next().asJenaBinding();
-        assertEquals( 3, bItVar121.size() );
 
-        assertTrue( itVar12.hasNext() );
-        final Binding bItVar122 = itVar12.next().asJenaBinding();
-        assertEquals( 3, bItVar122.size() );
+        final Set<Binding> result = new HashSet<>();
+        final Iterator<SolutionMapping> it1 = solMap12.iterator();
+        assertTrue( it1.hasNext() );
+        result.add( it1.next().asJenaBinding() );
 
-        assertFalse( itVar12.hasNext() );
+        assertTrue( it1.hasNext() );
+        result.add( it1.next().asJenaBinding() );
+
+        assertFalse( it1.hasNext() );
+
+        for ( final Binding b: result ) {
+            assertEquals( 3, b.size() );
+            if ( b.get(solMaps.var3).getURI().equals("http://example.org/z1") ) {
+                assertEquals( "http://example.org/x1", b.get(solMaps.var1).getURI() );
+                assertEquals( "http://example.org/y1", b.get(solMaps.var2).getURI() );
+
+            }
+            else if ( b.get(solMaps.var3).getURI().equals("http://example.org/z2") ) {
+                assertEquals( "http://example.org/x1", b.get(solMaps.var1).getURI() );
+                assertEquals( "http://example.org/y1", b.get(solMaps.var2).getURI() );
+            }
+            else {
+                fail( "Unexpected URI for ?v3: " + b.get(solMaps.var3).getURI() );
+            }
+        }
     }
 
     @Test
@@ -120,6 +139,9 @@ public class SolutionMappingsHashTableTest {
         assertTrue( itVar21.hasNext() );
         final Binding bItVar21 = itVar21.next().asJenaBinding();
         assertEquals( 3, bItVar21.size() );
+        assertEquals( "http://example.org/x2", bItVar21.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y2", bItVar21.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z2", bItVar21.get(solMaps.var3).getURI() );
 
         assertFalse( itVar21.hasNext() );
     }
@@ -129,12 +151,15 @@ public class SolutionMappingsHashTableTest {
         final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
         final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
 
-        // findSolutionMappings(var2, y2, var4, p): one matching solution mapping
+        // findSolutionMappings(var2, y2, var4, p)
         final Iterable<SolutionMapping> solMap24= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y2, solMaps.var4, solMaps.p);
         final Iterator<SolutionMapping> itVar24 = solMap24.iterator();
         assertTrue( itVar24.hasNext() );
         final Binding bItVar24 = itVar24.next().asJenaBinding();
         assertEquals( 3, bItVar24.size() );
+        assertEquals( "http://example.org/x2", bItVar24.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y2", bItVar24.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z2", bItVar24.get(solMaps.var3).getURI() );
 
         assertFalse( itVar24.hasNext() );
     }
@@ -144,12 +169,15 @@ public class SolutionMappingsHashTableTest {
         final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
         final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
 
-        // findSolutionMappings(var2, y1, var1, x1, var3, z1): one matching solution mapping
+        // findSolutionMappings(var2, y1, var1, x1, var3, z1)
         final Iterable<SolutionMapping> solMap213= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y1, solMaps.var1, solMaps.x1, solMaps.var3, solMaps.z1);
         final Iterator<SolutionMapping> itVar213 = solMap213.iterator();
         assertTrue( itVar213.hasNext() );
         final Binding bitVar213 = itVar213.next().asJenaBinding();
         assertEquals( 3, bitVar213.size() );
+        assertEquals( "http://example.org/x1", bitVar213.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y1", bitVar213.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z1", bitVar213.get(solMaps.var3).getURI() );
 
         assertFalse( itVar213.hasNext() );
     }
@@ -159,13 +187,16 @@ public class SolutionMappingsHashTableTest {
         final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
         final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
 
-        // findSolutionMappings(var2, y2, var1, x2, var4, p): one matching solution mapping
+        // findSolutionMappings(var2, y2, var1, x2, var4, p)
         final Iterable<SolutionMapping> solMap214= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y2, solMaps.var1, solMaps.x2, solMaps.var4, solMaps.p);
         final Iterator<SolutionMapping> itVar214 = solMap214.iterator();
 
         assertTrue( itVar214.hasNext() );
         final Binding bitVar214 = itVar214.next().asJenaBinding();
         assertEquals( 3, bitVar214.size() );
+        assertEquals( "http://example.org/x2", bitVar214.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y2", bitVar214.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z2", bitVar214.get(solMaps.var3).getURI() );
 
         assertFalse( itVar214.hasNext() );
     }
@@ -175,13 +206,16 @@ public class SolutionMappingsHashTableTest {
         final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
         final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
 
-        // findSolutionMappings(var2, y1, var1, x1, var3, z1, var4, p): one matching solution mapping
+        // findSolutionMappings(var2, y1, var1, x1, var3, z1, var4, p)
         final Iterable<SolutionMapping> solMap2134= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y1, solMaps.var1, solMaps.x1, solMaps.var3, solMaps.z1);
         final Iterator<SolutionMapping> itVar2134 = solMap2134.iterator();
 
         assertTrue( itVar2134.hasNext() );
         final Binding bitVar2134 = itVar2134.next().asJenaBinding();
         assertEquals( 3, bitVar2134.size() );
+        assertEquals( "http://example.org/x1", bitVar2134.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y1", bitVar2134.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z1", bitVar2134.get(solMaps.var3).getURI() );
 
         assertFalse( itVar2134.hasNext() );
     }
@@ -248,6 +282,9 @@ public class SolutionMappingsHashTableTest {
         assertTrue( it3.hasNext() );
         final Binding bit3 = it3.next().asJenaBinding();
         assertEquals( 3, bit3.size() );
+        assertEquals( "http://example.org/x1", bit3.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y1", bit3.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z1", bit3.get(solMaps.var3).getURI() );
 
         assertFalse( it3.hasNext() );
     }

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableTest.java
@@ -1,4 +1,4 @@
-package se.liu.ida.hefquin.engine.queryplan.executable.impl.pullbased;
+package se.liu.ida.hefquin.engine.datastructures.impl;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -7,7 +7,6 @@ import org.apache.jena.sparql.engine.binding.Binding;
 import org.junit.Test;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
-import se.liu.ida.hefquin.engine.datastructures.impl.SolutionMappingsHashTable;
 
 import java.util.*;
 

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableTest.java
@@ -14,145 +14,7 @@ import static org.junit.Assert.*;
 
 public class SolutionMappingsHashTableTest {
     @Test
-    public void hashTableWithOneInputVariable() {
-        final Var var1 = Var.alloc("v1");
-        final Var var2 = Var.alloc("v2");
-        final Var var3 = Var.alloc("v3");
-
-        final Node x1 = NodeFactory.createURI("http://example.org/x1");
-        final Node x2 = NodeFactory.createURI("http://example.org/x2");
-        final Node y1 = NodeFactory.createURI("http://example.org/y1");
-        final Node y2 = NodeFactory.createURI("http://example.org/y2");
-        final Node y3 = NodeFactory.createURI("http://example.org/y3");
-        final Node z1 = NodeFactory.createURI("http://example.org/z1");
-        final Node z2 = NodeFactory.createURI("http://example.org/z2");
-        final Node z3 = NodeFactory.createURI("http://example.org/z3");
-
-        final SolutionMappingsHashTable solMHashTable = new SolutionMappingsHashTable(var2);
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var2, y1,
-                var3, z1) );
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var2, y1,
-                var3, z2) );
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var2, y2,
-                var3, z3) );
-
-        //------------------
-        // Checking SolutionMappingsHashTable
-        assertEquals( 3, solMHashTable.size() );
-        final Iterator<SolutionMapping> it = solMHashTable.iterator();
-        assertTrue( it.hasNext() );
-        final Binding b1 = it.next().asJenaBinding();
-        assertEquals( 2, b1.size() );
-
-        assertTrue( it.hasNext() );
-        final Binding b2 = it.next().asJenaBinding();
-        assertEquals( 2, b2.size() );
-
-        assertTrue( it.hasNext() );
-        final Binding b3 = it.next().asJenaBinding();
-        assertEquals( 2, b3.size() );
-
-        assertFalse( it.hasNext() );
-
-        // Find solution mappings with (var2, y2)
-        final Iterable<SolutionMapping> solMap= solMHashTable.findSolutionMappings(var2, y2);
-        for ( final SolutionMapping sm: solMap ){
-            final Binding bsm = sm.asJenaBinding();
-            if ( bsm.get(var2).getURI().equals("http://example.org/y2") ) {
-                assertEquals( "http://example.org/z3", bsm.get(var3).getURI() );
-            }
-            else {
-                fail( "Unexpected URI for ?v2: " + bsm.get(var2).getURI() );
-            }
-        }
-
-        // Find solution mappings with (var3, z3), getAllSolutionMappings()
-        Iterable<SolutionMapping> solMapVar3 = solMHashTable.findSolutionMappings(var3, z3);
-        final Iterator<SolutionMapping> itVar3 = solMapVar3.iterator();
-
-        assertTrue( itVar3.hasNext() );
-        final Binding bItVar31 = itVar3.next().asJenaBinding();
-        assertEquals( 2, bItVar31.size() );
-
-        assertTrue( itVar3.hasNext() );
-        final Binding bItVar32 = itVar3.next().asJenaBinding();
-        assertEquals( 2, bItVar32.size() );
-
-        assertTrue( itVar3.hasNext() );
-        final Binding bItVar33 = itVar3.next().asJenaBinding();
-        assertEquals( 2, bItVar33.size() );
-
-        assertFalse( itVar3.hasNext() );
-
-        //----------------------------
-        // Probe
-        // getJoinPartners of sm1: one join variable with two join partners
-        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1);
-        Iterable<SolutionMapping> matchSolMap1 = solMHashTable.getJoinPartners(sm1);
-
-        final Set<Binding> result = new HashSet<>();
-        final Iterator<SolutionMapping> it1 = matchSolMap1.iterator();
-        assertTrue( it1.hasNext() );
-        result.add( it1.next().asJenaBinding() );
-
-        assertTrue( it1.hasNext() );
-        result.add( it1.next().asJenaBinding() );
-
-        assertFalse( it1.hasNext() );
-
-        for ( final Binding b: result ) {
-            assertEquals( 2, b.size() );
-            if ( b.get(var3).getURI().equals("http://example.org/z1") ) {
-                assertEquals( "http://example.org/y1", b.get(var2).getURI() );
-            }
-            else if ( b.get(var3).getURI().equals("http://example.org/z2") ) {
-                assertEquals( "http://example.org/y1", b.get(var2).getURI() );
-            }
-            else {
-                fail( "Unexpected URI for ?v3: " + b.get(var3).getURI() );
-            }
-        }
-
-        // getJoinPartners of sm2: one join variable but without join partner
-        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(var1, x2, var2, y3);
-        Iterable<SolutionMapping> matchSolMap2 = solMHashTable.getJoinPartners(sm2);
-        final Iterator<SolutionMapping> it2 = matchSolMap2.iterator();
-        assertFalse( it2.hasNext() );
-
-        // getJoinPartners of sm3: do not contain the join variable, should return all sm in hash table as join partners
-        final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(var1, x2);
-        Iterable<SolutionMapping> matchSolMap3 = solMHashTable.getJoinPartners(sm3);
-        final Iterator<SolutionMapping> it3 = matchSolMap3.iterator();
-
-        assertTrue( it3.hasNext() );
-        final Binding bIt31 = it3.next().asJenaBinding();
-        assertEquals( 2, bIt31.size() );
-
-        assertTrue( it3.hasNext() );
-        final Binding bIt32 = it3.next().asJenaBinding();
-        assertEquals( 2, bIt32.size() );
-
-        assertTrue( it3.hasNext() );
-        final Binding bIt33 = it3.next().asJenaBinding();
-        assertEquals( 2, bIt33.size() );
-
-        assertFalse( it3.hasNext() );
-
-        // Clear SolutionMappingsHashTable
-        final SolutionMapping sm0 = SolutionMappingUtils.createSolutionMapping(var2, y1, var3, z1);
-
-        assertTrue(solMHashTable.contains(sm0));
-        solMHashTable.clear();
-        assertFalse(solMHashTable.contains(sm0));
-
-        assertTrue(solMHashTable.isEmpty());
-    }
-
-    @Test
-    public void hashTableWithTwoInputVariable() {
+    public void hashTableWithThreeInputVariable() {
         final Var var1 = Var.alloc("v1");
         final Var var2 = Var.alloc("v2");
         final Var var3 = Var.alloc("v3");
@@ -160,18 +22,21 @@ public class SolutionMappingsHashTableTest {
 
         final Node x1 = NodeFactory.createURI("http://example.org/x1");
         final Node x2 = NodeFactory.createURI("http://example.org/x2");
-        final Node x3 = NodeFactory.createURI("http://example.org/x3");
         final Node y1 = NodeFactory.createURI("http://example.org/y1");
         final Node y2 = NodeFactory.createURI("http://example.org/y2");
-        final Node y3 = NodeFactory.createURI("http://example.org/y3");
         final Node z1 = NodeFactory.createURI("http://example.org/z1");
         final Node z2 = NodeFactory.createURI("http://example.org/z2");
+        final Node p = NodeFactory.createURI("http://example.org/p");
 
-        final SolutionMappingsHashTable solMHashTable = new SolutionMappingsHashTable(var1, var2);
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var1, x1,
-                var2, y1,
-                var3, z1) );
+        // create SolutionMappingsIndexBase, test methods: isEmpty(), contains(), add(), size()
+        final SolutionMappingsHashTable solMHashTable = new SolutionMappingsHashTable(var1, var2, var3);
+        assertTrue(solMHashTable.isEmpty());
+
+        final SolutionMapping sm0 = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1, var3, z1);
+        assertFalse(solMHashTable.contains(sm0));
+        solMHashTable.add(sm0);
+        assertTrue(solMHashTable.contains(sm0));
+
         solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
                 var1, x1,
                 var2, y1,
@@ -181,8 +46,7 @@ public class SolutionMappingsHashTableTest {
                 var2, y2,
                 var3, z2) );
 
-        //------------------
-        // Checking SolutionMappingsHashTable
+        // getAllSolutionMappings()
         assertEquals( 3, solMHashTable.size() );
 
         final Iterator<SolutionMapping> it = solMHashTable.iterator();
@@ -200,109 +64,151 @@ public class SolutionMappingsHashTableTest {
 
         assertFalse( it.hasNext() );
 
-        // Checking solution mappings with (var1, x2, var2, y2)
-        final Iterable<SolutionMapping> solMap2= solMHashTable.findSolutionMappings(var1, x2, var2, y2);
-        for(final SolutionMapping sm: solMap2){
-            final Binding bsm = sm.asJenaBinding();
-            if ( bsm.get(var3).getURI().equals("http://example.org/z2") ) {
-                assertEquals( "http://example.org/x2", bsm.get(var1).getURI() );
-                assertEquals( "http://example.org/y2", bsm.get(var2).getURI() );
-            }
-            else {
-                fail( "Unexpected URI for ?v3: " + bsm.get(var3).getURI() );
-            }
-        }
+        //---------------------------------------
+        // findSolutionMappings(var2, y2): one matching solution mapping
+        final Iterable<SolutionMapping> solMapVar2= solMHashTable.findSolutionMappings(var2, y2);
+        final Iterator<SolutionMapping> itVar2 = solMapVar2.iterator();
 
-        // Checking solution mappings with (var2, y2, var1, x2), change order of var1 and var2
-        final Iterable<SolutionMapping> solMap3= solMHashTable.findSolutionMappings(var2, y2, var1, x2);
-        for(final SolutionMapping sm: solMap3){
-            final Binding bsm = sm.asJenaBinding();
-            if ( bsm.get(var3).getURI().equals("http://example.org/z2") ) {
-                assertEquals( "http://example.org/x2", bsm.get(var1).getURI() );
-                assertEquals( "http://example.org/y2", bsm.get(var2).getURI() );
-            }
-            else {
-                fail( "Unexpected URI for ?v3: " + bsm.get(var3).getURI() );
-            }
-        }
+        assertTrue( itVar2.hasNext() );
+        final Binding bItVar2 = itVar2.next().asJenaBinding();
+        assertEquals( 3, bItVar2.size() );
+
+        assertFalse( itVar2.hasNext() );
+
+        // findSolutionMappings(var4, p): return all solution mappings
+        Iterable<SolutionMapping> solMapVar4 = solMHashTable.findSolutionMappings(var4, p);
+        final Iterator<SolutionMapping> itVar4 = solMapVar4.iterator();
+
+        assertTrue( itVar4.hasNext() );
+        final Binding bitVar41 = itVar4.next().asJenaBinding();
+        assertEquals( 3, bitVar41.size() );
+
+        assertTrue( itVar4.hasNext() );
+        final Binding bitVar42 = itVar4.next().asJenaBinding();
+        assertEquals( 3, bitVar42.size() );
+
+        assertTrue( itVar4.hasNext() );
+        final Binding bitVar43 = itVar4.next().asJenaBinding();
+        assertEquals( 3, bitVar43.size() );
+
+        assertFalse( itVar4.hasNext() );
+
+        // findSolutionMappings(var1, x1, var2, y1)
+        final Iterable<SolutionMapping> solMap12= solMHashTable.findSolutionMappings(var1, x1, var2, y1);
+        final Iterator<SolutionMapping> itVar12 = solMap12.iterator();
+        assertTrue( itVar12.hasNext() );
+        final Binding bItVar121 = itVar12.next().asJenaBinding();
+        assertEquals( 3, bItVar121.size() );
+
+        assertTrue( itVar12.hasNext() );
+        final Binding bItVar122 = itVar12.next().asJenaBinding();
+        assertEquals( 3, bItVar122.size() );
+
+        assertFalse( itVar12.hasNext() );
+
+        // findSolutionMappings(var2, y2, var1, x2), change order of var1 and var2
+        final Iterable<SolutionMapping> solMap21= solMHashTable.findSolutionMappings(var2, y2, var1, x2);
+        final Iterator<SolutionMapping> itVar21 = solMap21.iterator();
+        assertTrue( itVar21.hasNext() );
+        final Binding bItVar21 = itVar21.next().asJenaBinding();
+        assertEquals( 3, bItVar21.size() );
+
+        assertFalse( itVar21.hasNext() );
+
+        // findSolutionMappings(var2, y2, var4, p): one matching solution mapping
+        final Iterable<SolutionMapping> solMap24= solMHashTable.findSolutionMappings(var2, y2, var4, p);
+        final Iterator<SolutionMapping> itVar24 = solMap24.iterator();
+        assertTrue( itVar24.hasNext() );
+        final Binding bItVar24 = itVar24.next().asJenaBinding();
+        assertEquals( 3, bItVar24.size() );
+
+        assertFalse( itVar24.hasNext() );
+
+        // findSolutionMappings(var2, y1, var1, x1, var3, z1): one matching solution mapping
+        final Iterable<SolutionMapping> solMap213= solMHashTable.findSolutionMappings(var2, y1, var1, x1, var3, z1);
+        final Iterator<SolutionMapping> itVar213 = solMap213.iterator();
+        assertTrue( itVar213.hasNext() );
+        final Binding bitVar213 = itVar213.next().asJenaBinding();
+        assertEquals( 3, bitVar213.size() );
+
+        assertFalse( itVar213.hasNext() );
+
+        // findSolutionMappings(var2, y2, var1, x2, var4, p): one matching solution mapping
+        final Iterable<SolutionMapping> solMap214= solMHashTable.findSolutionMappings(var2, y2, var1, x2, var4, p);
+        final Iterator<SolutionMapping> itVar214 = solMap214.iterator();
+
+        assertTrue( itVar214.hasNext() );
+        final Binding bitVar214 = itVar214.next().asJenaBinding();
+        assertEquals( 3, bitVar214.size() );
+
+        assertFalse( itVar214.hasNext() );
+
+        // findSolutionMappings(var2, y1, var1, x1, var3, z1, var4, p): one matching solution mapping
+        final Iterable<SolutionMapping> solMap2134= solMHashTable.findSolutionMappings(var2, y1, var1, x1, var3, z1);
+        final Iterator<SolutionMapping> itVar2134 = solMap2134.iterator();
+
+        assertTrue( itVar2134.hasNext() );
+        final Binding bitVar2134 = itVar2134.next().asJenaBinding();
+        assertEquals( 3, bitVar2134.size() );
+
+        assertFalse( itVar2134.hasNext() );
 
         //----------------------------
-        // Probe
-        // getJoinPartners of sm1: two join variables with two join partners
+        // getJoinPartners(): do not contain complete join variables; Return all solution mappings (if no post-matching)
         final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1);
         Iterable<SolutionMapping> matchSolMap1 = solMHashTable.getJoinPartners(sm1);
-
-        final Set<Binding> result = new HashSet<>();
         final Iterator<SolutionMapping> it1 = matchSolMap1.iterator();
-        assertTrue( it1.hasNext() );
-        result.add( it1.next().asJenaBinding() );
 
         assertTrue( it1.hasNext() );
-        result.add( it1.next().asJenaBinding() );
+        final Binding bIt11 = it1.next().asJenaBinding();
+        assertEquals( 3, bIt11.size() );
+
+        assertTrue( it1.hasNext() );
+        final Binding bIt12 = it1.next().asJenaBinding();
+        assertEquals( 3, bIt12.size() );
+
+        assertTrue( it1.hasNext() );
+        final Binding bIt13 = it1.next().asJenaBinding();
+        assertEquals( 3, bIt13.size() );
 
         assertFalse( it1.hasNext() );
 
-        for ( final Binding b: result ) {
-            assertEquals( 3, b.size() );
-            if ( b.get(var3).getURI().equals("http://example.org/z1") ) {
-                assertEquals( "http://example.org/x1", b.get(var1).getURI() );
-                assertEquals( "http://example.org/y1", b.get(var2).getURI() );
-
-            }
-            else if ( b.get(var3).getURI().equals("http://example.org/z2") ) {
-                assertEquals( "http://example.org/x1", b.get(var1).getURI() );
-                assertEquals( "http://example.org/y1", b.get(var2).getURI() );
-            }
-            else {
-                fail( "Unexpected URI for ?v3: " + b.get(var3).getURI() );
-            }
-        }
-
-        // getJoinPartners of sm2: two join variables but without join partner (case 1: subset matching)
-        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y2);
+        // getJoinPartners(): do not contain any join variable
+        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(var4, z2);
         Iterable<SolutionMapping> matchSolMap2 = solMHashTable.getJoinPartners(sm2);
         final Iterator<SolutionMapping> it2 = matchSolMap2.iterator();
-        assertFalse( it2.hasNext() );
+        assertTrue( it2.hasNext() );
+        final Binding bIt21 = it2.next().asJenaBinding();
+        assertEquals( 3, bIt21.size() );
 
-        // getJoinPartners of sm3: two join variables but without join partner (case 2: no matching)
-        final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(var1, x3, var2, y3);
-        Iterable<SolutionMapping> matchSolMap3 = solMHashTable.getJoinPartners(sm3);
-        final Iterator<SolutionMapping> it3 = matchSolMap3.iterator();
-        assertFalse( it3.hasNext() );
-
-        // getJoinPartners of sm4: do not contain any join variable
-        final SolutionMapping sm4 = SolutionMappingUtils.createSolutionMapping(var4, z2);
-        Iterable<SolutionMapping> matchSolMap4 = solMHashTable.getJoinPartners(sm4);
-        final Iterator<SolutionMapping> it4 = matchSolMap4.iterator();
-        assertTrue( it4.hasNext() );
-        final Binding bIt41 = it4.next().asJenaBinding();
-        assertEquals( 3, bIt41.size() );
-
-        assertTrue( it4.hasNext() );
-        final Binding bIt42 = it4.next().asJenaBinding();
+        assertTrue( it2.hasNext() );
+        final Binding bIt42 = it2.next().asJenaBinding();
         assertEquals( 3, bIt42.size() );
 
-        assertTrue( it4.hasNext() );
-        final Binding bIt43 = it4.next().asJenaBinding();
-        assertEquals( 3, bIt43.size() );
+        assertTrue( it2.hasNext() );
+        final Binding bIt23 = it2.next().asJenaBinding();
+        assertEquals( 3, bIt23.size() );
 
-        assertFalse( it4.hasNext() );
+        assertFalse( it2.hasNext() );
 
-        // getJoinPartners of sm5: do not contain complete join variables (compare with the sm4, this one needs double-check of compatible)
-        final SolutionMapping sm5 = SolutionMappingUtils.createSolutionMapping(var1, x2);
-        Iterable<SolutionMapping> matchSolMap5 = new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm5);
-        final Iterator<SolutionMapping> it5 = matchSolMap5.iterator();
-        assertTrue( it5.hasNext() );
-        final Binding bIt51 = it5.next().asJenaBinding();
-        assertEquals( 3, bIt51.size() );
+        // getJoinPartners(var2, y1, var1, x1, var3, z1): one join partner
+        final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(var2, y1, var1, x1, var3, z1);
+        Iterable<SolutionMapping> matchSolMap3 = solMHashTable.getJoinPartners(sm3);
+        final Iterator<SolutionMapping> it3 = matchSolMap3.iterator();
 
-        assertFalse( it5.hasNext() );
+        assertTrue( it3.hasNext() );
+        final Binding bit3 = it3.next().asJenaBinding();
+        assertEquals( 3, bit3.size() );
 
+        assertFalse( it3.hasNext() );
+
+        // clear()
+        solMHashTable.clear();
+        assertTrue(solMHashTable.isEmpty());
     }
 
     @Test
     public void hashTableWithEmptyInputVariable() {
-
         final List<Var> inputVars = Arrays.asList(); // create an empty list
         assertThrows(AssertionError.class,
                 ()->{ new SolutionMappingsHashTable(inputVars); });

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableTest.java
@@ -76,7 +76,7 @@ public class SolutionMappingsHashTableTest {
         assertFalse( itVar2.hasNext() );
 
         // findSolutionMappings(var4, p): return all solution mappings
-        Iterable<SolutionMapping> solMapVar4 = solMHashTable.findSolutionMappings(var4, p);
+        final Iterable<SolutionMapping> solMapVar4 = solMHashTable.findSolutionMappings(var4, p);
         final Iterator<SolutionMapping> itVar4 = solMapVar4.iterator();
 
         assertTrue( itVar4.hasNext() );
@@ -156,7 +156,7 @@ public class SolutionMappingsHashTableTest {
         //----------------------------
         // getJoinPartners(): do not contain complete join variables; Return all solution mappings (if no post-matching)
         final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1);
-        Iterable<SolutionMapping> matchSolMap1 = solMHashTable.getJoinPartners(sm1);
+        final Iterable<SolutionMapping> matchSolMap1 = solMHashTable.getJoinPartners(sm1);
         final Iterator<SolutionMapping> it1 = matchSolMap1.iterator();
 
         assertTrue( it1.hasNext() );
@@ -175,7 +175,7 @@ public class SolutionMappingsHashTableTest {
 
         // getJoinPartners(): do not contain any join variable
         final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(var4, z2);
-        Iterable<SolutionMapping> matchSolMap2 = solMHashTable.getJoinPartners(sm2);
+        final Iterable<SolutionMapping> matchSolMap2 = solMHashTable.getJoinPartners(sm2);
         final Iterator<SolutionMapping> it2 = matchSolMap2.iterator();
         assertTrue( it2.hasNext() );
         final Binding bIt21 = it2.next().asJenaBinding();
@@ -193,7 +193,7 @@ public class SolutionMappingsHashTableTest {
 
         // getJoinPartners(var2, y1, var1, x1, var3, z1): one join partner
         final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(var2, y1, var1, x1, var3, z1);
-        Iterable<SolutionMapping> matchSolMap3 = solMHashTable.getJoinPartners(sm3);
+        final Iterable<SolutionMapping> matchSolMap3 = solMHashTable.getJoinPartners(sm3);
         final Iterator<SolutionMapping> it3 = matchSolMap3.iterator();
 
         assertTrue( it3.hasNext() );

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableTest.java
@@ -1,7 +1,5 @@
 package se.liu.ida.hefquin.engine.datastructures.impl;
 
-import org.apache.jena.graph.Node;
-import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.junit.Test;
@@ -14,41 +12,28 @@ import static org.junit.Assert.*;
 
 public class SolutionMappingsHashTableTest {
     @Test
-    public void hashTableWithThreeInputVariable() {
-        final Var var1 = Var.alloc("v1");
-        final Var var2 = Var.alloc("v2");
-        final Var var3 = Var.alloc("v3");
-        final Var var4 = Var.alloc("v4");
+    public void hashTableWithThreeInputVariable_basic() {
+        // test method: isEmpty(), contains(), add(), size(), clear()
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
 
-        final Node x1 = NodeFactory.createURI("http://example.org/x1");
-        final Node x2 = NodeFactory.createURI("http://example.org/x2");
-        final Node y1 = NodeFactory.createURI("http://example.org/y1");
-        final Node y2 = NodeFactory.createURI("http://example.org/y2");
-        final Node z1 = NodeFactory.createURI("http://example.org/z1");
-        final Node z2 = NodeFactory.createURI("http://example.org/z2");
-        final Node p = NodeFactory.createURI("http://example.org/p");
-
-        // create SolutionMappingsIndexBase, test methods: isEmpty(), contains(), add(), size()
-        final SolutionMappingsHashTable solMHashTable = new SolutionMappingsHashTable(var1, var2, var3);
-        assertTrue(solMHashTable.isEmpty());
-
-        final SolutionMapping sm0 = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1, var3, z1);
-        assertFalse(solMHashTable.contains(sm0));
-        solMHashTable.add(sm0);
-        assertTrue(solMHashTable.contains(sm0));
-
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var1, x1,
-                var2, y1,
-                var3, z2) );
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var1, x2,
-                var2, y2,
-                var3, z2) );
-
-        // getAllSolutionMappings()
+        assertFalse(solMHashTable.isEmpty());
         assertEquals( 3, solMHashTable.size() );
 
+        final SolutionMapping sm0 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y1, solMaps.var3, solMaps.z1);
+        assertTrue(solMHashTable.contains(sm0));
+
+        solMHashTable.clear();
+        assertTrue(solMHashTable.isEmpty());
+        assertFalse(solMHashTable.contains(sm0));
+    }
+
+    @Test
+    public void hashTableWithThreeInputVariable_getAllSolMaps() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
+
+        // test getAllSolutionMappings()
         final Iterator<SolutionMapping> it = solMHashTable.iterator();
         assertTrue( it.hasNext() );
         final Binding b1 = it.next().asJenaBinding();
@@ -63,10 +48,15 @@ public class SolutionMappingsHashTableTest {
         assertEquals( 3, b3.size() );
 
         assertFalse( it.hasNext() );
+    }
 
-        //---------------------------------------
+    @Test
+    public void hashTableWithThreeInputVariable_findSolutionMappings1() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
+
         // findSolutionMappings(var2, y2): one matching solution mapping
-        final Iterable<SolutionMapping> solMapVar2= solMHashTable.findSolutionMappings(var2, y2);
+        final Iterable<SolutionMapping> solMapVar2= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y2);
         final Iterator<SolutionMapping> itVar2 = solMapVar2.iterator();
 
         assertTrue( itVar2.hasNext() );
@@ -74,9 +64,15 @@ public class SolutionMappingsHashTableTest {
         assertEquals( 3, bItVar2.size() );
 
         assertFalse( itVar2.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithThreeInputVariable_findSolutionMappings2() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
 
         // findSolutionMappings(var4, p): return all solution mappings
-        final Iterable<SolutionMapping> solMapVar4 = solMHashTable.findSolutionMappings(var4, p);
+        final Iterable<SolutionMapping> solMapVar4 = solMHashTable.findSolutionMappings(solMaps.var4, solMaps.p);
         final Iterator<SolutionMapping> itVar4 = solMapVar4.iterator();
 
         assertTrue( itVar4.hasNext() );
@@ -92,9 +88,15 @@ public class SolutionMappingsHashTableTest {
         assertEquals( 3, bitVar43.size() );
 
         assertFalse( itVar4.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithThreeInputVariable_findSolutionMappings3() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
 
         // findSolutionMappings(var1, x1, var2, y1)
-        final Iterable<SolutionMapping> solMap12= solMHashTable.findSolutionMappings(var1, x1, var2, y1);
+        final Iterable<SolutionMapping> solMap12= solMHashTable.findSolutionMappings(solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y1);
         final Iterator<SolutionMapping> itVar12 = solMap12.iterator();
         assertTrue( itVar12.hasNext() );
         final Binding bItVar121 = itVar12.next().asJenaBinding();
@@ -105,36 +107,60 @@ public class SolutionMappingsHashTableTest {
         assertEquals( 3, bItVar122.size() );
 
         assertFalse( itVar12.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithThreeInputVariable_findSolutionMappings4() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
 
         // findSolutionMappings(var2, y2, var1, x2), change order of var1 and var2
-        final Iterable<SolutionMapping> solMap21= solMHashTable.findSolutionMappings(var2, y2, var1, x2);
+        final Iterable<SolutionMapping> solMap21= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y2, solMaps.var1, solMaps.x2);
         final Iterator<SolutionMapping> itVar21 = solMap21.iterator();
         assertTrue( itVar21.hasNext() );
         final Binding bItVar21 = itVar21.next().asJenaBinding();
         assertEquals( 3, bItVar21.size() );
 
         assertFalse( itVar21.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithThreeInputVariable_findSolutionMappings5() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
 
         // findSolutionMappings(var2, y2, var4, p): one matching solution mapping
-        final Iterable<SolutionMapping> solMap24= solMHashTable.findSolutionMappings(var2, y2, var4, p);
+        final Iterable<SolutionMapping> solMap24= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y2, solMaps.var4, solMaps.p);
         final Iterator<SolutionMapping> itVar24 = solMap24.iterator();
         assertTrue( itVar24.hasNext() );
         final Binding bItVar24 = itVar24.next().asJenaBinding();
         assertEquals( 3, bItVar24.size() );
 
         assertFalse( itVar24.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithThreeInputVariable_findSolutionMappings6() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
 
         // findSolutionMappings(var2, y1, var1, x1, var3, z1): one matching solution mapping
-        final Iterable<SolutionMapping> solMap213= solMHashTable.findSolutionMappings(var2, y1, var1, x1, var3, z1);
+        final Iterable<SolutionMapping> solMap213= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y1, solMaps.var1, solMaps.x1, solMaps.var3, solMaps.z1);
         final Iterator<SolutionMapping> itVar213 = solMap213.iterator();
         assertTrue( itVar213.hasNext() );
         final Binding bitVar213 = itVar213.next().asJenaBinding();
         assertEquals( 3, bitVar213.size() );
 
         assertFalse( itVar213.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithThreeInputVariable_findSolutionMappings7() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
 
         // findSolutionMappings(var2, y2, var1, x2, var4, p): one matching solution mapping
-        final Iterable<SolutionMapping> solMap214= solMHashTable.findSolutionMappings(var2, y2, var1, x2, var4, p);
+        final Iterable<SolutionMapping> solMap214= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y2, solMaps.var1, solMaps.x2, solMaps.var4, solMaps.p);
         final Iterator<SolutionMapping> itVar214 = solMap214.iterator();
 
         assertTrue( itVar214.hasNext() );
@@ -142,9 +168,15 @@ public class SolutionMappingsHashTableTest {
         assertEquals( 3, bitVar214.size() );
 
         assertFalse( itVar214.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithThreeInputVariable_findSolutionMappings8() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
 
         // findSolutionMappings(var2, y1, var1, x1, var3, z1, var4, p): one matching solution mapping
-        final Iterable<SolutionMapping> solMap2134= solMHashTable.findSolutionMappings(var2, y1, var1, x1, var3, z1);
+        final Iterable<SolutionMapping> solMap2134= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y1, solMaps.var1, solMaps.x1, solMaps.var3, solMaps.z1);
         final Iterator<SolutionMapping> itVar2134 = solMap2134.iterator();
 
         assertTrue( itVar2134.hasNext() );
@@ -152,10 +184,15 @@ public class SolutionMappingsHashTableTest {
         assertEquals( 3, bitVar2134.size() );
 
         assertFalse( itVar2134.hasNext() );
+    }
 
-        //----------------------------
+    @Test
+    public void hashTableWithThreeInputVariable_getJoinPartners1() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
+
         // getJoinPartners(): do not contain complete join variables; Return all solution mappings (if no post-matching)
-        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1);
+        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y1);
         final Iterable<SolutionMapping> matchSolMap1 = solMHashTable.getJoinPartners(sm1);
         final Iterator<SolutionMapping> it1 = matchSolMap1.iterator();
 
@@ -172,9 +209,15 @@ public class SolutionMappingsHashTableTest {
         assertEquals( 3, bIt13.size() );
 
         assertFalse( it1.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithThreeInputVariable_getJoinPartners2() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
 
         // getJoinPartners(): do not contain any join variable
-        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(var4, z2);
+        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(solMaps.var4, solMaps.z2);
         final Iterable<SolutionMapping> matchSolMap2 = solMHashTable.getJoinPartners(sm2);
         final Iterator<SolutionMapping> it2 = matchSolMap2.iterator();
         assertTrue( it2.hasNext() );
@@ -190,9 +233,15 @@ public class SolutionMappingsHashTableTest {
         assertEquals( 3, bIt23.size() );
 
         assertFalse( it2.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithThreeInputVariable_getJoinPartners3() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
 
         // getJoinPartners(var2, y1, var1, x1, var3, z1): one join partner
-        final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(var2, y1, var1, x1, var3, z1);
+        final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y1, solMaps.var1, solMaps.x1, solMaps.var3, solMaps.z1);
         final Iterable<SolutionMapping> matchSolMap3 = solMHashTable.getJoinPartners(sm3);
         final Iterator<SolutionMapping> it3 = matchSolMap3.iterator();
 
@@ -201,10 +250,6 @@ public class SolutionMappingsHashTableTest {
         assertEquals( 3, bit3.size() );
 
         assertFalse( it3.hasNext() );
-
-        // clear()
-        solMHashTable.clear();
-        assertTrue(solMHashTable.isEmpty());
     }
 
     @Test

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableTest.java
@@ -225,8 +225,41 @@ public class SolutionMappingsHashTableTest {
         final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
         final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
 
-        // getJoinPartners(): do not contain complete join variables; Return all solution mappings (if no post-matching)
-        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y1);
+        // getJoinPartners(var2, y1, var1, x1, var3, z1): one join partner
+        final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y1, solMaps.var1, solMaps.x1, solMaps.var3, solMaps.z1);
+        final Iterable<SolutionMapping> matchSolMap3 = solMHashTable.getJoinPartners(sm3);
+        final Iterator<SolutionMapping> it3 = matchSolMap3.iterator();
+
+        assertTrue( it3.hasNext() );
+        final Binding bit3 = it3.next().asJenaBinding();
+        assertEquals( 3, bit3.size() );
+        assertEquals( "http://example.org/x1", bit3.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y1", bit3.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z1", bit3.get(solMaps.var3).getURI() );
+
+        assertFalse( it3.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithThreeInputVariable_getJoinPartners2() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
+
+        // getJoinPartners(var2, y2, var1, x1, var3, z1): no join partner
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y2, solMaps.var1, solMaps.x1, solMaps.var3, solMaps.z1);
+        final Iterable<SolutionMapping> matchSolMap = solMHashTable.getJoinPartners(sm);
+        final Iterator<SolutionMapping> it = matchSolMap.iterator();
+
+        assertFalse( it.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithThreeInputVariable_getJoinPartners3() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
+
+        // getJoinPartners(): do not contain complete join variables. Return all solution mappings (if no post-matching)
+        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x2);
         final Iterable<SolutionMapping> matchSolMap1 = solMHashTable.getJoinPartners(sm1);
         final Iterator<SolutionMapping> it1 = matchSolMap1.iterator();
 
@@ -246,11 +279,11 @@ public class SolutionMappingsHashTableTest {
     }
 
     @Test
-    public void hashTableWithThreeInputVariable_getJoinPartners2() {
+    public void hashTableWithThreeInputVariable_getJoinPartners4() {
         final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
         final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
 
-        // getJoinPartners(): do not contain any join variable
+        // getJoinPartners(): do not contain any join variable. Return all solution mappings (if no post-matching)
         final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(solMaps.var4, solMaps.z2);
         final Iterable<SolutionMapping> matchSolMap2 = solMHashTable.getJoinPartners(sm2);
         final Iterator<SolutionMapping> it2 = matchSolMap2.iterator();
@@ -267,26 +300,6 @@ public class SolutionMappingsHashTableTest {
         assertEquals( 3, bIt23.size() );
 
         assertFalse( it2.hasNext() );
-    }
-
-    @Test
-    public void hashTableWithThreeInputVariable_getJoinPartners3() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
-
-        // getJoinPartners(var2, y1, var1, x1, var3, z1): one join partner
-        final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y1, solMaps.var1, solMaps.x1, solMaps.var3, solMaps.z1);
-        final Iterable<SolutionMapping> matchSolMap3 = solMHashTable.getJoinPartners(sm3);
-        final Iterator<SolutionMapping> it3 = matchSolMap3.iterator();
-
-        assertTrue( it3.hasNext() );
-        final Binding bit3 = it3.next().asJenaBinding();
-        assertEquals( 3, bit3.size() );
-        assertEquals( "http://example.org/x1", bit3.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y1", bit3.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z1", bit3.get(solMaps.var3).getURI() );
-
-        assertFalse( it3.hasNext() );
     }
 
     @Test

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsHashTableTest.java
@@ -10,31 +10,28 @@ import java.util.*;
 
 import static org.junit.Assert.*;
 
-public class SolutionMappingsHashTableTest {
+public class SolutionMappingsHashTableTest extends TestsForSolutionMappingsIndex {
     @Test
     public void hashTableWithThreeInputVariable_basic() {
         // test method: isEmpty(), contains(), add(), size(), clear()
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
+        final SolutionMappingsIndexBase solMHashTable = createHashTableBasedThreeVars();
 
         assertFalse(solMHashTable.isEmpty());
         assertEquals( 3, solMHashTable.size() );
 
-        final SolutionMapping sm0 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y1, solMaps.var3, solMaps.z1);
-        assertTrue(solMHashTable.contains(sm0));
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1, var3, z1);
+        assertTrue(solMHashTable.contains(sm));
 
         solMHashTable.clear();
         assertTrue(solMHashTable.isEmpty());
-        assertFalse(solMHashTable.contains(sm0));
+        assertFalse(solMHashTable.contains(sm));
     }
 
     @Test
     public void hashTableWithThreeInputVariable_getAllSolMaps() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
-
         // test getAllSolutionMappings()
-        final Iterator<SolutionMapping> it = solMHashTable.iterator();
+        final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().getAllSolutionMappings().iterator();
+
         assertTrue( it.hasNext() );
         final Binding b1 = it.next().asJenaBinding();
         assertEquals( 3, b1.size() );
@@ -52,254 +49,173 @@ public class SolutionMappingsHashTableTest {
 
     @Test
     public void hashTableWithThreeInputVariable_findSolutionMappings1() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
-
         // findSolutionMappings(var2, y2): one matching solution mapping
-        final Iterable<SolutionMapping> solMapVar2= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y2);
-        final Iterator<SolutionMapping> itVar2 = solMapVar2.iterator();
+        final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().findSolutionMappings(var2, y2).iterator();
 
-        assertTrue( itVar2.hasNext() );
-        final Binding bItVar2 = itVar2.next().asJenaBinding();
-        assertEquals( 3, bItVar2.size() );
-        assertEquals( "http://example.org/x2", bItVar2.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y2", bItVar2.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z2", bItVar2.get(solMaps.var3).getURI() );
+        assertHasNext( it, "http://example.org/x2", var1, "http://example.org/y2", var2, "http://example.org/z2", var3 );
 
-        assertFalse( itVar2.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithThreeInputVariable_findSolutionMappings2() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
-
         // findSolutionMappings(var4, p): return all solution mappings
-        final Iterable<SolutionMapping> solMapVar4 = solMHashTable.findSolutionMappings(solMaps.var4, solMaps.p);
-        final Iterator<SolutionMapping> itVar4 = solMapVar4.iterator();
+        final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().findSolutionMappings(var4, p).iterator();
 
-        assertTrue( itVar4.hasNext() );
-        final Binding bitVar41 = itVar4.next().asJenaBinding();
-        assertEquals( 3, bitVar41.size() );
+        assertTrue( it.hasNext() );
+        final Binding b1 = it.next().asJenaBinding();
+        assertEquals( 3, b1.size() );
 
-        assertTrue( itVar4.hasNext() );
-        final Binding bitVar42 = itVar4.next().asJenaBinding();
-        assertEquals( 3, bitVar42.size() );
+        assertTrue( it.hasNext() );
+        final Binding b2 = it.next().asJenaBinding();
+        assertEquals( 3, b2.size() );
 
-        assertTrue( itVar4.hasNext() );
-        final Binding bitVar43 = itVar4.next().asJenaBinding();
-        assertEquals( 3, bitVar43.size() );
+        assertTrue( it.hasNext() );
+        final Binding b3 = it.next().asJenaBinding();
+        assertEquals( 3, b3.size() );
 
-        assertFalse( itVar4.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithThreeInputVariable_findSolutionMappings3() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
-
         // findSolutionMappings(var1, x1, var2, y1)
-        final Iterable<SolutionMapping> solMap12= solMHashTable.findSolutionMappings(solMaps.var1, solMaps.x1, solMaps.var2, solMaps.y1);
+        final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().findSolutionMappings(var1, x1, var2, y1).iterator();
 
         final Set<Binding> result = new HashSet<>();
-        final Iterator<SolutionMapping> it1 = solMap12.iterator();
-        assertTrue( it1.hasNext() );
-        result.add( it1.next().asJenaBinding() );
+        assertTrue( it.hasNext() );
+        result.add( it.next().asJenaBinding() );
 
-        assertTrue( it1.hasNext() );
-        result.add( it1.next().asJenaBinding() );
+        assertTrue( it.hasNext() );
+        result.add( it.next().asJenaBinding() );
 
-        assertFalse( it1.hasNext() );
+        assertFalse( it.hasNext() );
 
         for ( final Binding b: result ) {
             assertEquals( 3, b.size() );
-            if ( b.get(solMaps.var3).getURI().equals("http://example.org/z1") ) {
-                assertEquals( "http://example.org/x1", b.get(solMaps.var1).getURI() );
-                assertEquals( "http://example.org/y1", b.get(solMaps.var2).getURI() );
+            if ( b.get(var3).getURI().equals("http://example.org/z1") ) {
+                assertEquals( "http://example.org/x1", b.get(var1).getURI() );
+                assertEquals( "http://example.org/y1", b.get(var2).getURI() );
 
             }
-            else if ( b.get(solMaps.var3).getURI().equals("http://example.org/z2") ) {
-                assertEquals( "http://example.org/x1", b.get(solMaps.var1).getURI() );
-                assertEquals( "http://example.org/y1", b.get(solMaps.var2).getURI() );
+            else if ( b.get(var3).getURI().equals("http://example.org/z2") ) {
+                assertEquals( "http://example.org/x1", b.get(var1).getURI() );
+                assertEquals( "http://example.org/y1", b.get(var2).getURI() );
             }
             else {
-                fail( "Unexpected URI for ?v3: " + b.get(solMaps.var3).getURI() );
+                fail( "Unexpected URI for ?v3: " + b.get(var3).getURI() );
             }
         }
     }
 
     @Test
     public void hashTableWithThreeInputVariable_findSolutionMappings4() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
-
         // findSolutionMappings(var2, y2, var1, x2), change order of var1 and var2
-        final Iterable<SolutionMapping> solMap21= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y2, solMaps.var1, solMaps.x2);
-        final Iterator<SolutionMapping> itVar21 = solMap21.iterator();
-        assertTrue( itVar21.hasNext() );
-        final Binding bItVar21 = itVar21.next().asJenaBinding();
-        assertEquals( 3, bItVar21.size() );
-        assertEquals( "http://example.org/x2", bItVar21.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y2", bItVar21.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z2", bItVar21.get(solMaps.var3).getURI() );
+        final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().findSolutionMappings(var2, y2, var1, x2).iterator();
 
-        assertFalse( itVar21.hasNext() );
+        assertHasNext( it, "http://example.org/x2", var1, "http://example.org/y2", var2, "http://example.org/z2", var3 );
+
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithThreeInputVariable_findSolutionMappings5() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
-
         // findSolutionMappings(var2, y2, var4, p)
-        final Iterable<SolutionMapping> solMap24= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y2, solMaps.var4, solMaps.p);
-        final Iterator<SolutionMapping> itVar24 = solMap24.iterator();
-        assertTrue( itVar24.hasNext() );
-        final Binding bItVar24 = itVar24.next().asJenaBinding();
-        assertEquals( 3, bItVar24.size() );
-        assertEquals( "http://example.org/x2", bItVar24.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y2", bItVar24.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z2", bItVar24.get(solMaps.var3).getURI() );
+        final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().findSolutionMappings(var2, y2, var4, p).iterator();
+        assertHasNext( it, "http://example.org/x2", var1, "http://example.org/y2", var2, "http://example.org/z2", var3 );
 
-        assertFalse( itVar24.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithThreeInputVariable_findSolutionMappings6() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
-
         // findSolutionMappings(var2, y1, var1, x1, var3, z1)
-        final Iterable<SolutionMapping> solMap213= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y1, solMaps.var1, solMaps.x1, solMaps.var3, solMaps.z1);
-        final Iterator<SolutionMapping> itVar213 = solMap213.iterator();
-        assertTrue( itVar213.hasNext() );
-        final Binding bitVar213 = itVar213.next().asJenaBinding();
-        assertEquals( 3, bitVar213.size() );
-        assertEquals( "http://example.org/x1", bitVar213.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y1", bitVar213.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z1", bitVar213.get(solMaps.var3).getURI() );
+        final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().findSolutionMappings(var2, y1, var1, x1, var3, z1).iterator();
+        assertHasNext( it, "http://example.org/x1", var1, "http://example.org/y1", var2, "http://example.org/z1", var3 );
 
-        assertFalse( itVar213.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithThreeInputVariable_findSolutionMappings7() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
-
         // findSolutionMappings(var2, y2, var1, x2, var4, p)
-        final Iterable<SolutionMapping> solMap214= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y2, solMaps.var1, solMaps.x2, solMaps.var4, solMaps.p);
-        final Iterator<SolutionMapping> itVar214 = solMap214.iterator();
+        final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().findSolutionMappings(var2, y2, var1, x2, var4, p).iterator();
 
-        assertTrue( itVar214.hasNext() );
-        final Binding bitVar214 = itVar214.next().asJenaBinding();
-        assertEquals( 3, bitVar214.size() );
-        assertEquals( "http://example.org/x2", bitVar214.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y2", bitVar214.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z2", bitVar214.get(solMaps.var3).getURI() );
+        assertHasNext( it, "http://example.org/x2", var1, "http://example.org/y2", var2, "http://example.org/z2", var3 );
 
-        assertFalse( itVar214.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithThreeInputVariable_findSolutionMappings8() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
-
         // findSolutionMappings(var2, y1, var1, x1, var3, z1, var4, p)
-        final Iterable<SolutionMapping> solMap2134= solMHashTable.findSolutionMappings(solMaps.var2, solMaps.y1, solMaps.var1, solMaps.x1, solMaps.var3, solMaps.z1);
-        final Iterator<SolutionMapping> itVar2134 = solMap2134.iterator();
+        final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().findSolutionMappings(var2, y1, var1, x1, var3, z1).iterator();
 
-        assertTrue( itVar2134.hasNext() );
-        final Binding bitVar2134 = itVar2134.next().asJenaBinding();
-        assertEquals( 3, bitVar2134.size() );
-        assertEquals( "http://example.org/x1", bitVar2134.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y1", bitVar2134.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z1", bitVar2134.get(solMaps.var3).getURI() );
+        assertHasNext( it, "http://example.org/x1", var1, "http://example.org/y1", var2, "http://example.org/z1", var3 );
 
-        assertFalse( itVar2134.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithThreeInputVariable_getJoinPartners1() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
-
         // getJoinPartners(var2, y1, var1, x1, var3, z1): one join partner
-        final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y1, solMaps.var1, solMaps.x1, solMaps.var3, solMaps.z1);
-        final Iterable<SolutionMapping> matchSolMap3 = solMHashTable.getJoinPartners(sm3);
-        final Iterator<SolutionMapping> it3 = matchSolMap3.iterator();
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var2, y1, var1, x1, var3, z1);
+        final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().getJoinPartners(sm).iterator();
 
-        assertTrue( it3.hasNext() );
-        final Binding bit3 = it3.next().asJenaBinding();
-        assertEquals( 3, bit3.size() );
-        assertEquals( "http://example.org/x1", bit3.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y1", bit3.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z1", bit3.get(solMaps.var3).getURI() );
+        assertHasNext( it, "http://example.org/x1", var1, "http://example.org/y1", var2, "http://example.org/z1", var3 );
 
-        assertFalse( it3.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithThreeInputVariable_getJoinPartners2() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
-
         // getJoinPartners(var2, y2, var1, x1, var3, z1): no join partner
-        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y2, solMaps.var1, solMaps.x1, solMaps.var3, solMaps.z1);
-        final Iterable<SolutionMapping> matchSolMap = solMHashTable.getJoinPartners(sm);
-        final Iterator<SolutionMapping> it = matchSolMap.iterator();
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var2, y2, var1, x1, var3, z1);
+        final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().getJoinPartners(sm).iterator();
 
         assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithThreeInputVariable_getJoinPartners3() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
-
         // getJoinPartners(): do not contain complete join variables. Return all solution mappings (if no post-matching)
-        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x2);
-        final Iterable<SolutionMapping> matchSolMap1 = solMHashTable.getJoinPartners(sm1);
-        final Iterator<SolutionMapping> it1 = matchSolMap1.iterator();
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var1, x2);
+        final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().getJoinPartners(sm).iterator();
 
-        assertTrue( it1.hasNext() );
-        final Binding bIt11 = it1.next().asJenaBinding();
-        assertEquals( 3, bIt11.size() );
+        assertTrue( it.hasNext() );
+        final Binding b1 = it.next().asJenaBinding();
+        assertEquals( 3, b1.size() );
 
-        assertTrue( it1.hasNext() );
-        final Binding bIt12 = it1.next().asJenaBinding();
-        assertEquals( 3, bIt12.size() );
+        assertTrue( it.hasNext() );
+        final Binding b2 = it.next().asJenaBinding();
+        assertEquals( 3, b2.size() );
 
-        assertTrue( it1.hasNext() );
-        final Binding bIt13 = it1.next().asJenaBinding();
-        assertEquals( 3, bIt13.size() );
+        assertTrue( it.hasNext() );
+        final Binding b3 = it.next().asJenaBinding();
+        assertEquals( 3, b3.size() );
 
-        assertFalse( it1.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithThreeInputVariable_getJoinPartners4() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
-
         // getJoinPartners(): do not contain any join variable. Return all solution mappings (if no post-matching)
-        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(solMaps.var4, solMaps.z2);
-        final Iterable<SolutionMapping> matchSolMap2 = solMHashTable.getJoinPartners(sm2);
-        final Iterator<SolutionMapping> it2 = matchSolMap2.iterator();
-        assertTrue( it2.hasNext() );
-        final Binding bIt21 = it2.next().asJenaBinding();
-        assertEquals( 3, bIt21.size() );
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var4, z2);
+        final Iterator<SolutionMapping> it = createHashTableBasedThreeVars().getJoinPartners(sm).iterator();
 
-        assertTrue( it2.hasNext() );
-        final Binding bIt42 = it2.next().asJenaBinding();
-        assertEquals( 3, bIt42.size() );
+        assertTrue( it.hasNext() );
+        final Binding b1 = it.next().asJenaBinding();
+        assertEquals( 3, b1.size() );
 
-        assertTrue( it2.hasNext() );
-        final Binding bIt23 = it2.next().asJenaBinding();
-        assertEquals( 3, bIt23.size() );
+        assertTrue( it.hasNext() );
+        final Binding b2 = it.next().asJenaBinding();
+        assertEquals( 3, b2.size() );
 
-        assertFalse( it2.hasNext() );
+        assertTrue( it.hasNext() );
+        final Binding b3 = it.next().asJenaBinding();
+        assertEquals( 3, b3.size() );
+
+        assertFalse( it.hasNext() );
     }
 
     @Test

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsIndexWithPostMatchingTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsIndexWithPostMatchingTest.java
@@ -1,8 +1,5 @@
 package se.liu.ida.hefquin.engine.datastructures.impl;
 
-import org.apache.jena.graph.Node;
-import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.junit.Test;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
@@ -14,29 +11,12 @@ import static org.junit.Assert.*;
 
 public class SolutionMappingsIndexWithPostMatchingTest {
     @Test
-    public void hashTableWithOneInputVariable() {
-        final Var var2 = Var.alloc("v2");
-        final Var var3 = Var.alloc("v3");
+    public void hashTableWithOneInputVariable_getJoinPartnersWithPostMatching1() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
 
-        final Node y1 = NodeFactory.createURI("http://example.org/y1");
-        final Node y2 = NodeFactory.createURI("http://example.org/y2");
-        final Node z1 = NodeFactory.createURI("http://example.org/z1");
-        final Node z2 = NodeFactory.createURI("http://example.org/z2");
-        final Node z3 = NodeFactory.createURI("http://example.org/z3");
-
-        final SolutionMappingsHashTable solMHashTable = new SolutionMappingsHashTable(var2);
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var2, y1,
-                var3, z1) );
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var2, y1,
-                var3, z2) );
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var2, y2,
-                var3, z3) );
-
-        // getJoinPartners with post matching
-        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(var3, z3);
+        // getJoinPartners of (var3, z3)
+        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(solMaps.var3, solMaps.z3);
         final Iterable<SolutionMapping> matchSolMap1 = new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm1);
         final Iterator<SolutionMapping> itVar1 = matchSolMap1.iterator();
 
@@ -45,9 +25,15 @@ public class SolutionMappingsIndexWithPostMatchingTest {
         assertEquals( 2, bItVar1.size() );
 
         assertFalse( itVar1.hasNext() );
+    }
 
-        // getJoinPartners with post matching
-        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(var2, y1, var3, z2);
+    @Test
+    public void hashTableWithOneInputVariable_getJoinPartnersWithPostMatching2() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
+
+        // getJoinPartners of (var2, y1, var3, z2)
+        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y1, solMaps.var3, solMaps.z2);
         final Iterable<SolutionMapping> matchSolMap2 = new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm2);
         final Iterator<SolutionMapping> itVar2 = matchSolMap2.iterator();
 
@@ -59,34 +45,12 @@ public class SolutionMappingsIndexWithPostMatchingTest {
     }
 
     @Test
-    public void hashTableWithTwoInputVariable() {
-        final Var var1 = Var.alloc("v1");
-        final Var var2 = Var.alloc("v2");
-        final Var var3 = Var.alloc("v3");
+    public void hashTableWithTwoInputVariable_getJoinPartnersWithPostMatching1() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
 
-        final Node x1 = NodeFactory.createURI("http://example.org/x1");
-        final Node x2 = NodeFactory.createURI("http://example.org/x2");
-        final Node y1 = NodeFactory.createURI("http://example.org/y1");
-        final Node y2 = NodeFactory.createURI("http://example.org/y2");
-        final Node z1 = NodeFactory.createURI("http://example.org/z1");
-        final Node z2 = NodeFactory.createURI("http://example.org/z2");
-
-        final SolutionMappingsHashTable solMHashTable = new SolutionMappingsHashTable(var1, var2);
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var1, x1,
-                var2, y1,
-                var3, z1) );
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var1, x1,
-                var2, y1,
-                var3, z2) );
-        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
-                var1, x2,
-                var2, y2,
-                var3, z2) );
-
-        // getJoinPartners with post matching
-        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(var1, x2);
+        // getJoinPartners of (var1, x2)
+        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x2);
         final Iterable<SolutionMapping> matchSolMap1 = new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm1);
         final Iterator<SolutionMapping> it1 = matchSolMap1.iterator();
         assertTrue( it1.hasNext() );
@@ -94,16 +58,28 @@ public class SolutionMappingsIndexWithPostMatchingTest {
         assertEquals( 3, bIt1.size() );
 
         assertFalse( it1.hasNext() );
+    }
 
-        // getJoinPartners()
-        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(var2, y2, var3, z1);
+    @Test
+    public void hashTableWithTwoInputVariable_getJoinPartnersWithPostMatching2() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
+
+        // getJoinPartners of (var2, y2, var3, z1)
+        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y2, solMaps.var3, solMaps.z1);
         final Iterable<SolutionMapping> matchSolMap2 =  new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm2);
         final Iterator<SolutionMapping> it2 = matchSolMap2.iterator();
 
         assertFalse( it2.hasNext() );
+    }
 
-        // getJoinPartners()
-        final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(var3, z1);
+    @Test
+    public void hashTableWithTwoInputVariable_getJoinPartnersWithPostMatching3() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
+
+        // getJoinPartners of (var3, z1)
+        final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(solMaps.var3, solMaps.z1);
         final Iterable<SolutionMapping> matchSolMap3 =  new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm3);
         final Iterator<SolutionMapping> it3 = matchSolMap3.iterator();
         assertTrue( it3.hasNext() );
@@ -112,5 +88,4 @@ public class SolutionMappingsIndexWithPostMatchingTest {
 
         assertFalse( it3.hasNext() );
     }
-
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsIndexWithPostMatchingTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsIndexWithPostMatchingTest.java
@@ -1,6 +1,5 @@
 package se.liu.ida.hefquin.engine.datastructures.impl;
 
-import org.apache.jena.sparql.engine.binding.Binding;
 import org.junit.Test;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
@@ -9,94 +8,57 @@ import java.util.*;
 
 import static org.junit.Assert.*;
 
-public class SolutionMappingsIndexWithPostMatchingTest {
+public class SolutionMappingsIndexWithPostMatchingTest extends TestsForSolutionMappingsIndex {
     @Test
     public void hashTableWithOneInputVariable_getJoinPartnersWithPostMatching1() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
-
         // getJoinPartners of (var3, z3): would find three solution mappings if without post matching
-        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(solMaps.var3, solMaps.z3);
-        final Iterable<SolutionMapping> matchSolMap1 = new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm1);
-        final Iterator<SolutionMapping> itVar1 = matchSolMap1.iterator();
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var3, z3);
+        final Iterator<SolutionMapping> it = new SolutionMappingsIndexWithPostMatching(createHashTableBasedOneVar()).getJoinPartners(sm).iterator();
 
-        assertTrue( itVar1.hasNext() );
-        final Binding bItVar1 = itVar1.next().asJenaBinding();
-        assertEquals( 2, bItVar1.size() );
-        assertEquals("http://example.org/y2", bItVar1.get(solMaps.var2).getURI());
-        assertEquals("http://example.org/z3", bItVar1.get(solMaps.var3).getURI());
+        assertHasNext( it, "http://example.org/y2", var2, "http://example.org/z3", var3 );
 
-        assertFalse( itVar1.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithOneInputVariable_getJoinPartnersWithPostMatching2() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
-
         // getJoinPartners of (var2, y1, var3, z2): would find two solution mappings if without post matching
-        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y1, solMaps.var3, solMaps.z2);
-        final Iterable<SolutionMapping> matchSolMap2 = new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm2);
-        final Iterator<SolutionMapping> itVar2 = matchSolMap2.iterator();
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var2, y1, var3, z2);
+        final Iterator<SolutionMapping> it = new SolutionMappingsIndexWithPostMatching(createHashTableBasedOneVar()).getJoinPartners(sm).iterator();
 
-        assertTrue( itVar2.hasNext() );
-        final Binding bItVar2 = itVar2.next().asJenaBinding();
-        assertEquals( 2, bItVar2.size() );
-        assertEquals("http://example.org/y1", bItVar2.get(solMaps.var2).getURI());
-        assertEquals("http://example.org/z2", bItVar2.get(solMaps.var3).getURI());
+        assertHasNext( it, "http://example.org/y1", var2, "http://example.org/z2", var3 );
 
-        assertFalse( itVar2.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithTwoInputVariable_getJoinPartnersWithPostMatching1() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
-
         // getJoinPartners of (var3, z1): would find three solution mappings if without post matching
-        final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(solMaps.var3, solMaps.z1);
-        final Iterable<SolutionMapping> matchSolMap3 =  new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm3);
-        final Iterator<SolutionMapping> it3 = matchSolMap3.iterator();
-        assertTrue( it3.hasNext() );
-        final Binding bIt3 = it3.next().asJenaBinding();
-        assertEquals( 3, bIt3.size() );
-        assertEquals( "http://example.org/x1", bIt3.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y1", bIt3.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z1", bIt3.get(solMaps.var3).getURI() );
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var3, z1);
+        final Iterator<SolutionMapping> it = new SolutionMappingsIndexWithPostMatching(createHashTableBasedTwoVars()).getJoinPartners(sm).iterator();
 
-        assertFalse( it3.hasNext() );
+        assertHasNext( it, "http://example.org/x1", var1, "http://example.org/y1", var2, "http://example.org/z1", var3 );
+
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithTwoInputVariable_getJoinPartnersWithPostMatching2() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
-
         // getJoinPartners of (var2, y2, var3, z1): would find one solution mappings if without post matching
-        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y2, solMaps.var3, solMaps.z1);
-        final Iterable<SolutionMapping> matchSolMap2 =  new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm2);
-        final Iterator<SolutionMapping> it2 = matchSolMap2.iterator();
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var2, y2, var3, z1);
+        final Iterator<SolutionMapping> it = new SolutionMappingsIndexWithPostMatching(createHashTableBasedTwoVars()).getJoinPartners(sm).iterator();
 
-        assertFalse( it2.hasNext() );
+        assertFalse( it.hasNext() );
     }
 
     @Test
     public void hashTableWithThreeInputVariable_getJoinPartnersWithPostMatching1() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
-
         // getJoinPartners(): would find three solution mappings if no post-matching
-        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x2);
-        final Iterable<SolutionMapping> matchSolMap1 =  new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm1);
-        final Iterator<SolutionMapping> it1 = matchSolMap1.iterator();
+        final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var1, x2);
+        final Iterator<SolutionMapping> it = new SolutionMappingsIndexWithPostMatching(createHashTableBasedThreeVars()).getJoinPartners(sm).iterator();
 
-        assertTrue( it1.hasNext() );
-        final Binding bIt1 = it1.next().asJenaBinding();
-        assertEquals( 3, bIt1.size() );
-        assertEquals( "http://example.org/x2", bIt1.get(solMaps.var1).getURI() );
-        assertEquals( "http://example.org/y2", bIt1.get(solMaps.var2).getURI() );
-        assertEquals( "http://example.org/z2", bIt1.get(solMaps.var3).getURI() );
+        assertHasNext( it, "http://example.org/x2", var1, "http://example.org/y2", var2, "http://example.org/z2", var3 );
 
-        assertFalse( it1.hasNext() );
+        assertFalse( it.hasNext() );
     }
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsIndexWithPostMatchingTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsIndexWithPostMatchingTest.java
@@ -15,7 +15,7 @@ public class SolutionMappingsIndexWithPostMatchingTest {
         final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
         final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
 
-        // getJoinPartners of (var3, z3)
+        // getJoinPartners of (var3, z3): find three solution mappings if without post matching
         final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(solMaps.var3, solMaps.z3);
         final Iterable<SolutionMapping> matchSolMap1 = new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm1);
         final Iterator<SolutionMapping> itVar1 = matchSolMap1.iterator();
@@ -23,6 +23,8 @@ public class SolutionMappingsIndexWithPostMatchingTest {
         assertTrue( itVar1.hasNext() );
         final Binding bItVar1 = itVar1.next().asJenaBinding();
         assertEquals( 2, bItVar1.size() );
+        assertEquals("http://example.org/y2", bItVar1.get(solMaps.var2).getURI());
+        assertEquals("http://example.org/z3", bItVar1.get(solMaps.var3).getURI());
 
         assertFalse( itVar1.hasNext() );
     }
@@ -32,7 +34,7 @@ public class SolutionMappingsIndexWithPostMatchingTest {
         final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
         final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
 
-        // getJoinPartners of (var2, y1, var3, z2)
+        // getJoinPartners of (var2, y1, var3, z2): find two solution mappings if without post matching
         final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y1, solMaps.var3, solMaps.z2);
         final Iterable<SolutionMapping> matchSolMap2 = new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm2);
         final Iterator<SolutionMapping> itVar2 = matchSolMap2.iterator();
@@ -40,6 +42,8 @@ public class SolutionMappingsIndexWithPostMatchingTest {
         assertTrue( itVar2.hasNext() );
         final Binding bItVar2 = itVar2.next().asJenaBinding();
         assertEquals( 2, bItVar2.size() );
+        assertEquals("http://example.org/y1", bItVar2.get(solMaps.var2).getURI());
+        assertEquals("http://example.org/z2", bItVar2.get(solMaps.var3).getURI());
 
         assertFalse( itVar2.hasNext() );
     }
@@ -49,23 +53,7 @@ public class SolutionMappingsIndexWithPostMatchingTest {
         final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
         final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
 
-        // getJoinPartners of (var1, x2)
-        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x2);
-        final Iterable<SolutionMapping> matchSolMap1 = new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm1);
-        final Iterator<SolutionMapping> it1 = matchSolMap1.iterator();
-        assertTrue( it1.hasNext() );
-        final Binding bIt1 = it1.next().asJenaBinding();
-        assertEquals( 3, bIt1.size() );
-
-        assertFalse( it1.hasNext() );
-    }
-
-    @Test
-    public void hashTableWithTwoInputVariable_getJoinPartnersWithPostMatching2() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
-
-        // getJoinPartners of (var2, y2, var3, z1)
+        // getJoinPartners of (var2, y2, var3, z1): find one solution mappings if without post matching
         final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y2, solMaps.var3, solMaps.z1);
         final Iterable<SolutionMapping> matchSolMap2 =  new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm2);
         final Iterator<SolutionMapping> it2 = matchSolMap2.iterator();
@@ -74,18 +62,41 @@ public class SolutionMappingsIndexWithPostMatchingTest {
     }
 
     @Test
-    public void hashTableWithTwoInputVariable_getJoinPartnersWithPostMatching3() {
+    public void hashTableWithTwoInputVariable_getJoinPartnersWithPostMatching2() {
         final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
         final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
 
-        // getJoinPartners of (var3, z1)
+        // getJoinPartners of (var3, z1): find three solution mappings if without post matching
         final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(solMaps.var3, solMaps.z1);
         final Iterable<SolutionMapping> matchSolMap3 =  new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm3);
         final Iterator<SolutionMapping> it3 = matchSolMap3.iterator();
         assertTrue( it3.hasNext() );
         final Binding bIt3 = it3.next().asJenaBinding();
         assertEquals( 3, bIt3.size() );
+        assertEquals( "http://example.org/x1", bIt3.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y1", bIt3.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z1", bIt3.get(solMaps.var3).getURI() );
 
         assertFalse( it3.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithThreeInputVariable_getJoinPartnersWithPostMatching1() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
+
+        // getJoinPartners(): do not contain complete join variables; Find three solution mappings if no post-matching
+        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x2);
+        final Iterable<SolutionMapping> matchSolMap1 =  new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm1);
+        final Iterator<SolutionMapping> it1 = matchSolMap1.iterator();
+
+        assertTrue( it1.hasNext() );
+        final Binding bIt1 = it1.next().asJenaBinding();
+        assertEquals( 3, bIt1.size() );
+        assertEquals( "http://example.org/x2", bIt1.get(solMaps.var1).getURI() );
+        assertEquals( "http://example.org/y2", bIt1.get(solMaps.var2).getURI() );
+        assertEquals( "http://example.org/z2", bIt1.get(solMaps.var3).getURI() );
+
+        assertFalse( it1.hasNext() );
     }
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsIndexWithPostMatchingTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsIndexWithPostMatchingTest.java
@@ -7,7 +7,6 @@ import org.apache.jena.sparql.engine.binding.Binding;
 import org.junit.Test;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
-import se.liu.ida.hefquin.engine.datastructures.SolutionMappingsIndex;
 
 import java.util.*;
 
@@ -88,7 +87,7 @@ public class SolutionMappingsIndexWithPostMatchingTest {
 
         // getJoinPartners with post matching
         final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(var1, x2);
-        Iterable<SolutionMapping> matchSolMap1 = new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm1);
+        final Iterable<SolutionMapping> matchSolMap1 = new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm1);
         final Iterator<SolutionMapping> it1 = matchSolMap1.iterator();
         assertTrue( it1.hasNext() );
         final Binding bIt1 = it1.next().asJenaBinding();
@@ -98,14 +97,14 @@ public class SolutionMappingsIndexWithPostMatchingTest {
 
         // getJoinPartners()
         final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(var2, y2, var3, z1);
-        Iterable<SolutionMapping> matchSolMap2 =  new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm2);
+        final Iterable<SolutionMapping> matchSolMap2 =  new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm2);
         final Iterator<SolutionMapping> it2 = matchSolMap2.iterator();
 
         assertFalse( it2.hasNext() );
 
         // getJoinPartners()
         final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(var3, z1);
-        Iterable<SolutionMapping> matchSolMap3 =  new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm3);
+        final Iterable<SolutionMapping> matchSolMap3 =  new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm3);
         final Iterator<SolutionMapping> it3 = matchSolMap3.iterator();
         assertTrue( it3.hasNext() );
         final Binding bIt3 = it3.next().asJenaBinding();

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsIndexWithPostMatchingTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsIndexWithPostMatchingTest.java
@@ -15,7 +15,7 @@ public class SolutionMappingsIndexWithPostMatchingTest {
         final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
         final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
 
-        // getJoinPartners of (var3, z3): find three solution mappings if without post matching
+        // getJoinPartners of (var3, z3): would find three solution mappings if without post matching
         final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(solMaps.var3, solMaps.z3);
         final Iterable<SolutionMapping> matchSolMap1 = new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm1);
         final Iterator<SolutionMapping> itVar1 = matchSolMap1.iterator();
@@ -34,7 +34,7 @@ public class SolutionMappingsIndexWithPostMatchingTest {
         final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
         final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedOneVar();
 
-        // getJoinPartners of (var2, y1, var3, z2): find two solution mappings if without post matching
+        // getJoinPartners of (var2, y1, var3, z2): would find two solution mappings if without post matching
         final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y1, solMaps.var3, solMaps.z2);
         final Iterable<SolutionMapping> matchSolMap2 = new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm2);
         final Iterator<SolutionMapping> itVar2 = matchSolMap2.iterator();
@@ -53,20 +53,7 @@ public class SolutionMappingsIndexWithPostMatchingTest {
         final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
         final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
 
-        // getJoinPartners of (var2, y2, var3, z1): find one solution mappings if without post matching
-        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y2, solMaps.var3, solMaps.z1);
-        final Iterable<SolutionMapping> matchSolMap2 =  new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm2);
-        final Iterator<SolutionMapping> it2 = matchSolMap2.iterator();
-
-        assertFalse( it2.hasNext() );
-    }
-
-    @Test
-    public void hashTableWithTwoInputVariable_getJoinPartnersWithPostMatching2() {
-        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
-        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
-
-        // getJoinPartners of (var3, z1): find three solution mappings if without post matching
+        // getJoinPartners of (var3, z1): would find three solution mappings if without post matching
         final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(solMaps.var3, solMaps.z1);
         final Iterable<SolutionMapping> matchSolMap3 =  new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm3);
         final Iterator<SolutionMapping> it3 = matchSolMap3.iterator();
@@ -81,11 +68,24 @@ public class SolutionMappingsIndexWithPostMatchingTest {
     }
 
     @Test
+    public void hashTableWithTwoInputVariable_getJoinPartnersWithPostMatching2() {
+        final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
+        final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedTwoVars();
+
+        // getJoinPartners of (var2, y2, var3, z1): would find one solution mappings if without post matching
+        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(solMaps.var2, solMaps.y2, solMaps.var3, solMaps.z1);
+        final Iterable<SolutionMapping> matchSolMap2 =  new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm2);
+        final Iterator<SolutionMapping> it2 = matchSolMap2.iterator();
+
+        assertFalse( it2.hasNext() );
+    }
+
+    @Test
     public void hashTableWithThreeInputVariable_getJoinPartnersWithPostMatching1() {
         final TestsForSolutionMappingsIndex solMaps= new TestsForSolutionMappingsIndex();
         final SolutionMappingsIndexBase solMHashTable = solMaps.createHashTableBasedThreeVars();
 
-        // getJoinPartners(): do not contain complete join variables; Find three solution mappings if no post-matching
+        // getJoinPartners(): would find three solution mappings if no post-matching
         final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(solMaps.var1, solMaps.x2);
         final Iterable<SolutionMapping> matchSolMap1 =  new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm1);
         final Iterator<SolutionMapping> it1 = matchSolMap1.iterator();

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsIndexWithPostMatchingTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsIndexWithPostMatchingTest.java
@@ -1,0 +1,117 @@
+package se.liu.ida.hefquin.engine.datastructures.impl;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.junit.Test;
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
+import se.liu.ida.hefquin.engine.datastructures.SolutionMappingsIndex;
+
+import java.util.*;
+
+import static org.junit.Assert.*;
+
+public class SolutionMappingsIndexWithPostMatchingTest {
+    @Test
+    public void hashTableWithOneInputVariable() {
+        final Var var2 = Var.alloc("v2");
+        final Var var3 = Var.alloc("v3");
+
+        final Node y1 = NodeFactory.createURI("http://example.org/y1");
+        final Node y2 = NodeFactory.createURI("http://example.org/y2");
+        final Node z1 = NodeFactory.createURI("http://example.org/z1");
+        final Node z2 = NodeFactory.createURI("http://example.org/z2");
+        final Node z3 = NodeFactory.createURI("http://example.org/z3");
+
+        final SolutionMappingsHashTable solMHashTable = new SolutionMappingsHashTable(var2);
+        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+                var2, y1,
+                var3, z1) );
+        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+                var2, y1,
+                var3, z2) );
+        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+                var2, y2,
+                var3, z3) );
+
+        // getJoinPartners with post matching
+        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(var3, z3);
+        final Iterable<SolutionMapping> matchSolMap1 = new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm1);
+        final Iterator<SolutionMapping> itVar1 = matchSolMap1.iterator();
+
+        assertTrue( itVar1.hasNext() );
+        final Binding bItVar1 = itVar1.next().asJenaBinding();
+        assertEquals( 2, bItVar1.size() );
+
+        assertFalse( itVar1.hasNext() );
+
+        // getJoinPartners with post matching
+        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(var2, y1, var3, z2);
+        final Iterable<SolutionMapping> matchSolMap2 = new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm2);
+        final Iterator<SolutionMapping> itVar2 = matchSolMap2.iterator();
+
+        assertTrue( itVar2.hasNext() );
+        final Binding bItVar2 = itVar2.next().asJenaBinding();
+        assertEquals( 2, bItVar2.size() );
+
+        assertFalse( itVar2.hasNext() );
+    }
+
+    @Test
+    public void hashTableWithTwoInputVariable() {
+        final Var var1 = Var.alloc("v1");
+        final Var var2 = Var.alloc("v2");
+        final Var var3 = Var.alloc("v3");
+
+        final Node x1 = NodeFactory.createURI("http://example.org/x1");
+        final Node x2 = NodeFactory.createURI("http://example.org/x2");
+        final Node y1 = NodeFactory.createURI("http://example.org/y1");
+        final Node y2 = NodeFactory.createURI("http://example.org/y2");
+        final Node z1 = NodeFactory.createURI("http://example.org/z1");
+        final Node z2 = NodeFactory.createURI("http://example.org/z2");
+
+        final SolutionMappingsHashTable solMHashTable = new SolutionMappingsHashTable(var1, var2);
+        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+                var1, x1,
+                var2, y1,
+                var3, z1) );
+        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+                var1, x1,
+                var2, y1,
+                var3, z2) );
+        solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+                var1, x2,
+                var2, y2,
+                var3, z2) );
+
+        // getJoinPartners with post matching
+        final SolutionMapping sm1 = SolutionMappingUtils.createSolutionMapping(var1, x2);
+        Iterable<SolutionMapping> matchSolMap1 = new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm1);
+        final Iterator<SolutionMapping> it1 = matchSolMap1.iterator();
+        assertTrue( it1.hasNext() );
+        final Binding bIt1 = it1.next().asJenaBinding();
+        assertEquals( 3, bIt1.size() );
+
+        assertFalse( it1.hasNext() );
+
+        // getJoinPartners()
+        final SolutionMapping sm2 = SolutionMappingUtils.createSolutionMapping(var2, y2, var3, z1);
+        Iterable<SolutionMapping> matchSolMap2 =  new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm2);
+        final Iterator<SolutionMapping> it2 = matchSolMap2.iterator();
+
+        assertFalse( it2.hasNext() );
+
+        // getJoinPartners()
+        final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(var3, z1);
+        Iterable<SolutionMapping> matchSolMap3 =  new SolutionMappingsIndexWithPostMatching(solMHashTable).getJoinPartners(sm3);
+        final Iterator<SolutionMapping> it3 = matchSolMap3.iterator();
+        assertTrue( it3.hasNext() );
+        final Binding bIt3 = it3.next().asJenaBinding();
+        assertEquals( 3, bIt3.size() );
+
+        assertFalse( it3.hasNext() );
+    }
+
+}

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/TestsForSolutionMappingsIndex.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/TestsForSolutionMappingsIndex.java
@@ -3,19 +3,14 @@ package se.liu.ida.hefquin.engine.datastructures.impl;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.sparql.core.Var;
-import org.apache.jena.sparql.engine.binding.Binding;
-import se.liu.ida.hefquin.engine.data.SolutionMapping;
+
+import se.liu.ida.hefquin.engine.EngineTestBase;
 import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
-
-import java.util.Iterator;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 /**
  * This is a class with helper functions for testing SolutionMappingsIndex
  */
-public class TestsForSolutionMappingsIndex
+public abstract class TestsForSolutionMappingsIndex extends EngineTestBase
 {
 	final Var var1 = Var.alloc("v1");
 	final Var var2 = Var.alloc("v2");
@@ -85,34 +80,6 @@ public class TestsForSolutionMappingsIndex
 				var3, z2) );
 
 		return solMHashTable;
-	}
-
-	protected void assertHasNext( final Iterator<SolutionMapping> it,
-								  final String expectedURIforV1, final Var v1,
-								  final String expectedURIforV2, final Var v2 )
-	{
-		assertTrue( it.hasNext() );
-
-		final Binding b = it.next().asJenaBinding();
-		assertEquals( 2, b.size() );
-
-		assertEquals( expectedURIforV1, b.get(v1).getURI() );
-		assertEquals( expectedURIforV2, b.get(v2).getURI() );
-	}
-
-	protected void assertHasNext( final Iterator<SolutionMapping> it,
-								  final String expectedURIforV1, final Var v1,
-								  final String expectedURIforV2, final Var v2,
-								  final String expectedURIforV3, final Var v3 )
-	{
-		assertTrue( it.hasNext() );
-
-		final Binding b = it.next().asJenaBinding();
-		assertEquals( 3, b.size() );
-
-		assertEquals( expectedURIforV1, b.get(v1).getURI() );
-		assertEquals( expectedURIforV2, b.get(v2).getURI() );
-		assertEquals( expectedURIforV3, b.get(v3).getURI() );
 	}
 
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/TestsForSolutionMappingsIndex.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/TestsForSolutionMappingsIndex.java
@@ -3,7 +3,14 @@ package se.liu.ida.hefquin.engine.datastructures.impl;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.binding.Binding;
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
+
+import java.util.Iterator;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * This is a class with helper functions for testing SolutionMappingsIndex
@@ -79,4 +86,33 @@ public class TestsForSolutionMappingsIndex
 
 		return solMHashTable;
 	}
+
+	protected void assertHasNext( final Iterator<SolutionMapping> it,
+								  final String expectedURIforV1, final Var v1,
+								  final String expectedURIforV2, final Var v2 )
+	{
+		assertTrue( it.hasNext() );
+
+		final Binding b = it.next().asJenaBinding();
+		assertEquals( 2, b.size() );
+
+		assertEquals( expectedURIforV1, b.get(v1).getURI() );
+		assertEquals( expectedURIforV2, b.get(v2).getURI() );
+	}
+
+	protected void assertHasNext( final Iterator<SolutionMapping> it,
+								  final String expectedURIforV1, final Var v1,
+								  final String expectedURIforV2, final Var v2,
+								  final String expectedURIforV3, final Var v3 )
+	{
+		assertTrue( it.hasNext() );
+
+		final Binding b = it.next().asJenaBinding();
+		assertEquals( 3, b.size() );
+
+		assertEquals( expectedURIforV1, b.get(v1).getURI() );
+		assertEquals( expectedURIforV2, b.get(v2).getURI() );
+		assertEquals( expectedURIforV3, b.get(v3).getURI() );
+	}
+
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/TestsForSolutionMappingsIndex.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/TestsForSolutionMappingsIndex.java
@@ -1,0 +1,82 @@
+package se.liu.ida.hefquin.engine.datastructures.impl;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.Var;
+import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
+
+/**
+ * This is a class with helper functions for testing SolutionMappingsIndex
+ */
+public class TestsForSolutionMappingsIndex
+{
+	final Var var1 = Var.alloc("v1");
+	final Var var2 = Var.alloc("v2");
+	final Var var3 = Var.alloc("v3");
+	final Var var4 = Var.alloc("v4");
+
+	final Node x1 = NodeFactory.createURI("http://example.org/x1");
+	final Node x2 = NodeFactory.createURI("http://example.org/x2");
+	final Node x3 = NodeFactory.createURI("http://example.org/x3");
+	final Node y1 = NodeFactory.createURI("http://example.org/y1");
+	final Node y2 = NodeFactory.createURI("http://example.org/y2");
+	final Node y3 = NodeFactory.createURI("http://example.org/y3");
+	final Node z1 = NodeFactory.createURI("http://example.org/z1");
+	final Node z2 = NodeFactory.createURI("http://example.org/z2");
+	final Node z3 = NodeFactory.createURI("http://example.org/z3");
+	final Node p = NodeFactory.createURI("http://example.org/p");
+
+	protected SolutionMappingsIndexBase createHashTableBasedOneVar()
+	{
+		final SolutionMappingsIndexBase solMHashTable = new SolutionMappingsHashTableBasedOnOneVar(var2);
+		solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+				var2, y1,
+				var3, z1) );
+		solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+				var2, y1,
+				var3, z2) );
+		solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+				var2, y2,
+				var3, z3) );
+
+		return solMHashTable;
+	}
+
+	protected SolutionMappingsIndexBase createHashTableBasedTwoVars()
+	{
+		final SolutionMappingsIndexBase solMHashTable = new SolutionMappingsHashTableBasedOnTwoVars(var1, var2);
+		solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+				var1, x1,
+				var2, y1,
+				var3, z1) );
+		solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+				var1, x1,
+				var2, y1,
+				var3, z2) );
+		solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+				var1, x2,
+				var2, y2,
+				var3, z2) );
+
+		return solMHashTable;
+	}
+
+	protected SolutionMappingsIndexBase createHashTableBasedThreeVars()
+	{
+		final SolutionMappingsHashTable solMHashTable = new SolutionMappingsHashTable(var1, var2, var3);
+		solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+				var1, x1,
+				var2, y1,
+				var3, z1) );
+		solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+				var1, x1,
+				var2, y1,
+				var3, z2) );
+		solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
+				var1, x2,
+				var2, y2,
+				var3, z2) );
+
+		return solMHashTable;
+	}
+}

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/TestsForSolutionMappingsIndex.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/TestsForSolutionMappingsIndex.java
@@ -6,6 +6,7 @@ import org.apache.jena.sparql.core.Var;
 
 import se.liu.ida.hefquin.engine.EngineTestBase;
 import se.liu.ida.hefquin.engine.data.impl.SolutionMappingUtils;
+import se.liu.ida.hefquin.engine.datastructures.SolutionMappingsIndex;
 
 /**
  * This is a class with helper functions for testing SolutionMappingsIndex
@@ -28,9 +29,9 @@ public abstract class TestsForSolutionMappingsIndex extends EngineTestBase
 	final Node z3 = NodeFactory.createURI("http://example.org/z3");
 	final Node p = NodeFactory.createURI("http://example.org/p");
 
-	protected SolutionMappingsIndexBase createHashTableBasedOneVar()
+	protected SolutionMappingsIndex createHashTableBasedOneVar()
 	{
-		final SolutionMappingsIndexBase solMHashTable = new SolutionMappingsHashTableBasedOnOneVar(var2);
+		final SolutionMappingsIndex solMHashTable = new SolutionMappingsHashTableBasedOnOneVar(var2);
 		solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
 				var2, y1,
 				var3, z1) );
@@ -44,9 +45,9 @@ public abstract class TestsForSolutionMappingsIndex extends EngineTestBase
 		return solMHashTable;
 	}
 
-	protected SolutionMappingsIndexBase createHashTableBasedTwoVars()
+	protected SolutionMappingsIndex createHashTableBasedTwoVars()
 	{
-		final SolutionMappingsIndexBase solMHashTable = new SolutionMappingsHashTableBasedOnTwoVars(var1, var2);
+		final SolutionMappingsIndex solMHashTable = new SolutionMappingsHashTableBasedOnTwoVars(var1, var2);
 		solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
 				var1, x1,
 				var2, y1,
@@ -63,9 +64,9 @@ public abstract class TestsForSolutionMappingsIndex extends EngineTestBase
 		return solMHashTable;
 	}
 
-	protected SolutionMappingsIndexBase createHashTableBasedThreeVars()
+	protected SolutionMappingsIndex createHashTableBasedThreeVars()
 	{
-		final SolutionMappingsHashTable solMHashTable = new SolutionMappingsHashTable(var1, var2, var3);
+		final SolutionMappingsIndex solMHashTable = new SolutionMappingsHashTable(var1, var2, var3);
 		solMHashTable.add( SolutionMappingUtils.createSolutionMapping(
 				var1, x1,
 				var2, y1,

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/pullbased/SolutionMappingsHashTableTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/pullbased/SolutionMappingsHashTableTest.java
@@ -183,7 +183,7 @@ public class SolutionMappingsHashTableTest {
 
         assertTrue( it.hasNext() );
         final Binding b3 = it.next().asJenaBinding();
-        assertEquals( 3, b2.size() );
+        assertEquals( 3, b3.size() );
 
         assertFalse( it.hasNext() );
 
@@ -290,8 +290,8 @@ public class SolutionMappingsHashTableTest {
     @Test
     public void hashTableWithEmptyInputVariable() {
 
-        final Set<Var> inputVars = new HashSet<>();
-        assertThrows(IllegalArgumentException.class,
+        final List<Var> inputVars = Arrays.asList(); // create an empty list
+        assertThrows(AssertionError.class,
                 ()->{ new SolutionMappingsHashTable(inputVars); });
     }
 }


### PR DESCRIPTION
This PR brings some restructuring and improvements (functionality, potential performance issues, source code documentation) for the hash-table implementations of `SolutionMappingsIndex`.

The previous implementation was generic in the sense that it included functionality that would be needed only in specific cases (checking for compatibility after doing the actual index look-ups, creating and returning copies of the index buckets to ensure that nothing unexpected happens in cases in which there is a concurrent thread that writes to these buckets while another thread still consumes the result from the index). In cases in which this functionality would not be needed, it adds an unnecessary overhead in terms of performance. Therefore, I have separated the functionalities into different classes that can be plugged into one another depending on the specific situation in which they are used. Additionally, I have implemented all the `findSolutionMappings` methods.

There are still a few TODOs remaining in this PR:
* [ ] Currently, the unit tests still fail (and, in fact, need some work to cover the different implementations).
* [ ] The two operators that use these indexes need to be extended to use the classes in the best possible way.

This PR is related to #10 

/cc @chengsijin0817 