### PR TITLE
Identify SPARQL request with basic pattern

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/rewriting/rules/IdentifyTypeOfRequestUsedForReq.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/rewriting/rules/IdentifyTypeOfRequestUsedForReq.java
@@ -3,6 +3,10 @@ package se.liu.ida.hefquin.engine.queryproc.impl.optimizer.rewriting.rules;
 import se.liu.ida.hefquin.engine.federation.FederationMember;
 import se.liu.ida.hefquin.engine.federation.SPARQLEndpoint;
 import se.liu.ida.hefquin.engine.federation.access.BGPRequest;
+import org.apache.jena.sparql.algebra.op.OpBGP;
+import se.liu.ida.hefquin.engine.query.BGP;
+import se.liu.ida.hefquin.engine.query.SPARQLGraphPattern;
+import se.liu.ida.hefquin.engine.query.TriplePattern;
 import se.liu.ida.hefquin.engine.federation.access.SPARQLRequest;
 import se.liu.ida.hefquin.engine.federation.access.TriplePatternRequest;
 import se.liu.ida.hefquin.engine.queryplan.LogicalOperator;
@@ -21,6 +25,27 @@ public class IdentifyTypeOfRequestUsedForReq {
     public static boolean isBGPRequest( final LogicalOperator lop ) {
         if( lop instanceof LogicalOpRequest){
             return ( (LogicalOpRequest<?, ?>) lop ).getRequest() instanceof BGPRequest;
+        }
+        return false;
+    }
+
+    // Check whether the type of request is a SPARQL request with BasicPattern
+    public static boolean isGraphPatternReqWithBGP( final PhysicalOperator op ) {
+        final LogicalOperator lop = ((PhysicalOperatorForLogicalOperator) op).getLogicalOperator();
+
+        return isGraphPatternReqWithBGP(lop);
+    }
+
+    public static boolean isGraphPatternReqWithBGP( final LogicalOperator lop ) {
+        if ( isGraphPatternRequest(lop) ) {
+            final SPARQLRequest req = (SPARQLRequest) ( (LogicalOpRequest<?, ?>) lop ).getRequest();
+            final SPARQLGraphPattern pattern = req.getQueryPattern();
+            if ( pattern instanceof TriplePattern || pattern instanceof BGP){
+                return false;
+            }
+            else {
+                return pattern.asJenaOp() instanceof OpBGP;
+            }
         }
         return false;
     }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/rewriting/rules/RuleChangeOrderAndMergeJoinOfBGPReqIntoBGPAdd.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/rewriting/rules/RuleChangeOrderAndMergeJoinOfBGPReqIntoBGPAdd.java
@@ -21,8 +21,8 @@ public class RuleChangeOrderAndMergeJoinOfBGPReqIntoBGPAdd extends AbstractRewri
             final PhysicalOperator subPlanOp1 = plan.getSubPlan(0).getRootOperator();
             final PhysicalOperator subPlanOp2 = plan.getSubPlan(1).getRootOperator();
 
-            return ( IdentifyLogicalOp.isJoin(subPlanOp1) && IdentifyTypeOfRequestUsedForReq.isBGPRequest(subPlanOp2) )
-                    ||( IdentifyLogicalOp.isJoin(subPlanOp2) && IdentifyTypeOfRequestUsedForReq.isBGPRequest(subPlanOp1));
+            return ( IdentifyLogicalOp.isJoin(subPlanOp1) && ( IdentifyTypeOfRequestUsedForReq.isBGPRequest(subPlanOp2) || IdentifyTypeOfRequestUsedForReq.isGraphPatternReqWithBGP(subPlanOp2) ))
+                    || ( IdentifyLogicalOp.isJoin(subPlanOp2) && ( IdentifyTypeOfRequestUsedForReq.isBGPRequest(subPlanOp1) || IdentifyTypeOfRequestUsedForReq.isGraphPatternReqWithBGP(subPlanOp1) ));
         }
         return false;
     }
@@ -39,13 +39,13 @@ public class RuleChangeOrderAndMergeJoinOfBGPReqIntoBGPAdd extends AbstractRewri
                 final PhysicalOperator subPlanOp1 = subPlan1.getRootOperator();
                 final PhysicalOperator subPlanOp2 = subPlan2.getRootOperator();
 
