### PR TITLE
Upgraded to Jena version 4.0.0. Fixed imports and removed deprecated …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,12 @@
 		<groupId>org.apache.jena</groupId>
 		<artifactId>apache-jena-libs</artifactId>
 		<type>pom</type>
-		<version>4.0.0</version>
+		<version>4.1.0</version>
 	</dependency>
 	<dependency>
 		<groupId>org.apache.jena</groupId>
 		<artifactId>jena-cmds</artifactId>
-		<version>4.0.0</version>
+		<version>4.1.0</version>
 	</dependency>
 <!--
 	<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -4,11 +4,11 @@
   <artifactId>HeFQUIN</artifactId>
   <version>0.0.1-SNAPSHOT</version>
 
-  <properties>
-   <maven.compiler.source>1.8</maven.compiler.source>
-   <maven.compiler.target>1.8</maven.compiler.target> 
+  <!--properties>
+   <maven.compiler.source>1.11</maven.compiler.source>
+   <maven.compiler.target>1.11</maven.compiler.target>
    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-  </properties>
+  </properties-->
 
   <dependencies>
 <!--
@@ -38,12 +38,12 @@
 		<groupId>org.apache.jena</groupId>
 		<artifactId>apache-jena-libs</artifactId>
 		<type>pom</type>
-		<version>3.17.0</version>
+		<version>4.0.0</version>
 	</dependency>
 	<dependency>
 		<groupId>org.apache.jena</groupId>
 		<artifactId>jena-cmds</artifactId>
-		<version>3.17.0</version>
+		<version>4.0.0</version>
 	</dependency>
 <!--
 	<dependency>
@@ -122,8 +122,15 @@
           </execution>
         </executions>
       </plugin>
-
-   </plugins>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <version>3.8.0</version>
+            <configuration>
+                <release>11</release>
+            </configuration>
+        </plugin>
+    </plugins>
   </build>
 
 </project>

--- a/src/main/java/se/liu/ida/hefquin/cli/RunQueryWithoutSrcSel.java
+++ b/src/main/java/se/liu/ida/hefquin/cli/RunQueryWithoutSrcSel.java
@@ -1,5 +1,6 @@
 package se.liu.ida.hefquin.cli;
 
+import org.apache.jena.cmd.TerminationException;
 import org.apache.jena.query.ARQ;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
@@ -14,7 +15,6 @@ import org.apache.jena.sparql.util.QueryExecUtils;
 import arq.cmdline.CmdARQ;
 import arq.cmdline.ModResultsOut;
 import arq.cmdline.ModTime;
-import jena.cmd.TerminationException;
 import se.liu.ida.hefquin.cli.modules.ModFederation;
 import se.liu.ida.hefquin.cli.modules.ModQuery;
 import se.liu.ida.hefquin.engine.federation.BRTPFServer;

--- a/src/main/java/se/liu/ida/hefquin/cli/modules/ModFederation.java
+++ b/src/main/java/se/liu/ida/hefquin/cli/modules/ModFederation.java
@@ -6,10 +6,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import jena.cmd.ArgDecl;
-import jena.cmd.CmdArgModule;
-import jena.cmd.CmdGeneral;
-import jena.cmd.ModBase;
+import org.apache.jena.cmd.ArgDecl;
+import org.apache.jena.cmd.CmdArgModule;
+import org.apache.jena.cmd.CmdGeneral;
+import org.apache.jena.cmd.ModBase;
 import se.liu.ida.hefquin.engine.federation.FederationMember;
 import se.liu.ida.hefquin.engine.federation.SPARQLEndpoint;
 import se.liu.ida.hefquin.engine.federation.access.SPARQLEndpointInterface;

--- a/src/main/java/se/liu/ida/hefquin/cli/modules/ModQuery.java
+++ b/src/main/java/se/liu/ida/hefquin/cli/modules/ModQuery.java
@@ -1,9 +1,9 @@
 package se.liu.ida.hefquin.cli.modules;
 
+import org.apache.jena.cmd.CmdGeneral;
 import org.apache.jena.query.Syntax;
 
 import arq.cmdline.ModQueryIn;
