### PR TITLE
Collect query processing stats

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/cli/RunQueryWithoutSrcSel.java
+++ b/src/main/java/se/liu/ida/hefquin/cli/RunQueryWithoutSrcSel.java
@@ -1,5 +1,6 @@
 package se.liu.ida.hefquin.cli;
 
+import org.apache.jena.cmd.ArgDecl;
 import org.apache.jena.cmd.TerminationException;
 import org.apache.jena.query.Query;
 import org.apache.jena.shared.NotFoundException;
@@ -13,6 +14,8 @@ import se.liu.ida.hefquin.cli.modules.ModFederation;
 import se.liu.ida.hefquin.cli.modules.ModQuery;
 import se.liu.ida.hefquin.engine.HeFQUINEngine;
 import se.liu.ida.hefquin.engine.HeFQUINEngineBuilder;
+import se.liu.ida.hefquin.engine.queryproc.QueryProcStats;
+import se.liu.ida.hefquin.engine.utils.StatsPrinter;
 
 public class RunQueryWithoutSrcSel extends CmdARQ
 {
@@ -21,6 +24,8 @@ public class RunQueryWithoutSrcSel extends CmdARQ
 	protected final ModFederation    modFederation =    new ModFederation();
 	protected final ModResultsOut    modResults =       new ModResultsOut();
 	protected final ModEngineConfig  modEngineConfig =  new ModEngineConfig();
+
+	protected final ArgDecl statsDecl = new ArgDecl(ArgDecl.NoValue, "queryProcStats");
 
 	public static void main( final String... argv ) {
 		new RunQueryWithoutSrcSel(argv).mainRun();
@@ -34,6 +39,8 @@ public class RunQueryWithoutSrcSel extends CmdARQ
 		addModule(modFederation);
 		addModule(modResults);
 		addModule(modEngineConfig);
+
+		add(statsDecl, "--queryProcStats", "Print out statistics about the query execution process");
 	}
 
 	@Override
@@ -53,8 +60,10 @@ public class RunQueryWithoutSrcSel extends CmdARQ
 
 		modTime.startTimer();
 
+		QueryProcStats stats = null;
+
 		try {
-			e.executeQuery(query, resFmt);
+			stats = e.executeQuery(query, resFmt);
 		}
 		catch ( final Exception ex ) {
 			System.out.flush();
@@ -65,6 +74,10 @@ public class RunQueryWithoutSrcSel extends CmdARQ
 		if ( modTime.timingEnabled() ) {
 			final long time = modTime.endTimer();
 			System.err.println("Time: " + modTime.timeStr(time) + " sec");
+		}
+
+		if ( stats != null && contains(statsDecl) ) {
+			StatsPrinter.print(stats, System.err, true);
 		}
 	}
 

--- a/src/main/java/se/liu/ida/hefquin/engine/HeFQUINEngine.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/HeFQUINEngine.java
@@ -5,19 +5,21 @@ import java.io.PrintStream;
 import org.apache.jena.query.Query;
 import org.apache.jena.sparql.resultset.ResultsFormat;
 
+import se.liu.ida.hefquin.engine.queryproc.QueryProcStats;
+
 public interface HeFQUINEngine
 {
-	void executeQuery( Query query, ResultsFormat outputFormat, PrintStream output );
+	QueryProcStats executeQuery( Query query, ResultsFormat outputFormat, PrintStream output );
 
-	default void executeQuery( Query query, ResultsFormat outputFormat ) {
-		executeQuery(query, outputFormat, System.out);
+	default QueryProcStats executeQuery( Query query, ResultsFormat outputFormat ) {
+		return executeQuery(query, outputFormat, System.out);
 	}
 
-	default void executeQuery( Query query, PrintStream output ) {
-		executeQuery(query, ResultsFormat.FMT_TEXT, output);
+	default QueryProcStats executeQuery( Query query, PrintStream output ) {
+		return executeQuery(query, ResultsFormat.FMT_TEXT, output);
 	}
 
-	default void executeQuery( Query query ) {
-		executeQuery(query, ResultsFormat.FMT_TEXT);
+	default QueryProcStats executeQuery( Query query ) {
+		return executeQuery(query, ResultsFormat.FMT_TEXT);
 	}
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/HeFQUINEngineBuilder.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/HeFQUINEngineBuilder.java
@@ -6,6 +6,7 @@ import org.apache.jena.query.ARQ;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
 import org.apache.jena.query.QueryExecutionFactory;
+import org.apache.jena.sparql.core.DatasetGraph;
 import org.apache.jena.sparql.core.DatasetGraphFactory;
 import org.apache.jena.sparql.engine.main.QC;
 import org.apache.jena.sparql.resultset.ResultsFormat;
@@ -27,6 +28,7 @@ import se.liu.ida.hefquin.engine.federation.access.impl.reqproc.SPARQLRequestPro
 import se.liu.ida.hefquin.engine.federation.access.impl.reqproc.SPARQLRequestProcessorImpl;
 import se.liu.ida.hefquin.engine.federation.access.impl.reqproc.TPFRequestProcessor;
 import se.liu.ida.hefquin.engine.federation.catalog.FederationCatalog;
+import se.liu.ida.hefquin.engine.queryproc.QueryProcStats;
 import se.liu.ida.hefquin.jenaintegration.sparql.HeFQUINConstants;
 import se.liu.ida.hefquin.jenaintegration.sparql.engine.main.OpExecutorHeFQUIN;
 
@@ -109,9 +111,12 @@ public class HeFQUINEngineBuilder
 
 	protected static class MyEngine implements HeFQUINEngine {
 		@Override
-		public void executeQuery( final Query query, final ResultsFormat outputFormat, final PrintStream output ) {
-			final QueryExecution qe = QueryExecutionFactory.create( query, DatasetGraphFactory.createGeneral() );
+		public QueryProcStats executeQuery( final Query query, final ResultsFormat outputFormat, final PrintStream output ) {
+			final DatasetGraph dsg = DatasetGraphFactory.createGeneral();
+			final QueryExecution qe = QueryExecutionFactory.create(query, dsg);
 			QueryExecUtils.executeQuery(query, qe, outputFormat, output);
+
+			return (QueryProcStats) qe.getContext().get( HeFQUINConstants.sysQueryProcStats );
 		}
 		
 	}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/ExecutionEngine.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/ExecutionEngine.java
@@ -4,6 +4,6 @@ import se.liu.ida.hefquin.engine.queryplan.ExecutablePlan;
 
 public interface ExecutionEngine
 {
-	void execute( final ExecutablePlan plan, final QueryResultSink resultSink )
+	ExecutionStats execute( final ExecutablePlan plan, final QueryResultSink resultSink )
 			throws ExecutionException;
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/ExecutionStats.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/ExecutionStats.java
@@ -1,0 +1,8 @@
+package se.liu.ida.hefquin.engine.queryproc;
+
+import se.liu.ida.hefquin.engine.utils.Stats;
+
+public interface ExecutionStats extends Stats
+{
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/QueryOptimizationStats.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/QueryOptimizationStats.java
@@ -1,0 +1,8 @@
+package se.liu.ida.hefquin.engine.queryproc;
+
+import se.liu.ida.hefquin.engine.utils.Stats;
+
+public interface QueryOptimizationStats extends Stats
+{
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/QueryOptimizer.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/QueryOptimizer.java
@@ -2,8 +2,9 @@ package se.liu.ida.hefquin.engine.queryproc;
 
 import se.liu.ida.hefquin.engine.queryplan.LogicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.PhysicalPlan;
+import se.liu.ida.hefquin.engine.utils.Pair;
 
 public interface QueryOptimizer
 {
-	PhysicalPlan optimize( final LogicalPlan initialPlan ) throws QueryOptimizationException;
+	Pair<PhysicalPlan, QueryOptimizationStats> optimize( final LogicalPlan initialPlan ) throws QueryOptimizationException;
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/QueryPlanner.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/QueryPlanner.java
@@ -2,10 +2,11 @@ package se.liu.ida.hefquin.engine.queryproc;
 
 import se.liu.ida.hefquin.engine.query.Query;
 import se.liu.ida.hefquin.engine.queryplan.PhysicalPlan;
+import se.liu.ida.hefquin.engine.utils.Pair;
 
 public interface QueryPlanner
 {
-	PhysicalPlan createPlan( final Query query ) throws QueryPlanningException;
+	Pair<PhysicalPlan, QueryPlanningStats> createPlan( final Query query ) throws QueryPlanningException;
 
 	SourcePlanner getSourcePlanner();
 

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/QueryPlanningStats.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/QueryPlanningStats.java
@@ -1,0 +1,13 @@
+package se.liu.ida.hefquin.engine.queryproc;
+
+import se.liu.ida.hefquin.engine.utils.Stats;
+
+public interface QueryPlanningStats extends Stats
+{
+	long getOverallQueryPlanningTime();
+	long getSourcePlanningTime();
+	long getQueryOptimizationTime();
+
+	SourcePlanningStats getSourcePlanningStats();
+	QueryOptimizationStats getQueryOptimizationStats();
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/QueryProcStats.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/QueryProcStats.java
@@ -1,0 +1,14 @@
+package se.liu.ida.hefquin.engine.queryproc;
+
+import se.liu.ida.hefquin.engine.utils.Stats;
+
+public interface QueryProcStats extends Stats
+{
+	long getOverallQueryProcessingTime();
+	long getPlanningTime();
+	long getCompilationTime();
+	long getExecutionTime();
+
+	QueryPlanningStats getQueryPlanningStats();
+	ExecutionStats getExecutionStats();
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/QueryProcessor.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/QueryProcessor.java
@@ -4,7 +4,7 @@ import se.liu.ida.hefquin.engine.query.Query;
 
 public interface QueryProcessor
 {
-	void processQuery( final Query query, final QueryResultSink resultSink )
+	QueryProcStats processQuery( final Query query, final QueryResultSink resultSink )
 			throws QueryProcException;
 
 	QueryPlanner getPlanner();

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/SourcePlanner.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/SourcePlanner.java
@@ -2,6 +2,7 @@ package se.liu.ida.hefquin.engine.queryproc;
 
 import se.liu.ida.hefquin.engine.query.Query;
 import se.liu.ida.hefquin.engine.queryplan.LogicalPlan;
+import se.liu.ida.hefquin.engine.utils.Pair;
 
 public interface SourcePlanner
 {
@@ -12,5 +13,5 @@ public interface SourcePlanner
 	 * multiway joins ({@link LogicalOpMultiwayJoin}), and multiway unions
 	 * ({@link LogicalOpMultiwayUnion}). 
 	 */
-	LogicalPlan createSourceAssignment( final Query query ) throws SourcePlanningException;
+	Pair<LogicalPlan, SourcePlanningStats> createSourceAssignment( final Query query ) throws SourcePlanningException;
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/SourcePlanningStats.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/SourcePlanningStats.java
@@ -1,0 +1,8 @@
+package se.liu.ida.hefquin.engine.queryproc;
+
+import se.liu.ida.hefquin.engine.utils.Stats;
+
+public interface SourcePlanningStats extends Stats
+{
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/QueryProcStatsImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/QueryProcStatsImpl.java
@@ -1,0 +1,63 @@
+package se.liu.ida.hefquin.engine.queryproc.impl;
+
+import se.liu.ida.hefquin.engine.queryproc.ExecutionStats;
+import se.liu.ida.hefquin.engine.queryproc.QueryPlanningStats;
+import se.liu.ida.hefquin.engine.queryproc.QueryProcStats;
+import se.liu.ida.hefquin.engine.utils.StatsImpl;
+
+public class QueryProcStatsImpl extends StatsImpl implements QueryProcStats
+{
+	protected static final String enOverallProcTime     = "overallQueryProcessingTime";
+	protected static final String enPlanningTime        = "planningTime";
+	protected static final String enCompilationTime     = "compilationTime";
+	protected static final String enExecutionTime       = "executionTime";
+	protected static final String enQueryPlanningStats  = "queryPlanningStats";
+	protected static final String enExecStats           = "executionStats";
+
+	public QueryProcStatsImpl( final long overallQueryProcessingTime,
+	                           final long planningTime,
+	                           final long compilationTime,
+	                           final long executionTime,
+	                           final QueryPlanningStats queryPlanningStats,
+	                           final ExecutionStats execStats )
+	{
+		put( enOverallProcTime, Long.valueOf(overallQueryProcessingTime) );
+		put( enPlanningTime,    Long.valueOf(planningTime) );
+		put( enCompilationTime, Long.valueOf(compilationTime) );
+		put( enExecutionTime,   Long.valueOf(executionTime) );
+
+		put( enQueryPlanningStats, queryPlanningStats );
+		put( enExecStats,          execStats );
+	}
+
+	@Override
+	public long getOverallQueryProcessingTime() {
+		return (Long) getEntry(enOverallProcTime);
+	}
+
+	@Override
+	public long getPlanningTime() {
+		return (Long) getEntry(enPlanningTime);
+	}
+
+	@Override
+	public long getCompilationTime() {
+		return (Long) getEntry(enCompilationTime);
+	}
+
+	@Override
+	public long getExecutionTime() {
+		return (Long) getEntry(enExecutionTime);
+	}
+
+	@Override
+	public QueryPlanningStats getQueryPlanningStats() {
+		return (QueryPlanningStats) getEntry(enQueryPlanningStats);
+	}
+
+	@Override
+	public ExecutionStats getExecutionStats() {
+		return (ExecutionStats) getEntry(enExecStats);
+	}
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/QueryProcessorImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/QueryProcessorImpl.java
@@ -4,11 +4,15 @@ import se.liu.ida.hefquin.engine.query.Query;
 import se.liu.ida.hefquin.engine.queryplan.ExecutablePlan;
 import se.liu.ida.hefquin.engine.queryplan.PhysicalPlan;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionEngine;
+import se.liu.ida.hefquin.engine.queryproc.ExecutionStats;
 import se.liu.ida.hefquin.engine.queryproc.QueryPlanCompiler;
 import se.liu.ida.hefquin.engine.queryproc.QueryPlanner;
+import se.liu.ida.hefquin.engine.queryproc.QueryPlanningStats;
 import se.liu.ida.hefquin.engine.queryproc.QueryProcException;
+import se.liu.ida.hefquin.engine.queryproc.QueryProcStats;
 import se.liu.ida.hefquin.engine.queryproc.QueryProcessor;
 import se.liu.ida.hefquin.engine.queryproc.QueryResultSink;
+import se.liu.ida.hefquin.engine.utils.Pair;
 
 /**
  * Simple implementation of {@link QueryProcessor}.
@@ -31,18 +35,31 @@ public class QueryProcessorImpl implements QueryProcessor
 		this.execEngine = execEngine;
 	}
 
+	@Override
 	public QueryPlanner getPlanner() { return planner; }
 
+	@Override
 	public QueryPlanCompiler getPlanCompiler() { return planCompiler; }
 
+	@Override
 	public ExecutionEngine getExecutionEngine() { return execEngine; }
 
-	public void processQuery( final Query query, final QueryResultSink resultSink )
+	@Override
+	public QueryProcStats processQuery( final Query query, final QueryResultSink resultSink )
 			throws QueryProcException
 	{
-		final PhysicalPlan qep = planner.createPlan(query);
-		final ExecutablePlan prg = planCompiler.compile(qep);
-		execEngine.execute(prg, resultSink);
+		final long t1 = System.currentTimeMillis();
+		final Pair<PhysicalPlan, QueryPlanningStats> qepAndStats = planner.createPlan(query);
+
+		final long t2 = System.currentTimeMillis();
+		final ExecutablePlan prg = planCompiler.compile(qepAndStats.object1);
+
+		final long t3 = System.currentTimeMillis();
+		final ExecutionStats execStats = execEngine.execute(prg, resultSink);
+
+		final long t4 = System.currentTimeMillis();
+
+		return new QueryProcStatsImpl( t4-t1, t2-t1, t3-t2, t4-t3, qepAndStats.object2, execStats );
 	}
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/execution/ExecutionEngineImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/execution/ExecutionEngineImpl.java
@@ -3,15 +3,18 @@ package se.liu.ida.hefquin.engine.queryproc.impl.execution;
 import se.liu.ida.hefquin.engine.queryplan.ExecutablePlan;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionEngine;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionException;
+import se.liu.ida.hefquin.engine.queryproc.ExecutionStats;
 import se.liu.ida.hefquin.engine.queryproc.QueryResultSink;
 
 public class ExecutionEngineImpl implements ExecutionEngine
 {
 	@Override
-	public void execute( final ExecutablePlan plan, final QueryResultSink resultSink )
+	public ExecutionStats execute( final ExecutablePlan plan, final QueryResultSink resultSink )
 			throws ExecutionException
 	{
 		plan.run(resultSink);
+
+		return new ExecutionStatsImpl();
 	}
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/execution/ExecutionStatsImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/execution/ExecutionStatsImpl.java
@@ -1,0 +1,9 @@
+package se.liu.ida.hefquin.engine.queryproc.impl.execution;
+
+import se.liu.ida.hefquin.engine.queryproc.ExecutionStats;
+import se.liu.ida.hefquin.engine.utils.StatsImpl;
+
+public class ExecutionStatsImpl extends StatsImpl implements ExecutionStats
+{
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/QueryOptimizationStatsImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/QueryOptimizationStatsImpl.java
@@ -1,0 +1,9 @@
+package se.liu.ida.hefquin.engine.queryproc.impl.optimizer;
+
+import se.liu.ida.hefquin.engine.queryproc.QueryOptimizationStats;
+import se.liu.ida.hefquin.engine.utils.StatsImpl;
+
+public class QueryOptimizationStatsImpl extends StatsImpl implements QueryOptimizationStats
+{
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/QueryOptimizerImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/QueryOptimizerImpl.java
@@ -3,7 +3,9 @@ package se.liu.ida.hefquin.engine.queryproc.impl.optimizer;
 import se.liu.ida.hefquin.engine.queryplan.LogicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.PhysicalPlan;
 import se.liu.ida.hefquin.engine.queryproc.QueryOptimizationException;
+import se.liu.ida.hefquin.engine.queryproc.QueryOptimizationStats;
 import se.liu.ida.hefquin.engine.queryproc.QueryOptimizer;
+import se.liu.ida.hefquin.engine.utils.Pair;
 
 public class QueryOptimizerImpl implements QueryOptimizer
 {
@@ -15,12 +17,15 @@ public class QueryOptimizerImpl implements QueryOptimizer
 	}
 
 	@Override
-	public PhysicalPlan optimize( final LogicalPlan initialPlan )
+	public Pair<PhysicalPlan, QueryOptimizationStats> optimize( final LogicalPlan initialPlan )
 			throws QueryOptimizationException
 	{
 		final boolean keepMultiwayJoins = false;
 		final PhysicalPlan initialPhysicalPlan = ctxt.getLogicalToPhysicalPlanConverter().convert(initialPlan, keepMultiwayJoins);
-		return initialPhysicalPlan;
+
+		final QueryOptimizationStats myStats = new QueryOptimizationStatsImpl();
+
+		return new Pair<>(initialPhysicalPlan, myStats);
 
 		// TODO implement query optimization
 	}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/randomized/RandomizedQueryOptimizerBase.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/randomized/RandomizedQueryOptimizerBase.java
@@ -8,11 +8,14 @@ import java.util.Set;
 import se.liu.ida.hefquin.engine.queryplan.LogicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.PhysicalPlan;
 import se.liu.ida.hefquin.engine.queryproc.QueryOptimizationException;
+import se.liu.ida.hefquin.engine.queryproc.QueryOptimizationStats;
 import se.liu.ida.hefquin.engine.queryproc.QueryOptimizer;
 import se.liu.ida.hefquin.engine.queryproc.impl.optimizer.QueryOptimizationContext;
+import se.liu.ida.hefquin.engine.queryproc.impl.optimizer.QueryOptimizationStatsImpl;
 import se.liu.ida.hefquin.engine.queryproc.impl.optimizer.rewriting.PlanRewritingUtils;
 import se.liu.ida.hefquin.engine.queryproc.impl.optimizer.rewriting.RuleApplication;
 import se.liu.ida.hefquin.engine.queryproc.impl.optimizer.rewriting.RuleInstances;
+import se.liu.ida.hefquin.engine.utils.Pair;
 
 public abstract class RandomizedQueryOptimizerBase implements QueryOptimizer
 {
@@ -30,8 +33,12 @@ public abstract class RandomizedQueryOptimizerBase implements QueryOptimizer
 	}
 
 	@Override
-	public PhysicalPlan optimize( final LogicalPlan initialPlan ) throws QueryOptimizationException {
-		return optimize( context.getLogicalToPhysicalPlanConverter().convert(initialPlan,false) );
+	public Pair<PhysicalPlan, QueryOptimizationStats> optimize( final LogicalPlan initialPlan ) throws QueryOptimizationException {
+		final PhysicalPlan bestPlan = optimize( context.getLogicalToPhysicalPlanConverter().convert(initialPlan,false) );
+
+        final QueryOptimizationStats myStats = new QueryOptimizationStatsImpl();
+
+		return new Pair<>(bestPlan, myStats);		
 	}
 
 	abstract public PhysicalPlan optimize( PhysicalPlan initialPlan ) throws QueryOptimizationException;

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/simple/SimpleJoinOrderingQueryOptimizer.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/simple/SimpleJoinOrderingQueryOptimizer.java
@@ -7,8 +7,11 @@ import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayJoin;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalOperatorForLogicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.utils.PhysicalPlanFactory;
 import se.liu.ida.hefquin.engine.queryproc.QueryOptimizationException;
+import se.liu.ida.hefquin.engine.queryproc.QueryOptimizationStats;
 import se.liu.ida.hefquin.engine.queryproc.QueryOptimizer;
 import se.liu.ida.hefquin.engine.queryproc.impl.optimizer.QueryOptimizationContext;
+import se.liu.ida.hefquin.engine.queryproc.impl.optimizer.QueryOptimizationStatsImpl;
+import se.liu.ida.hefquin.engine.utils.Pair;
 
 /**
  * This class implements a simple query optimizer that focuses only
@@ -34,11 +37,14 @@ public class SimpleJoinOrderingQueryOptimizer implements QueryOptimizer
     }
 
     @Override
-    public PhysicalPlan optimize( final LogicalPlan initialPlan ) throws QueryOptimizationException {
+    public Pair<PhysicalPlan, QueryOptimizationStats> optimize( final LogicalPlan initialPlan ) throws QueryOptimizationException {
         final boolean keepMultiwayJoins = true;
         final PhysicalPlan initialPhysicalPlan = ctxt.getLogicalToPhysicalPlanConverter().convert( initialPlan, keepMultiwayJoins );
+        final PhysicalPlan bestPlan = optimizePlan( initialPhysicalPlan );
 
-        return optimizePlan( initialPhysicalPlan );
+        final QueryOptimizationStats myStats = new QueryOptimizationStatsImpl();
+
+		return new Pair<>(bestPlan, myStats);
     }
 
     public PhysicalPlan optimizePlan( final PhysicalPlan plan ) throws QueryOptimizationException {

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/planning/QueryPlannerImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/planning/QueryPlannerImpl.java
@@ -1,11 +1,16 @@
 package se.liu.ida.hefquin.engine.queryproc.impl.planning;
 
 import se.liu.ida.hefquin.engine.query.Query;
+import se.liu.ida.hefquin.engine.queryplan.LogicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.PhysicalPlan;
+import se.liu.ida.hefquin.engine.queryproc.QueryOptimizationStats;
 import se.liu.ida.hefquin.engine.queryproc.QueryOptimizer;
 import se.liu.ida.hefquin.engine.queryproc.QueryPlanner;
 import se.liu.ida.hefquin.engine.queryproc.QueryPlanningException;
+import se.liu.ida.hefquin.engine.queryproc.QueryPlanningStats;
 import se.liu.ida.hefquin.engine.queryproc.SourcePlanner;
+import se.liu.ida.hefquin.engine.queryproc.SourcePlanningStats;
+import se.liu.ida.hefquin.engine.utils.Pair;
 
 /**
  * Simple implementation of {@link QueryPlanner}.
@@ -24,12 +29,25 @@ public class QueryPlannerImpl implements QueryPlanner
 		this.optimizer = optimizer;
 	}
 
+	@Override
 	public SourcePlanner getSourcePlanner() { return sourcePlanner; }
 
+	@Override
 	public QueryOptimizer getOptimizer() { return optimizer; }
 
-	public PhysicalPlan createPlan( final Query query ) throws QueryPlanningException {
-		return optimizer.optimize( sourcePlanner.createSourceAssignment(query) );
+	@Override
+	public Pair<PhysicalPlan, QueryPlanningStats> createPlan( final Query query ) throws QueryPlanningException {
+		final long t1 = System.currentTimeMillis();
+		final Pair<LogicalPlan, SourcePlanningStats> saAndStats = sourcePlanner.createSourceAssignment(query);
+
+		final long t2 = System.currentTimeMillis();
+		final Pair<PhysicalPlan, QueryOptimizationStats> planAndStats = optimizer.optimize( saAndStats.object1 );
+
+		final long t3 = System.currentTimeMillis();
+
+		final QueryPlanningStats myStats = new QueryPlanningStatsImpl( t3-t1, t2-t1, t3-t2, saAndStats.object2, planAndStats.object2 );
+
+		return new Pair<>(planAndStats.object1, myStats);
 	}
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/planning/QueryPlanningStatsImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/planning/QueryPlanningStatsImpl.java
@@ -1,0 +1,55 @@
+package se.liu.ida.hefquin.engine.queryproc.impl.planning;
+
+import se.liu.ida.hefquin.engine.queryproc.QueryOptimizationStats;
+import se.liu.ida.hefquin.engine.queryproc.QueryPlanningStats;
+import se.liu.ida.hefquin.engine.queryproc.SourcePlanningStats;
+import se.liu.ida.hefquin.engine.utils.StatsImpl;
+
+public class QueryPlanningStatsImpl extends StatsImpl implements QueryPlanningStats
+{
+	protected static final String enOverallPlanningTime  = "overallQueryPlanningTime";
+	protected static final String enSrcPlanningTime      = "sourcePlanningTime";
+	protected static final String enOptimizationTime     = "queryOptimizationTime";
+	protected static final String enSrcPlanningStats     = "sourcePlanningStats";
+	protected static final String enOptimizationStats    = "queryOptimizationStats";
+
+	public QueryPlanningStatsImpl( final long overallQueryPlanningTime,
+	                               final long sourcePlanningTime,
+	                               final long queryOptimizationTime,
+	                               final SourcePlanningStats sourcePlanningStats,
+	                               final QueryOptimizationStats queryOptimizationStats )
+	{
+		put( enOverallPlanningTime, Long.valueOf(overallQueryPlanningTime) );
+		put( enSrcPlanningTime,     Long.valueOf(sourcePlanningTime) );
+		put( enOptimizationTime,    Long.valueOf(queryOptimizationTime) );
+
+		put( enSrcPlanningStats,   sourcePlanningStats );
+		put( enOptimizationStats,  queryOptimizationStats );
+	}
+
+	@Override
+	public long getOverallQueryPlanningTime() {
+		return (Long) getEntry(enOverallPlanningTime);
+	}
+
+	@Override
+	public long getSourcePlanningTime() {
+		return (Long) getEntry(enSrcPlanningTime);
+	}
+
+	@Override
+	public long getQueryOptimizationTime() {
+		return (Long) getEntry(enOptimizationTime);
+	}
+
+	@Override
+	public SourcePlanningStats getSourcePlanningStats() {
+		return (SourcePlanningStats) getEntry(enSrcPlanningStats);
+	}
+
+	@Override
+	public QueryOptimizationStats getQueryOptimizationStats() {
+		return (QueryOptimizationStats) getEntry(enOptimizationStats);
+	}
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/srcsel/SourcePlannerImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/srcsel/SourcePlannerImpl.java
@@ -35,6 +35,8 @@ import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalPlanWithNullaryRo
 import se.liu.ida.hefquin.engine.queryproc.QueryProcContext;
 import se.liu.ida.hefquin.engine.queryproc.SourcePlanner;
 import se.liu.ida.hefquin.engine.queryproc.SourcePlanningException;
+import se.liu.ida.hefquin.engine.queryproc.SourcePlanningStats;
+import se.liu.ida.hefquin.engine.utils.Pair;
 
 public class SourcePlannerImpl implements SourcePlanner
 {
@@ -46,7 +48,7 @@ public class SourcePlannerImpl implements SourcePlanner
 	}
 
 	@Override
-	public LogicalPlan createSourceAssignment( final Query query )
+	public Pair<LogicalPlan, SourcePlanningStats> createSourceAssignment( final Query query )
 			throws SourcePlanningException
 	{
 		// The current implementation here does not actually perform
@@ -57,7 +59,11 @@ public class SourcePlannerImpl implements SourcePlanner
 		// implementation here does is to convert the given query
 		// pattern into a logical plan.
 		final Op jenaOp = ( (SPARQLGraphPattern) query ).asJenaOp();
-		return createPlan(jenaOp);
+		final LogicalPlan sa = createPlan(jenaOp);
+
+		final SourcePlanningStats myStats = new SourcePlanningStatsImpl();
+
+		return new Pair<>(sa, myStats);
 	}
 
 	protected LogicalPlan createPlan( final Op jenaOp ) {

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/srcsel/SourcePlanningStatsImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/srcsel/SourcePlanningStatsImpl.java
@@ -1,0 +1,9 @@
+package se.liu.ida.hefquin.engine.queryproc.impl.srcsel;
+
+import se.liu.ida.hefquin.engine.queryproc.SourcePlanningStats;
+import se.liu.ida.hefquin.engine.utils.StatsImpl;
+
+public class SourcePlanningStatsImpl extends StatsImpl implements SourcePlanningStats
+{
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/utils/Stats.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/utils/Stats.java
@@ -4,4 +4,5 @@ public interface Stats
 {
 	Iterable<String> getEntryNames();
 	Object getEntry(String entryName);
+	boolean isEmpty();
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/utils/Stats.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/utils/Stats.java
@@ -1,0 +1,7 @@
+package se.liu.ida.hefquin.engine.utils;
+
+public interface Stats
+{
+	Iterable<String> getEntryNames();
+	Object getEntry(String entryName);
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/utils/Stats.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/utils/Stats.java
@@ -1,8 +1,25 @@
 package se.liu.ida.hefquin.engine.utils;
 
+/**
+ * An interface for statistics collected during some process or by a data
+ * structure or component. Such statistics consists of multiple entries,
+ * each of which is a name-value pair. Note that a value may be another
+ * {@link Stats} object.
+ */
 public interface Stats
 {
+	/**
+	 * Returns the names of all entries.
+	 */
 	Iterable<String> getEntryNames();
+
+	/**
+	 * Returns the value of the entry with the given name.
+	 */
 	Object getEntry(String entryName);
+
+	/**
+	 * Returns <code>true</code> if there are no entries in this object.
+	 */
 	boolean isEmpty();
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/utils/StatsImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/utils/StatsImpl.java
@@ -1,0 +1,35 @@
+package se.liu.ida.hefquin.engine.utils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class StatsImpl implements Stats
+{
+	private final List<String> entryNames = new ArrayList<>();
+	private final Map<String,Object> entries = new HashMap<>();
+
+	@Override
+	public Iterable<String> getEntryNames() {
+		return entryNames;
+	}
+
+	@Override
+	public Object getEntry( final String entryName ) {
+		final Object entry = entries.get(entryName);
+
+		if ( entry == null )
+			throw new IllegalArgumentException();
+
+		return entry;
+	}
+
+	public Object put( final String entryName, final Object entry ) {
+		final Object old = entries.put(entryName, entry);
+		if ( old == null ) {
+			entryNames.add(entryName);
+		}
+		return old;
+	}
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/utils/StatsImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/utils/StatsImpl.java
@@ -16,7 +16,7 @@ public class StatsImpl implements Stats
 	public Object getEntry( final String entryName ) {
 		final Object entry = entries.get(entryName);
 
-		if ( entry == null )
+		if ( entry == null && ! entries.containsKey(entryName) )
 			throw new IllegalArgumentException();
 
 		return entry;

--- a/src/main/java/se/liu/ida/hefquin/engine/utils/StatsImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/utils/StatsImpl.java
@@ -22,6 +22,11 @@ public class StatsImpl implements Stats
 		return entry;
 	}
 
+	@Override
+	public boolean isEmpty() {
+		return entries.isEmpty();
+	}
+
 	public Object put( final String entryName, final Object entry ) {
 		return entries.put(entryName, entry);
 	}

--- a/src/main/java/se/liu/ida/hefquin/engine/utils/StatsImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/utils/StatsImpl.java
@@ -1,18 +1,15 @@
 package se.liu.ida.hefquin.engine.utils;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class StatsImpl implements Stats
 {
-	private final List<String> entryNames = new ArrayList<>();
-	private final Map<String,Object> entries = new HashMap<>();
+	private final Map<String,Object> entries = new LinkedHashMap<>();
 
 	@Override
 	public Iterable<String> getEntryNames() {
-		return entryNames;
+		return entries.keySet();
 	}
 
 	@Override
@@ -26,10 +23,6 @@ public class StatsImpl implements Stats
 	}
 
 	public Object put( final String entryName, final Object entry ) {
-		final Object old = entries.put(entryName, entry);
-		if ( old == null ) {
-			entryNames.add(entryName);
-		}
-		return old;
+		return entries.put(entryName, entry);
 	}
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/utils/StatsPrinter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/utils/StatsPrinter.java
@@ -1,0 +1,61 @@
+package se.liu.ida.hefquin.engine.utils;
+
+import java.io.PrintStream;
+
+public class StatsPrinter
+{
+	/**
+	 * Prints the given stats to the given print stream.
+	 * 
+	 * Every entry that is a {@link Stats} object itself is
+	 * printed as well if the 'recursive' flag is 'true'.
+	 */
+	public static void print( final Stats s, final PrintStream out, final boolean recursive ) {
+		print(s, out, recursive, 0);
+	}
+
+	/**
+	 * Prints the given stats to the given print stream at the given indentation level.
+	 * 
+	 * Every entry that is a {@link Stats} object itself is
+	 * printed as well if the 'recursive' flag is 'true'.
+	 */
+	public static void print( final Stats s, final PrintStream out, final boolean recursive, final int indentLevel ) {
+		for ( final String entryName : s.getEntryNames() ) {
+			final Object entry = s.getEntry(entryName);
+
+			addTabs(out, indentLevel);
+			out.append(entryName + " : ");
+
+			if ( entry instanceof Stats ) {
+				final Stats ss = (Stats) entry;
+				if ( ss.isEmpty() ) {
+					out.append( "{ }" );
+				}
+				else if ( ! recursive ) {
+					out.append( "{ ... }" );
+				}
+				else {
+					out.append( "{" + System.lineSeparator() );
+					print(ss, out, recursive, indentLevel+1);
+					addTabs(out, indentLevel);
+					out.append( "}" );
+				}
+			}
+			else if ( entry == null) {
+				out.append( "null" );
+			}
+			else {
+				out.append( entry.toString() );
+			}
+			out.append( System.lineSeparator() );	
+		}
+	}
+
+
+    protected static void addTabs( final PrintStream out, final int indentLevel ) {
+        for (int i = 0; i < indentLevel; i++)
+            out.append("  ");
+    }
+
+}

--- a/src/main/java/se/liu/ida/hefquin/jenaintegration/sparql/HeFQUINConstants.java
+++ b/src/main/java/se/liu/ida/hefquin/jenaintegration/sparql/HeFQUINConstants.java
@@ -9,4 +9,6 @@ public class HeFQUINConstants {
     public static final Symbol sysFederationAccessManager = Symbol.create(systemVarNS+"fedAccessMgr");
 
     public static final Symbol sysQueryOptimizerFactory   = Symbol.create(systemVarNS+"optimizerFactory");
+
+    public static final Symbol sysQueryProcStats          = Symbol.create(systemVarNS+"queryProcStats");
 }

--- a/src/main/java/se/liu/ida/hefquin/jenaintegration/sparql/engine/main/OpExecutorHeFQUIN.java
+++ b/src/main/java/se/liu/ida/hefquin/jenaintegration/sparql/engine/main/OpExecutorHeFQUIN.java
@@ -26,6 +26,7 @@ import se.liu.ida.hefquin.engine.queryproc.QueryPlanCompiler;
 import se.liu.ida.hefquin.engine.queryproc.QueryPlanner;
 import se.liu.ida.hefquin.engine.queryproc.QueryProcContext;
 import se.liu.ida.hefquin.engine.queryproc.QueryProcException;
+import se.liu.ida.hefquin.engine.queryproc.QueryProcStats;
 import se.liu.ida.hefquin.engine.queryproc.QueryProcessor;
 import se.liu.ida.hefquin.engine.queryproc.SourcePlanner;
 import se.liu.ida.hefquin.engine.queryproc.impl.MaterializingQueryResultSinkImpl;
@@ -160,13 +161,16 @@ public class OpExecutorHeFQUIN extends OpExecutor
 			}
 
 			final MaterializingQueryResultSinkImpl sink = new MaterializingQueryResultSinkImpl();
+			final QueryProcStats stats;
 
 			try {
-				qProc.processQuery( new SPARQLGraphPatternImpl(opForStage), sink );
+				stats = qProc.processQuery( new SPARQLGraphPatternImpl(opForStage), sink );
 			}
 			catch ( final QueryProcException ex ) {
 				throw new QueryExecException("Processing the query operator using HeFQUIN failed.", ex);
 			}
+
+			execCxt.getContext().set( HeFQUINConstants.sysQueryProcStats, stats );
 
 			return new WrappingQueryIterator( sink.getSolMapsIter() );
 		}

--- a/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/QueryProcStatsImplTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/QueryProcStatsImplTest.java
@@ -31,6 +31,7 @@ public class QueryProcStatsImplTest
 		assertEquals( 1L, s.getCompilationTime() );
 		assertEquals( 2L, s.getExecutionTime() );
 
+		assertEquals( ps, s.getQueryPlanningStats() );
 		assertEquals( es, s.getExecutionStats() );
 
 		assertEquals( 42, s.getEntry("additionalEntry") );

--- a/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/QueryProcStatsImplTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/QueryProcStatsImplTest.java
@@ -1,0 +1,39 @@
+package se.liu.ida.hefquin.engine.queryproc.impl;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+
+import se.liu.ida.hefquin.engine.queryproc.ExecutionStats;
+import se.liu.ida.hefquin.engine.queryproc.QueryPlanningStats;
+import se.liu.ida.hefquin.engine.queryproc.impl.execution.ExecutionStatsImpl;
+
+public class QueryProcStatsImplTest
+{
+	@Test
+	public void test() {
+		final QueryPlanningStats ps = null;
+		final ExecutionStats es = new ExecutionStatsImpl();
+
+		final QueryProcStatsImpl s = new QueryProcStatsImpl(4L, 1L, 1L, 2L, ps, es);
+		s.put( "additionalEntry", Integer.valueOf(42) );
+
+		// check that the entries are in the correct order
+		String lastEntryName = null;
+		for ( final String n : s.getEntryNames() ) {
+			lastEntryName = n;
+		}
+		assertEquals( "additionalEntry", lastEntryName );
+
+		// check the correctness of the entries
+		assertEquals( 4L, s.getOverallQueryProcessingTime() );
+		assertEquals( 1L, s.getPlanningTime() );
+		assertEquals( 1L, s.getCompilationTime() );
+		assertEquals( 2L, s.getExecutionTime() );
+
+		assertEquals( es, s.getExecutionStats() );
+
+		assertEquals( 42, s.getEntry("additionalEntry") );
+	}
+
+}

--- a/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/srcsel/SourcePlannerImplTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/srcsel/SourcePlannerImplTest.java
@@ -155,7 +155,7 @@ public class SourcePlannerImplTest extends EngineTestBase
 
 		final SourcePlanner sourcePlanner = new SourcePlannerImpl(ctxt);
 		final Query query = new SPARQLGraphPatternImpl( QueryFactory.create(queryString).getQueryPattern() );
-		return sourcePlanner.createSourceAssignment(query);
+		return sourcePlanner.createSourceAssignment(query).object1;
 	}
 
 	public static void assertEqualTriplePatternsVUV( final String expectedSubjectVarName,


### PR DESCRIPTION
@chengsijin0817 @scferrada @SHSenpai  just for your info:

This PR introduces a general framework for collecting statistics about various aspects of the engine and corresponding specializations for the components of the query execution process. In more detail, the PR adds the following things:
1. a so-called `Stats` interface as a generic means for all sorts of statistics about all sorts of aspects of the engine
2. a corresponding implementation, `StatsImpl`
3. a helper class (`StatsPrinter`) to print such statistics to a given `PrintStream` (e.g., `System.out`)
4. specializations of the `Stats` interface for the different query processing steps, including corresponding implementations
5. an extension of `HeFQUINEngine` to obtain such query processing stats
6. an extension of the CLI with an option to print such stats (call the CLI with the argument `--queryProcStats`)

Regarding point 4, the main purpose of these specializations of the `Stats` interface for the different query processing steps is to provide helper methods for accessing relevant statistics entries. Think of these entries as general; that is, they are something that can be measured by every implementation of the corresponding query processing step. Note, however, that these are not the only types of entries that can be collected. Instead, further entries can be captured that are specific to a particular implementation of the corresponding query processing step. As an example, for the query optimizer that uses the evolutionary algorithm (`EvolutionaryAlgorithmQueryOptimizer`), I have added an extra entry called "numberOfGenerations".