-                if ( IdentifyLogicalOp.isJoin(subPlanOp1) && IdentifyTypeOfRequestUsedForReq.isBGPRequest(subPlanOp2) ) {
+                if ( IdentifyLogicalOp.isJoin(subPlanOp1) && (IdentifyTypeOfRequestUsedForReq.isBGPRequest(subPlanOp2) || IdentifyTypeOfRequestUsedForReq.isGraphPatternReqWithBGP(subPlanOp2))) {
                     final UnaryLogicalOp bgpAdd = LogicalOpUtils.createUnaryLopFromReq(subPlanOp2);
                     final PhysicalPlan newSubPlan = PhysicalPlanFactory.createPlan( bgpAdd, subPlan1.getSubPlan(1));
 
                     return PhysicalPlanFactory.createPlan( rootOp, subPlan1.getSubPlan(0), newSubPlan);
                 }
-                else if ( IdentifyLogicalOp.isJoin(subPlanOp2) && IdentifyTypeOfRequestUsedForReq.isBGPRequest(subPlanOp1) ) {
+                else if ( IdentifyLogicalOp.isJoin(subPlanOp2) && (IdentifyTypeOfRequestUsedForReq.isBGPRequest(subPlanOp1) || IdentifyTypeOfRequestUsedForReq.isGraphPatternReqWithBGP(subPlanOp1) )) {
                     final UnaryLogicalOp bgpAdd = LogicalOpUtils.createUnaryLopFromReq(subPlanOp1);
                     final PhysicalPlan newSubPlan = PhysicalPlanFactory.createPlan( bgpAdd, subPlan2.getSubPlan(0) );
 

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/rewriting/rules/RuleDivideBGPAddToMultiTPAdd.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/rewriting/rules/RuleDivideBGPAddToMultiTPAdd.java
@@ -38,7 +38,7 @@ public class RuleDivideBGPAddToMultiTPAdd extends AbstractRewritingRuleImpl{
                 final LogicalOpBGPAdd rootLop = (LogicalOpBGPAdd) ((PhysicalOperatorForLogicalOperator) rootOp).getLogicalOperator();
                 final FederationMember fm = rootLop.getFederationMember();
 
-                final Set<TriplePattern> tps = new HashSet<>(rootLop.getBGP().getTriplePatterns());
+                final Set<TriplePattern> tps = new HashSet<>( rootLop.getBGP().getTriplePatterns() );
 
                 if ( tps.size() == 0 ) {
                     throw new IllegalArgumentException( "the BGP is empty" );

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/rewriting/rules/RuleDivideBGPReqIntoJoinOfTPReqs.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/rewriting/rules/RuleDivideBGPReqIntoJoinOfTPReqs.java
@@ -1,7 +1,6 @@
 package se.liu.ida.hefquin.engine.queryproc.impl.optimizer.rewriting.rules;
 
 import se.liu.ida.hefquin.engine.federation.FederationMember;
-import se.liu.ida.hefquin.engine.federation.access.BGPRequest;
 import se.liu.ida.hefquin.engine.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.engine.federation.access.impl.req.TriplePatternRequestImpl;
 import se.liu.ida.hefquin.engine.query.TriplePattern;
@@ -10,10 +9,10 @@ import se.liu.ida.hefquin.engine.queryplan.PhysicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.PhysicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalOperatorForLogicalOperator;
+import se.liu.ida.hefquin.engine.queryplan.utils.LogicalOpUtils;
 import se.liu.ida.hefquin.engine.queryplan.utils.PhysicalPlanFactory;
 import se.liu.ida.hefquin.engine.queryproc.impl.optimizer.rewriting.RuleApplication;
 
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
@@ -26,7 +25,7 @@ public class RuleDivideBGPReqIntoJoinOfTPReqs extends AbstractRewritingRuleImpl{
     @Override
     protected boolean canBeAppliedTo( final PhysicalPlan plan ) {
         final PhysicalOperator rootOp = plan.getRootOperator();
-        return IdentifyTypeOfRequestUsedForReq.isBGPRequest(rootOp);
+        return IdentifyTypeOfRequestUsedForReq.isBGPRequest(rootOp) || IdentifyTypeOfRequestUsedForReq.isGraphPatternReqWithBGP(rootOp);
     }
 
     @Override
@@ -38,8 +37,7 @@ public class RuleDivideBGPReqIntoJoinOfTPReqs extends AbstractRewritingRuleImpl{
                 final LogicalOperator lop = ((PhysicalOperatorForLogicalOperator) rootOp).getLogicalOperator();
                 final FederationMember fm = ((LogicalOpRequest<?, ?>) lop).getFederationMember();
 
-                final BGPRequest req = (BGPRequest) ((LogicalOpRequest<?, ?>) lop).getRequest();
-                final Set<TriplePattern> tps = new HashSet<>(req.getQueryPattern().getTriplePatterns());
+                final Set<TriplePattern> tps = LogicalOpUtils.getTriplePatternsOfReq( (LogicalOpRequest<?, ?>) lop);
 
                 final Iterator<TriplePattern> it = tps.iterator();
                 if ( tps.size() == 1 ) {

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/rewriting/rules/RuleDivideBGPReqIntoMultiTPAdds.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/rewriting/rules/RuleDivideBGPReqIntoMultiTPAdds.java
@@ -1,7 +1,6 @@
 package se.liu.ida.hefquin.engine.queryproc.impl.optimizer.rewriting.rules;
 
 import se.liu.ida.hefquin.engine.federation.FederationMember;
-import se.liu.ida.hefquin.engine.federation.access.BGPRequest;
 import se.liu.ida.hefquin.engine.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.engine.federation.access.impl.req.TriplePatternRequestImpl;
 import se.liu.ida.hefquin.engine.query.TriplePattern;
@@ -11,10 +10,10 @@ import se.liu.ida.hefquin.engine.queryplan.PhysicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPAdd;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalOperatorForLogicalOperator;
+import se.liu.ida.hefquin.engine.queryplan.utils.LogicalOpUtils;
 import se.liu.ida.hefquin.engine.queryplan.utils.PhysicalPlanFactory;
 import se.liu.ida.hefquin.engine.queryproc.impl.optimizer.rewriting.RuleApplication;
 
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
@@ -27,7 +26,7 @@ public class RuleDivideBGPReqIntoMultiTPAdds extends AbstractRewritingRuleImpl{
     @Override
     protected boolean canBeAppliedTo( final PhysicalPlan plan ) {
         final PhysicalOperator rootOp = plan.getRootOperator();
-        return IdentifyTypeOfRequestUsedForReq.isBGPRequest(rootOp);
+        return IdentifyTypeOfRequestUsedForReq.isBGPRequest(rootOp) || IdentifyTypeOfRequestUsedForReq.isGraphPatternReqWithBGP(rootOp);
     }
 
     @Override
@@ -38,10 +37,9 @@ public class RuleDivideBGPReqIntoMultiTPAdds extends AbstractRewritingRuleImpl{
                 final PhysicalOperator rootOp = plan.getRootOperator();
                 final LogicalOperator lop = ((PhysicalOperatorForLogicalOperator) rootOp).getLogicalOperator();
 
-                final BGPRequest req = (BGPRequest) ((LogicalOpRequest<?, ?>) lop).getRequest();
-                final Set<TriplePattern> tps = new HashSet<>( req.getQueryPattern().getTriplePatterns() );
-                final Iterator<TriplePattern> it = tps.iterator();
+                final Set<TriplePattern> tps = LogicalOpUtils.getTriplePatternsOfReq( (LogicalOpRequest<?, ?>) lop);
 
+                final Iterator<TriplePattern> it = tps.iterator();
                 if ( tps.size() == 0 ) {
                     throw new IllegalArgumentException( "the BGP is empty" );
                 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/rewriting/rules/RuleMergeJoinOfOneBGPReqIntoBGPAdd.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/rewriting/rules/RuleMergeJoinOfOneBGPReqIntoBGPAdd.java
@@ -21,7 +21,9 @@ public class RuleMergeJoinOfOneBGPReqIntoBGPAdd extends AbstractRewritingRuleImp
             final PhysicalOperator subPlanOp2 = plan.getSubPlan(1).getRootOperator();
 
             return IdentifyTypeOfRequestUsedForReq.isBGPRequest( subPlanOp1 )
-                    || IdentifyTypeOfRequestUsedForReq.isBGPRequest( subPlanOp2 );
+                    || IdentifyTypeOfRequestUsedForReq.isGraphPatternReqWithBGP( subPlanOp1 )
+                    || IdentifyTypeOfRequestUsedForReq.isBGPRequest( subPlanOp2 )
+                    || IdentifyTypeOfRequestUsedForReq.isGraphPatternReqWithBGP( subPlanOp2 );
         }
         return false;
     }
@@ -36,11 +38,11 @@ public class RuleMergeJoinOfOneBGPReqIntoBGPAdd extends AbstractRewritingRuleImp
                 final PhysicalOperator subPlanOp1 = subPlan1.getRootOperator();
                 final PhysicalOperator subPlanOp2 = subPlan2.getRootOperator();
 
-                if ( IdentifyTypeOfRequestUsedForReq.isBGPRequest( subPlanOp1 ) ) {
+                if ( IdentifyTypeOfRequestUsedForReq.isBGPRequest( subPlanOp1 ) || IdentifyTypeOfRequestUsedForReq.isGraphPatternReqWithBGP( subPlanOp1 ) ) {
                     final UnaryLogicalOp newRoot = LogicalOpUtils.createUnaryLopFromReq( subPlanOp1 );
                     return PhysicalPlanFactory.createPlan(newRoot, subPlan2);
                 }
-                else if ( IdentifyTypeOfRequestUsedForReq.isBGPRequest( subPlanOp2 ) ) {
+                else if ( IdentifyTypeOfRequestUsedForReq.isBGPRequest( subPlanOp2 ) || IdentifyTypeOfRequestUsedForReq.isGraphPatternReqWithBGP( subPlanOp2 ) ) {
                     final UnaryLogicalOp newRoot = LogicalOpUtils.createUnaryLopFromReq( subPlanOp2 );
                     return PhysicalPlanFactory.createPlan(newRoot, subPlan1);
                 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/simple/DPBasedJoinPlanOptimizer.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/simple/DPBasedJoinPlanOptimizer.java
@@ -2,8 +2,6 @@ package se.liu.ida.hefquin.engine.queryproc.impl.optimizer.simple;
 
 import se.liu.ida.hefquin.engine.federation.FederationMember;
 import se.liu.ida.hefquin.engine.federation.SPARQLEndpoint;
-import se.liu.ida.hefquin.engine.federation.access.BGPRequest;
-import se.liu.ida.hefquin.engine.federation.access.TriplePatternRequest;
 import se.liu.ida.hefquin.engine.queryplan.PhysicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
@@ -71,7 +69,7 @@ public class DPBasedJoinPlanOptimizer extends JoinPlanOptimizerBase {
                         candidatePlans.add( PhysicalPlanFactory.createPlanWithJoin( plan_left,  plan_right) );
 
                         if ( IdentifyTypeOfRequestUsedForReq.isBGPRequestOverSPARQLEndpoint( plan_left.getRootOperator() ) ){
-                            final LogicalOpBGPAdd newRoot = LogicalOpUtils.createBGPAddLopFromReq((BGPRequest) plan_left.getRootOperator());
+                            final LogicalOpBGPAdd newRoot = (LogicalOpBGPAdd) LogicalOpUtils.createUnaryLopFromReq( plan_left.getRootOperator() );
 
                             candidatePlans.add( PhysicalPlanFactory.createPlanWithIndexNLJ( newRoot, plan_right ) );
                             candidatePlans.add( PhysicalPlanFactory.createPlanWithBindJoinFILTER( newRoot, plan_right ) );
@@ -79,7 +77,7 @@ public class DPBasedJoinPlanOptimizer extends JoinPlanOptimizerBase {
                             candidatePlans.add( PhysicalPlanFactory.createPlanWithBindJoinVALUES( newRoot, plan_right ) );
                         }
                         else if ( IdentifyTypeOfRequestUsedForReq.isTriplePatternRequest( plan_left.getRootOperator() ) ){
-                            final LogicalOpTPAdd newRoot = LogicalOpUtils.createTPAddLopFromReq((TriplePatternRequest) plan_left.getRootOperator());
+                            final LogicalOpTPAdd newRoot = (LogicalOpTPAdd) LogicalOpUtils.createUnaryLopFromReq( plan_left.getRootOperator() );
                             candidatePlans.add( PhysicalPlanFactory.createPlanWithIndexNLJ( newRoot, plan_right ) );
 
                             final FederationMember fm = ( (LogicalOpRequest<?, ?>)plan_left.getRootOperator() ).getFederationMember();


### PR DESCRIPTION
This pull request is to address a problem that the applicable rewrite rules identified are incomplete. Specifically, the evolutionary algorithm fails to identify rewriting rules related to decomposing/rewriting Basic Graph Pattern.

Reason: the initial logical query is created by the method createSourceAssignment.createPlan(), which uses SPARQLRequest as the default type of request. Hence, it can't be captured by checking whether the root operator is a BGPRequest. 
To enable these rewriting rules (related to BGP), it should also consider cases where the root operator is a SPARQLRequest but the pattern is BasicPattern.

Solution: Add another method, isGraphPatternReqWithBGP(), to check whether the request is a SPARQL request with BasicPattern, and then update the relevant rewrite rules.