-import jena.cmd.CmdGeneral;
 
 public class ModQuery extends ModQueryIn
 {

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingUtils.java
@@ -6,10 +6,7 @@ import java.util.Iterator;
 import org.apache.jena.graph.Node;
 import org.apache.jena.query.QuerySolution;
 import org.apache.jena.sparql.core.Var;
-import org.apache.jena.sparql.engine.binding.Binding;
-import org.apache.jena.sparql.engine.binding.BindingFactory;
-import org.apache.jena.sparql.engine.binding.BindingMap;
-import org.apache.jena.sparql.engine.binding.BindingUtils;
+import org.apache.jena.sparql.engine.binding.*;
 
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.data.impl.SolutionMappingImpl;
@@ -30,7 +27,7 @@ public class SolutionMappingUtils
 	 */
 	public static SolutionMapping createSolutionMapping( final QuerySolution s )
 	{
-		return new SolutionMappingImpl( BindingUtils.asBinding(s) );
+		return new SolutionMappingImpl( BindingLib.asBinding(s) );
 	}
 
 	/**
@@ -52,10 +49,10 @@ public class SolutionMappingUtils
 			final Var var1, final Node node1,
 			final Var var2, final Node node2 )
 	{
-		final BindingMap b = BindingFactory.create();
+		final BindingBuilder b = BindingBuilder.create();
 		b.add(var1, node1);
 		b.add(var2, node2);
-		return new SolutionMappingImpl(b);
+		return new SolutionMappingImpl(b.build());
 	}
 
 	/**
@@ -67,11 +64,11 @@ public class SolutionMappingUtils
 			final Var var2, final Node node2,
 			final Var var3, final Node node3 )
 	{
-		final BindingMap b = BindingFactory.create();
+		final BindingBuilder b = BindingBuilder.create();
 		b.add(var1, node1);
 		b.add(var2, node2);
 		b.add(var3, node3);
-		return new SolutionMappingImpl(b);
+		return new SolutionMappingImpl(b.build());
 	}
 
 	/**
@@ -80,7 +77,7 @@ public class SolutionMappingUtils
 	 * they are compatible.
 	 */
 	public static boolean equals( final SolutionMapping m1, final SolutionMapping m2 ) {
-		return BindingUtils.equals( m1.asJenaBinding(), m2.asJenaBinding() );		
+		return BindingLib.equals( m1.asJenaBinding(), m2.asJenaBinding() );
 	}
 
 	/**
@@ -107,7 +104,7 @@ public class SolutionMappingUtils
 	public static SolutionMapping merge( final SolutionMapping m1, final SolutionMapping m2 ) {
 		final Binding b1 = m1.asJenaBinding();
 		final Binding b2 = m2.asJenaBinding();
-		return new SolutionMappingImpl( BindingUtils.merge(b1,b2) );
+		return new SolutionMappingImpl( BindingLib.merge(b1,b2) );
 	}
 
 	/**
@@ -119,7 +116,7 @@ public class SolutionMappingUtils
 	 */
 	public static Binding restrict( final Binding input, final Collection<Var> vars ) {
 		final Iterator<Var> it = input.vars();
-		final BindingMap output = BindingFactory.create();
+		final BindingBuilder output = BindingBuilder.create();
 
 		while ( it.hasNext() ) {
 			final Var var = it.next();
@@ -127,7 +124,7 @@ public class SolutionMappingUtils
 				output.add( var, input.get(var) );
 			}
 		}
-		return output;
+		return output.build();
 	}
 	
 	/**

--- a/src/main/java/se/liu/ida/hefquin/jenaintegration/sparql/engine/main/OpExecutorHeFQUIN.java
+++ b/src/main/java/se/liu/ida/hefquin/jenaintegration/sparql/engine/main/OpExecutorHeFQUIN.java
@@ -223,7 +223,7 @@ public class OpExecutorHeFQUIN extends OpExecutor
 
 	    @Override public void visit(OpExtend opExtend)            { unsupportedOpFound = true; }
 
-	    @Override public void visit(OpFind opFind)                { unsupportedOpFound = true; }
+	    //@Override public void visit(OpFind opFind)                { unsupportedOpFound = true; }
 
 	    @Override public void visit(OpList opList)                { unsupportedOpFound = true; }
 

--- a/src/test/java/se/liu/ida/hefquin/engine/EngineTestBase.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/EngineTestBase.java
@@ -15,6 +15,7 @@ import org.apache.jena.sparql.algebra.Algebra;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.QueryIterator;
 import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.engine.binding.BindingBuilder;
 import org.apache.jena.sparql.engine.binding.BindingFactory;
 import org.apache.jena.sparql.engine.binding.BindingMap;
 
@@ -115,7 +116,7 @@ public abstract class EngineTestBase
 			final List<Triple> triples = getMatchingTriples(tp);
 			final List<SolutionMapping> result = new ArrayList<>();
 			for ( final Triple t : triples ) {
-				final BindingMap b = BindingFactory.create();
+				final BindingBuilder b = BindingBuilder.create();
 				if ( tp.asJenaTriple().getSubject().isVariable() ) {
 					b.add( Var.alloc(tp.asJenaTriple().getSubject()), t.asJenaTriple().getSubject() );
 				}
@@ -125,7 +126,7 @@ public abstract class EngineTestBase
 				if ( tp.asJenaTriple().getObject().isVariable() ) {
 					b.add( Var.alloc(tp.asJenaTriple().getObject()), t.asJenaTriple().getObject() );
 				}
-				result.add( new SolutionMappingImpl(b) );
+				result.add( new SolutionMappingImpl(b.build()) );
 			}
 			return result;
 		}


### PR DESCRIPTION
…API calls. All tests run. It should use Java 11 now.