### PR TITLE
Federation access manager with cache

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/cli/RunQueryWithoutSrcSel.java
+++ b/src/main/java/se/liu/ida/hefquin/cli/RunQueryWithoutSrcSel.java
@@ -24,6 +24,7 @@ import se.liu.ida.hefquin.engine.federation.access.FederationAccessManager;
 import se.liu.ida.hefquin.engine.federation.access.TPFRequest;
 import se.liu.ida.hefquin.engine.federation.access.TPFResponse;
 import se.liu.ida.hefquin.engine.federation.access.impl.AsyncFederationAccessManagerImpl;
+import se.liu.ida.hefquin.engine.federation.access.impl.FederationAccessManagerWithCache;
 import se.liu.ida.hefquin.engine.federation.access.impl.reqproc.*;
 import se.liu.ida.hefquin.jenaintegration.sparql.HeFQUINConstants;
 import se.liu.ida.hefquin.jenaintegration.sparql.engine.main.OpExecutorHeFQUIN;
@@ -106,7 +107,9 @@ public class RunQueryWithoutSrcSel extends CmdARQ
 
 		final Neo4jRequestProcessor reqProcNeo4j = new Neo4jRequestProcessorImpl();
 
-		return new AsyncFederationAccessManagerImpl(reqProcSPARQL, reqProcTPF, reqProcBRTPF, reqProcNeo4j);
+		final FederationAccessManager fedAccessMgrWithoutCache = new AsyncFederationAccessManagerImpl(reqProcSPARQL, reqProcTPF, reqProcBRTPF, reqProcNeo4j);
+		final FederationAccessManager fedAccessMgrWithCache = new FederationAccessManagerWithCache(fedAccessMgrWithoutCache, 100);
+		return fedAccessMgrWithCache;
     }
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/datastructures/impl/cache/CacheEntryBaseFactory.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/datastructures/impl/cache/CacheEntryBaseFactory.java
@@ -1,0 +1,13 @@
+package se.liu.ida.hefquin.engine.datastructures.impl.cache;
+
+/**
+ * An implementation of {@link CacheEntryFactory} for {@link CacheEntryBase} objects.
+ */
+public class CacheEntryBaseFactory<ObjectType> implements CacheEntryFactory<CacheEntryBase<ObjectType>, ObjectType>
+{
+	@Override
+	public CacheEntryBase<ObjectType> createCacheEntry( final ObjectType obj ) {
+		return new CacheEntryBase<>(obj);
+	}
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/FederationAccessManagerWithCache.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/FederationAccessManagerWithCache.java
@@ -4,98 +4,175 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
+import se.liu.ida.hefquin.engine.datastructures.Cache;
+import se.liu.ida.hefquin.engine.datastructures.impl.cache.CacheEntry;
+import se.liu.ida.hefquin.engine.datastructures.impl.cache.CachePolicies;
+import se.liu.ida.hefquin.engine.datastructures.impl.cache.GenericCacheImpl;
 import se.liu.ida.hefquin.engine.federation.BRTPFServer;
+import se.liu.ida.hefquin.engine.federation.FederationMember;
 import se.liu.ida.hefquin.engine.federation.Neo4jServer;
 import se.liu.ida.hefquin.engine.federation.SPARQLEndpoint;
 import se.liu.ida.hefquin.engine.federation.TPFServer;
 import se.liu.ida.hefquin.engine.federation.access.*;
 import se.liu.ida.hefquin.engine.query.TriplePattern;
+import se.liu.ida.hefquin.engine.utils.Pair;
 
-public class FederationAccessManagerWithCache implements FederationAccessManager 
+public class FederationAccessManagerWithCache implements FederationAccessManager
 {
 	protected final FederationAccessManager fedAccMan;
 	protected final Map<TriplePattern, CompletableFuture<CardinalityResponse>> cacheMap = new HashMap<>();
-	
-	public FederationAccessManagerWithCache(final FederationAccessManager fedAccMan) 
+	protected final Cache<Key, CompletableFuture<? extends DataRetrievalResponse>> cache;
+
+	public FederationAccessManagerWithCache( final FederationAccessManager fedAccMan,
+	                                         final int cacheCapacity,
+	                                         final CachePolicies<Key, CompletableFuture<? extends DataRetrievalResponse>, ? extends CacheEntry<CompletableFuture<? extends DataRetrievalResponse>>> cachePolicies ) 
 	{
 		assert fedAccMan != null;
 		this.fedAccMan = fedAccMan;
+
+		cache = new GenericCacheImpl<>(cacheCapacity, cachePolicies);
 	}
-	
+
+	@SuppressWarnings("unchecked")
 	@Override
 	public CompletableFuture<SolMapsResponse> issueRequest(final SPARQLRequest req, final SPARQLEndpoint fm)
 			throws FederationAccessException 
 	{
-		return fedAccMan.issueRequest(req, fm);
+		final Key key = new Key(req, fm);
+		final CompletableFuture<? extends DataRetrievalResponse> cachedResponse = cache.get(key);
+		if ( cachedResponse != null )
+			return (CompletableFuture<SolMapsResponse>) cachedResponse;
+
+		final CompletableFuture<SolMapsResponse> newResponse = fedAccMan.issueRequest(req, fm);
+		cache.put(key, newResponse);
+		return newResponse;
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public CompletableFuture<TPFResponse> issueRequest(final TPFRequest req, final TPFServer fm) 
 			throws FederationAccessException 
 	{
-		return fedAccMan.issueRequest(req, fm);
+		final Key key = new Key(req, fm);
+		final CompletableFuture<? extends DataRetrievalResponse> cachedResponse = cache.get(key);
+		if ( cachedResponse != null )
+			return (CompletableFuture<TPFResponse>) cachedResponse;
+
+		final CompletableFuture<TPFResponse> newResponse = fedAccMan.issueRequest(req, fm);
+		cache.put(key, newResponse);
+		return newResponse;
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public CompletableFuture<TPFResponse> issueRequest(final TPFRequest req, final BRTPFServer fm)
 			throws FederationAccessException 
 	{
-		return fedAccMan.issueRequest(req, fm);
+		final Key key = new Key(req, fm);
+		final CompletableFuture<? extends DataRetrievalResponse> cachedResponse = cache.get(key);
+		if ( cachedResponse != null )
+			return (CompletableFuture<TPFResponse>) cachedResponse;
+
+		final CompletableFuture<TPFResponse> newResponse = fedAccMan.issueRequest(req, fm);
+		cache.put(key, newResponse);
+		return newResponse;
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public CompletableFuture<TPFResponse> issueRequest(final BRTPFRequest req, final BRTPFServer fm)
 			throws FederationAccessException 
 	{
-		return fedAccMan.issueRequest(req, fm);
+		final Key key = new Key(req, fm);
+		final CompletableFuture<? extends DataRetrievalResponse> cachedResponse = cache.get(key);
+		if ( cachedResponse != null )
+			return (CompletableFuture<TPFResponse>) cachedResponse;
+
+		final CompletableFuture<TPFResponse> newResponse = fedAccMan.issueRequest(req, fm);
+		cache.put(key, newResponse);
+		return newResponse;
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public CompletableFuture<RecordsResponse> issueRequest(final Neo4jRequest req, final Neo4jServer fm)
 			throws FederationAccessException 
 	{
-		return fedAccMan.issueRequest(req, fm);
+		final Key key = new Key(req, fm);
+		final CompletableFuture<? extends DataRetrievalResponse> cachedResponse = cache.get(key);
+		if ( cachedResponse != null )
+			return (CompletableFuture<RecordsResponse>) cachedResponse;
+
+		final CompletableFuture<RecordsResponse> newResponse = fedAccMan.issueRequest(req, fm);
+		cache.put(key, newResponse);
+		return newResponse;
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public CompletableFuture<CardinalityResponse> issueCardinalityRequest(final SPARQLRequest req, final SPARQLEndpoint fm)
 			throws FederationAccessException 
 	{
-		return fedAccMan.issueCardinalityRequest(req, fm);
+		final Key key = new Key(req, fm);
+		final CompletableFuture<? extends DataRetrievalResponse> cachedResponse = cache.get(key);
+		if ( cachedResponse != null )
+			return (CompletableFuture<CardinalityResponse>) cachedResponse;
+
+		final CompletableFuture<CardinalityResponse> newResponse = fedAccMan.issueCardinalityRequest(req, fm);
+		cache.put(key, newResponse);
+		return newResponse;
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public CompletableFuture<CardinalityResponse> issueCardinalityRequest(final TPFRequest req, final TPFServer fm)
 			throws FederationAccessException 
 	{
-		final CompletableFuture<CardinalityResponse> cacheResponse = cacheMap.get(req.getQueryPattern());
-		if (cacheResponse == null) {
-			final CompletableFuture<CardinalityResponse> newFutureResponse = fedAccMan.issueCardinalityRequest(req, fm);
-			addResultToCache(req.getQueryPattern(), newFutureResponse);
-			return newFutureResponse;
-		}
-		else {
-			return cacheResponse;
-		}
+		final Key key = new Key(req, fm);
+		final CompletableFuture<? extends DataRetrievalResponse> cachedResponse = cache.get(key);
+		if ( cachedResponse != null )
+			return (CompletableFuture<CardinalityResponse>) cachedResponse;
+
+		final CompletableFuture<CardinalityResponse> newResponse = fedAccMan.issueCardinalityRequest(req, fm);
+		cache.put(key, newResponse);
+		return newResponse;
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public CompletableFuture<CardinalityResponse> issueCardinalityRequest(final TPFRequest req, final BRTPFServer fm)
 			throws FederationAccessException 
 	{
-		return fedAccMan.issueCardinalityRequest(req, fm);
+		final Key key = new Key(req, fm);
+		final CompletableFuture<? extends DataRetrievalResponse> cachedResponse = cache.get(key);
+		if ( cachedResponse != null )
+			return (CompletableFuture<CardinalityResponse>) cachedResponse;
+
+		final CompletableFuture<CardinalityResponse> newResponse = fedAccMan.issueCardinalityRequest(req, fm);
+		cache.put(key, newResponse);
+		return newResponse;
 	}
 
+	@SuppressWarnings("unchecked")
 	@Override
 	public CompletableFuture<CardinalityResponse> issueCardinalityRequest(final BRTPFRequest req, final BRTPFServer fm)
 			throws FederationAccessException 
 	{
-		return fedAccMan.issueCardinalityRequest(req, fm);
+		final Key key = new Key(req, fm);
+		final CompletableFuture<? extends DataRetrievalResponse> cachedResponse = cache.get(key);
+		if ( cachedResponse != null )
+			return (CompletableFuture<CardinalityResponse>) cachedResponse;
+
+		final CompletableFuture<CardinalityResponse> newResponse = fedAccMan.issueCardinalityRequest(req, fm);
+		cache.put(key, newResponse);
+		return newResponse;
 	}
-	
-	
-	protected void addResultToCache(final TriplePattern tp, final CompletableFuture<CardinalityResponse> response) 
-	{
-		cacheMap.put(tp, response);
+
+
+	protected static class Key extends Pair<DataRetrievalRequest, FederationMember> {
+		public Key( final DataRetrievalRequest req, final FederationMember fm ) {
+			super(req, fm);
+		}
 	}
+
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/cache/GenericCacheImplTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/datastructures/impl/cache/GenericCacheImplTest.java
@@ -147,12 +147,7 @@ public class GenericCacheImplTest
 			}
 		};
 
-		protected final CacheEntryFactory<CacheEntryBase<String>, String> ef = new CacheEntryFactory<CacheEntryBase<String>, String>() {
-			@Override
-			public CacheEntryBase<String> createCacheEntry( final String obj ) {
-				return new CacheEntryBase<String>(obj);
-			}
-		};
+		protected final CacheEntryFactory<CacheEntryBase<String>, String> ef = new CacheEntryBaseFactory<String>();
 
 		@Override
 		public CacheReplacementPolicyFactory<Integer, String, CacheEntryBase<String>> getReplacementPolicyFactory() {

--- a/src/test/java/se/liu/ida/hefquin/engine/federation/access/impl/AsyncFederationAccessManagerImplTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/federation/access/impl/AsyncFederationAccessManagerImplTest.java
@@ -40,7 +40,7 @@ public class AsyncFederationAccessManagerImplTest extends EngineTestBase
 		final TPFServer fm1 = new TPFServerForTest();
 		final TPFServer fm2 = new TPFServerForTest();
 
-		final FederationAccessManager fedAccessMgr = createFedAccessMgr(SLEEP_MILLIES);
+		final FederationAccessManager fedAccessMgr = createFedAccessMgrForTests(SLEEP_MILLIES);
 
 		final long startTime = new Date().getTime();
 
@@ -69,7 +69,7 @@ public class AsyncFederationAccessManagerImplTest extends EngineTestBase
 		final TPFServer fm1 = new TPFServerForTest();
 		final TPFServer fm2 = new TPFServerForTest();
 
-		final FederationAccessManager fedAccessMgr = createFedAccessMgr(SLEEP_MILLIES);
+		final FederationAccessManager fedAccessMgr = createFedAccessMgrForTests(SLEEP_MILLIES);
 
 		final long startTime = new Date().getTime();
 
@@ -101,7 +101,7 @@ public class AsyncFederationAccessManagerImplTest extends EngineTestBase
 			fms[i] = new TPFServerForTest();
 		}
 
-		final FederationAccessManager fedAccessMgr = createFedAccessMgr(SLEEP_MILLIES);
+		final FederationAccessManager fedAccessMgr = createFedAccessMgrForTests(SLEEP_MILLIES);
 
 		@SuppressWarnings("unchecked")
 		final CompletableFuture<TPFResponse>[] futures = new CompletableFuture[n];
@@ -123,7 +123,7 @@ public class AsyncFederationAccessManagerImplTest extends EngineTestBase
 
 	// ------------ helper code ------------
 
-	protected FederationAccessManager createFedAccessMgr( final long sleepMillis ) {
+	public static FederationAccessManager createFedAccessMgrForTests( final long sleepMillis ) {
 		final SPARQLRequestProcessor reqProc = new MySPARQLRequestProcessor(sleepMillis);
 		final TPFRequestProcessor reqProcTPF = new MyTPFRequestProcessor(sleepMillis);
 		final BRTPFRequestProcessor reqProcBRTPF = new BRTPFRequestProcessor() {

--- a/src/test/java/se/liu/ida/hefquin/engine/federation/access/impl/FederationAccessManagerBase1Test.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/federation/access/impl/FederationAccessManagerBase1Test.java
@@ -24,7 +24,6 @@ import se.liu.ida.hefquin.engine.federation.TPFServer;
 import se.liu.ida.hefquin.engine.federation.access.*;
 import se.liu.ida.hefquin.engine.federation.access.impl.req.SPARQLRequestImpl;
 import se.liu.ida.hefquin.engine.federation.access.impl.req.TPFRequestImpl;
-import se.liu.ida.hefquin.engine.federation.access.impl.response.RecordsResponseImpl;
 import se.liu.ida.hefquin.engine.federation.access.impl.response.SolMapsResponseImpl;
 import se.liu.ida.hefquin.engine.federation.access.impl.response.TPFResponseImpl;
 import se.liu.ida.hefquin.engine.query.TriplePattern;
@@ -141,15 +140,15 @@ public class FederationAccessManagerBase1Test extends EngineTestBase
 	// ------------ helper code ------------
 
 	protected FederationAccessManager createMyFedAccessMgr( final int card ) {
-		return new MyFederationAccessManager(Integer.valueOf(card), SLEEP_MILLIES);
+		return new MyFederationAccessManagerForTests(Integer.valueOf(card), SLEEP_MILLIES);
 	}
 
-	protected class MyFederationAccessManager extends FederationAccessManagerBase1
+	protected class MyFederationAccessManagerForTests extends FederationAccessManagerBase1
 	{
 		protected final Integer card;
 		protected final long sleepMillis;
 
-		public MyFederationAccessManager( final Integer card, final long sleepMillis ) {
+		public MyFederationAccessManagerForTests( final Integer card, final long sleepMillis ) {
 			this.card = card;
 			this.sleepMillis = sleepMillis;
 		}

--- a/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/cardinality/CardinalityEstimationImplTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/cardinality/CardinalityEstimationImplTest.java
@@ -37,7 +37,7 @@ public class CardinalityEstimationImplTest extends EngineTestBase
 
 	@Test
 	public void oneRequestOp() throws InterruptedException, ExecutionException {
-		final FederationAccessManager fedAccessMgr = new MyFederationAccessManager();
+		final FederationAccessManager fedAccessMgr = new MyFederationAccessManagerForTests();
 		final CardinalityEstimation cardEstimator = new CardinalityEstimationImpl(fedAccessMgr);
 
 		final CompletableFuture<Integer> f = initEstimateForRequestPlan(42, cardEstimator);
@@ -48,7 +48,7 @@ public class CardinalityEstimationImplTest extends EngineTestBase
 
 	@Test
 	public void twoRequestOpsInParallel() throws InterruptedException, ExecutionException {
-		final FederationAccessManager fedAccessMgr = new MyFederationAccessManager(SLEEP_MILLIES);
+		final FederationAccessManager fedAccessMgr = new MyFederationAccessManagerForTests(SLEEP_MILLIES);
 		final CardinalityEstimation cardEstimator = new CardinalityEstimationImpl(fedAccessMgr);
 
 		final PhysicalPlan plan1 = createRequestPlan(42);
@@ -71,7 +71,7 @@ public class CardinalityEstimationImplTest extends EngineTestBase
 
 	@Test
 	public void twoRequestOpsInSequence() throws InterruptedException, ExecutionException {
-		final FederationAccessManager fedAccessMgr = new MyFederationAccessManager(SLEEP_MILLIES);
+		final FederationAccessManager fedAccessMgr = new MyFederationAccessManagerForTests(SLEEP_MILLIES);
 		final CardinalityEstimation cardEstimator = new CardinalityEstimationImpl(fedAccessMgr);
 
 		final PhysicalPlan plan1 = createRequestPlan(42);
@@ -94,7 +94,7 @@ public class CardinalityEstimationImplTest extends EngineTestBase
 
 	@Test
 	public void sameRequestOpTwiceInParallel() throws InterruptedException, ExecutionException {
-		final FederationAccessManager fedAccessMgr = new MyFederationAccessManager(SLEEP_MILLIES);
+		final FederationAccessManager fedAccessMgr = new MyFederationAccessManagerForTests(SLEEP_MILLIES);
 		final CardinalityEstimation cardEstimator = new CardinalityEstimationImpl(fedAccessMgr);
 
 		final PhysicalPlan plan = createRequestPlan(42);
@@ -116,7 +116,7 @@ public class CardinalityEstimationImplTest extends EngineTestBase
 
 	@Test
 	public void sameRequestOpTwiceInSequence() throws InterruptedException, ExecutionException {
-		final FederationAccessManager fedAccessMgr = new MyFederationAccessManager(SLEEP_MILLIES);
+		final FederationAccessManager fedAccessMgr = new MyFederationAccessManagerForTests(SLEEP_MILLIES);
 		final CardinalityEstimation cardEstimator = new CardinalityEstimationImpl(fedAccessMgr);
 
 		final PhysicalPlan plan = createRequestPlan(42);
@@ -138,7 +138,7 @@ public class CardinalityEstimationImplTest extends EngineTestBase
 
 	@Test
 	public void joinOfTwoRequestOps() throws InterruptedException, ExecutionException {
-		final FederationAccessManager fedAccessMgr = new MyFederationAccessManager(SLEEP_MILLIES);
+		final FederationAccessManager fedAccessMgr = new MyFederationAccessManagerForTests(SLEEP_MILLIES);
 		final CardinalityEstimation cardEstimator = new CardinalityEstimationImpl(fedAccessMgr);
 
 		final PhysicalPlan plan = createJoinPlan(42, 13);
@@ -156,7 +156,7 @@ public class CardinalityEstimationImplTest extends EngineTestBase
 
 	@Test
 	public void joinOfSameRequestOp() throws InterruptedException, ExecutionException {
-		final FederationAccessManager fedAccessMgr = new MyFederationAccessManager(SLEEP_MILLIES);
+		final FederationAccessManager fedAccessMgr = new MyFederationAccessManagerForTests(SLEEP_MILLIES);
 		final CardinalityEstimation cardEstimator = new CardinalityEstimationImpl(fedAccessMgr);
 
 		final PhysicalPlan plan = createJoinPlan(42, 42);
@@ -174,7 +174,7 @@ public class CardinalityEstimationImplTest extends EngineTestBase
 
 	@Test
 	public void oneTPAdd() throws InterruptedException, ExecutionException {
-		final FederationAccessManager fedAccessMgr = new MyFederationAccessManager(SLEEP_MILLIES);
+		final FederationAccessManager fedAccessMgr = new MyFederationAccessManagerForTests(SLEEP_MILLIES);
 		final CardinalityEstimation cardEstimator = new CardinalityEstimationImpl(fedAccessMgr);
 
 		final PhysicalPlan plan = createTPAddPlan(42, 13);
@@ -192,7 +192,7 @@ public class CardinalityEstimationImplTest extends EngineTestBase
 
 	@Test
 	public void twoTPAdd() throws InterruptedException, ExecutionException {
-		final FederationAccessManager fedAccessMgr = new MyFederationAccessManager(SLEEP_MILLIES);
+		final FederationAccessManager fedAccessMgr = new MyFederationAccessManagerForTests(SLEEP_MILLIES);
 		final CardinalityEstimation cardEstimator = new CardinalityEstimationImpl(fedAccessMgr);
 
 		final PhysicalPlan subplan = createTPAddPlan(42, 13);
@@ -273,15 +273,15 @@ public class CardinalityEstimationImplTest extends EngineTestBase
 	}
 
 
-	protected static class MyFederationAccessManager extends FederationAccessManagerForTest
+	protected static class MyFederationAccessManagerForTests extends FederationAccessManagerForTest
 	{
 		protected final long sleepMillis;
 
-		public MyFederationAccessManager( final long sleepMillis ) {
+		public MyFederationAccessManagerForTests( final long sleepMillis ) {
 			this.sleepMillis = sleepMillis;
 		}
 
-		public MyFederationAccessManager() {
+		public MyFederationAccessManagerForTests() {
 			this(0L);
 		}
 


### PR DESCRIPTION
Uses the `Cache` data structure for `FederationAccessManagerWithCache`. This is the minimum needed for #88.

/cc @chengsijin0817 