### PR TITLE
Extend unary executable operators

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/query/impl/TriplePatternImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/query/impl/TriplePatternImpl.java
@@ -62,7 +62,7 @@ public class TriplePatternImpl implements TriplePattern
 	
 	@Override
 	public String toString() {
-		return this.asJenaTriple().toString();
+		return "(triple " + this.asJenaTriple().toString() + ") ";
 	}
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithFILTER.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithFILTER.java
@@ -59,14 +59,14 @@ public class ExecOpBindJoinSPARQLwithFILTER extends ExecOpGenericBindJoinWithReq
 
 	protected Op createFilter( final Iterable<SolutionMapping> solMaps ) {
 		if ( varsInTP.isEmpty() ) {
-			return createOpBasedOnQuery(query);
+			return representQueryPatternAsJenaOp(query);
 		}
 		Expr disjunction = null;
-		boolean mustHaveTheFilter = false;
+		boolean solMapsContainBlankNodes = false;
 		for (final SolutionMapping s : solMaps) {
 			final Binding b = SolutionMappingUtils.restrict(s.asJenaBinding(), varsInTP);
 			if ( SolutionMappingUtils.containsBlankNodes(b) ) {
-				mustHaveTheFilter = true;
+				solMapsContainBlankNodes = true;
 				continue;
 			}
 
@@ -92,10 +92,10 @@ public class ExecOpBindJoinSPARQLwithFILTER extends ExecOpGenericBindJoinWithReq
 		}
 
 		if ( disjunction == null ) {
-			return mustHaveTheFilter ? null : createOpBasedOnQuery(query);
+			return solMapsContainBlankNodes ? null : representQueryPatternAsJenaOp(query);
 		}
 
-		return OpFilter.filter(disjunction, createOpBasedOnQuery(query));
+		return OpFilter.filter(disjunction, representQueryPatternAsJenaOp(query));
 	}
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithFILTER.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithFILTER.java
@@ -28,21 +28,21 @@ import se.liu.ida.hefquin.engine.query.impl.SPARQLGraphPatternImpl;
 
 public class ExecOpBindJoinSPARQLwithFILTER extends ExecOpGenericBindJoinWithRequestOps<SPARQLGraphPattern, SPARQLEndpoint>
 {
-	protected final Set<Var> varsInTP;
+	protected final Set<Var> varsInSubQuery;
 
 	public ExecOpBindJoinSPARQLwithFILTER( final TriplePattern query, final SPARQLEndpoint fm ) {
 		super(query, fm);
-		varsInTP = QueryPatternUtils.getVariablesInPattern(query);
+		varsInSubQuery = QueryPatternUtils.getVariablesInPattern(query);
 	}
 
 	public ExecOpBindJoinSPARQLwithFILTER( final BGP query, final SPARQLEndpoint fm ) {
 		super(query, fm);
-		varsInTP = QueryPatternUtils.getVariablesInPattern(query);
+		varsInSubQuery = QueryPatternUtils.getVariablesInPattern(query);
 	}
 
 	public ExecOpBindJoinSPARQLwithFILTER( final SPARQLGraphPattern query, final SPARQLEndpoint fm ) {
 		super(query, fm);
-		varsInTP = QueryPatternUtils.getVariablesInPattern(query);
+		varsInSubQuery = QueryPatternUtils.getVariablesInPattern(query);
 	}
 
 	@Override
@@ -58,13 +58,13 @@ public class ExecOpBindJoinSPARQLwithFILTER extends ExecOpGenericBindJoinWithReq
 	}
 
 	protected Op createFilter( final Iterable<SolutionMapping> solMaps ) {
-		if ( varsInTP.isEmpty() ) {
+		if ( varsInSubQuery.isEmpty() ) {
 			return representQueryPatternAsJenaOp(query);
 		}
 		Expr disjunction = null;
 		boolean solMapsContainBlankNodes = false;
 		for (final SolutionMapping s : solMaps) {
-			final Binding b = SolutionMappingUtils.restrict(s.asJenaBinding(), varsInTP);
+			final Binding b = SolutionMappingUtils.restrict(s.asJenaBinding(), varsInSubQuery);
 			if ( SolutionMappingUtils.containsBlankNodes(b) ) {
 				solMapsContainBlankNodes = true;
 				continue;

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithUNION.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithUNION.java
@@ -27,21 +27,21 @@ import se.liu.ida.hefquin.engine.query.impl.SPARQLGraphPatternImpl;
 
 public class ExecOpBindJoinSPARQLwithUNION extends ExecOpGenericBindJoinWithRequestOps<SPARQLGraphPattern, SPARQLEndpoint>
 {
-	protected final List<Var> varsInTP;
+	protected final List<Var> varsInSubQuery;
 
 	public ExecOpBindJoinSPARQLwithUNION( final TriplePattern query, final SPARQLEndpoint fm ) {
 		super(query, fm);
-		varsInTP = new ArrayList<>( QueryPatternUtils.getVariablesInPattern(query) );
+		varsInSubQuery = new ArrayList<>( QueryPatternUtils.getVariablesInPattern(query) );
 	}
 
 	public ExecOpBindJoinSPARQLwithUNION( final BGP query, final SPARQLEndpoint fm ) {
 		super(query, fm);
-		varsInTP = new ArrayList<>( QueryPatternUtils.getVariablesInPattern(query) );
+		varsInSubQuery = new ArrayList<>( QueryPatternUtils.getVariablesInPattern(query) );
 	}
 
 	public ExecOpBindJoinSPARQLwithUNION( final SPARQLGraphPattern query, final SPARQLEndpoint fm ) {
 		super(query, fm);
-		varsInTP = new ArrayList<>( QueryPatternUtils.getVariablesInPattern(query) );
+		varsInSubQuery = new ArrayList<>( QueryPatternUtils.getVariablesInPattern(query) );
 	}
 
 	@Override
@@ -57,12 +57,12 @@ public class ExecOpBindJoinSPARQLwithUNION extends ExecOpGenericBindJoinWithRequ
 	}
 
 	protected Op createUnion(final Iterable<SolutionMapping> solMaps) {
-		if (varsInTP.isEmpty()) return representQueryPatternAsJenaOp(query);
+		if (varsInSubQuery.isEmpty()) return representQueryPatternAsJenaOp(query);
 
 		final Set<Expr> conjunctions = new HashSet<>();
 		boolean solMapsContainBlankNodes = false;
 		for ( final SolutionMapping s : solMaps) {
-			final Binding b = SolutionMappingUtils.restrict(s.asJenaBinding(), varsInTP);
+			final Binding b = SolutionMappingUtils.restrict(s.asJenaBinding(), varsInSubQuery);
 			// If the current solution mapping does not have any variables in common with
 			// the triple pattern of this operator, then every matching triple is a join partner
 			// for the current solution mapping. Hence, in this case, we may simply retrieve
@@ -75,7 +75,7 @@ public class ExecOpBindJoinSPARQLwithUNION extends ExecOpGenericBindJoinWithRequ
 			}
 
 			Expr conjunction = null;
-			for (final Var v : varsInTP){
+			for (final Var v : varsInSubQuery){
 				if (! b.contains(v)) continue;
 				final Node uri = b.get(v);
 				final Expr expr = new E_Equals(new ExprVar(v), new NodeValueNode(uri));

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithVALUES.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithVALUES.java
@@ -26,28 +26,28 @@ import se.liu.ida.hefquin.engine.query.impl.SPARQLGraphPatternImpl;
 
 public class ExecOpBindJoinSPARQLwithVALUES extends ExecOpGenericBindJoinWithRequestOps<SPARQLGraphPattern, SPARQLEndpoint>
 {
-	protected final List<Var> varsInTP;
+	protected final List<Var> varsInSubQuery;
 	
 	public ExecOpBindJoinSPARQLwithVALUES( final TriplePattern query, final SPARQLEndpoint fm ) {
 		super(query, fm);
-		varsInTP = new ArrayList<>( QueryPatternUtils.getVariablesInPattern(query) );
+		varsInSubQuery = new ArrayList<>( QueryPatternUtils.getVariablesInPattern(query) );
 	}
 
 	public ExecOpBindJoinSPARQLwithVALUES( final BGP query, final SPARQLEndpoint fm ) {
 		super(query, fm);
-		varsInTP = new ArrayList<>( QueryPatternUtils.getVariablesInPattern(query) );
+		varsInSubQuery = new ArrayList<>( QueryPatternUtils.getVariablesInPattern(query) );
 	}
 
 	public ExecOpBindJoinSPARQLwithVALUES( final SPARQLGraphPattern query, final SPARQLEndpoint fm ) {
 		super(query, fm);
-		varsInTP = new ArrayList<>( QueryPatternUtils.getVariablesInPattern(query) );
+		varsInSubQuery = new ArrayList<>( QueryPatternUtils.getVariablesInPattern(query) );
 	}
 
 	@Override
 	protected NullaryExecutableOp createExecutableRequestOperator( final Iterable<SolutionMapping> solMaps ) {
-		final Set<Binding> bindings = new HashSet<Binding>();
+		final Set<Binding> bindings = new HashSet<>();
 		for ( final SolutionMapping s : solMaps ) {
-			final Binding b = SolutionMappingUtils.restrict( s.asJenaBinding(), varsInTP );
+			final Binding b = SolutionMappingUtils.restrict( s.asJenaBinding(), varsInSubQuery );
 			if ( ! SolutionMappingUtils.containsBlankNodes(b) ) {
 				bindings.add(b);
 			}
@@ -57,7 +57,7 @@ public class ExecOpBindJoinSPARQLwithVALUES extends ExecOpGenericBindJoinWithReq
 			return null;
 		}
 
-		final Table table = new TableData( varsInTP, new ArrayList<>(bindings) );
+		final Table table = new TableData( varsInSubQuery, new ArrayList<>(bindings) );
 		final Op op = OpSequence.create( OpTable.create(table), representQueryPatternAsJenaOp(query) );
 		final SPARQLGraphPattern pattern = new SPARQLGraphPatternImpl(op);
 		final SPARQLRequest request = new SPARQLRequestImpl(pattern);

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithVALUES.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithVALUES.java
@@ -9,7 +9,6 @@ import org.apache.jena.sparql.algebra.Op;
 import org.apache.jena.sparql.algebra.Table;
 import org.apache.jena.sparql.algebra.op.OpSequence;
 import org.apache.jena.sparql.algebra.op.OpTable;
-import org.apache.jena.sparql.algebra.op.OpTriple;
 import org.apache.jena.sparql.algebra.table.TableData;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.binding.Binding;
@@ -19,16 +18,27 @@ import se.liu.ida.hefquin.engine.data.utils.SolutionMappingUtils;
 import se.liu.ida.hefquin.engine.federation.SPARQLEndpoint;
 import se.liu.ida.hefquin.engine.federation.access.SPARQLRequest;
 import se.liu.ida.hefquin.engine.federation.access.impl.req.SPARQLRequestImpl;
+import se.liu.ida.hefquin.engine.query.BGP;
 import se.liu.ida.hefquin.engine.query.SPARQLGraphPattern;
 import se.liu.ida.hefquin.engine.query.TriplePattern;
 import se.liu.ida.hefquin.engine.query.impl.QueryPatternUtils;
 import se.liu.ida.hefquin.engine.query.impl.SPARQLGraphPatternImpl;
 
-public class ExecOpBindJoinSPARQLwithVALUES extends ExecOpGenericBindJoinWithRequestOps<TriplePattern,SPARQLEndpoint>
+public class ExecOpBindJoinSPARQLwithVALUES extends ExecOpGenericBindJoinWithRequestOps<SPARQLGraphPattern, SPARQLEndpoint>
 {
 	protected final List<Var> varsInTP;
 	
 	public ExecOpBindJoinSPARQLwithVALUES( final TriplePattern query, final SPARQLEndpoint fm ) {
+		super(query, fm);
+		varsInTP = new ArrayList<>( QueryPatternUtils.getVariablesInPattern(query) );
+	}
+
+	public ExecOpBindJoinSPARQLwithVALUES( final BGP query, final SPARQLEndpoint fm ) {
+		super(query, fm);
+		varsInTP = new ArrayList<>( QueryPatternUtils.getVariablesInPattern(query) );
+	}
+
+	public ExecOpBindJoinSPARQLwithVALUES( final SPARQLGraphPattern query, final SPARQLEndpoint fm ) {
 		super(query, fm);
 		varsInTP = new ArrayList<>( QueryPatternUtils.getVariablesInPattern(query) );
 	}
@@ -48,7 +58,7 @@ public class ExecOpBindJoinSPARQLwithVALUES extends ExecOpGenericBindJoinWithReq
 		}
 
 		final Table table = new TableData( varsInTP, new ArrayList<>(bindings) );
-		final Op op = OpSequence.create( OpTable.create(table), new OpTriple(query.asJenaTriple()) );
+		final Op op = OpSequence.create( OpTable.create(table), createOpBasedOnQuery(query) );
 		final SPARQLGraphPattern pattern = new SPARQLGraphPatternImpl(op);
 		final SPARQLRequest request = new SPARQLRequestImpl(pattern);
 		return new ExecOpRequestSPARQL(request, fm);

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithVALUES.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithVALUES.java
@@ -58,7 +58,7 @@ public class ExecOpBindJoinSPARQLwithVALUES extends ExecOpGenericBindJoinWithReq
 		}
 
 		final Table table = new TableData( varsInTP, new ArrayList<>(bindings) );
-		final Op op = OpSequence.create( OpTable.create(table), createOpBasedOnQuery(query) );
+		final Op op = OpSequence.create( OpTable.create(table), representQueryPatternAsJenaOp(query) );
 		final SPARQLGraphPattern pattern = new SPARQLGraphPatternImpl(op);
 		final SPARQLRequest request = new SPARQLRequestImpl(pattern);
 		return new ExecOpRequestSPARQL(request, fm);

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpGenericBindJoinWithRequestOps.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpGenericBindJoinWithRequestOps.java
@@ -88,21 +88,27 @@ public abstract class ExecOpGenericBindJoinWithRequestOps<QueryType extends Quer
     } // end of helper class MyIntermediateResultElementSink
 
 	// ------- helper function ------
-	/* Convert a SPARQL graph pattern to jena Op based on the type of pattern*/
-	protected Op createOpBasedOnQuery( final SPARQLGraphPattern query ) {
-		if ( query instanceof TriplePattern) {
-			return new OpTriple( ((TriplePattern)query).asJenaTriple());
-		}
-		else if (query instanceof BGP) {
-			final Set<TriplePattern> tps = (Set<TriplePattern>) ((BGP) query).getTriplePatterns();
-			final BasicPattern bgp = new BasicPattern();
-			for (TriplePattern tp : tps) {
-				bgp.add( tp.asJenaTriple() );
+	/**
+	 * Returns a representation of this query pattern as an
+	 * object of the interface {@link Op} of the Jena API.
+	 */
+	protected Op representQueryPatternAsJenaOp( final QueryType query ) {
+		if ( query instanceof SPARQLGraphPattern ) {
+			if ( query instanceof TriplePattern) {
+				return new OpTriple( ((TriplePattern)query).asJenaTriple());
 			}
-			return new OpBGP(bgp);
+			else if (query instanceof BGP) {
+				final Set<TriplePattern> tps = (Set<TriplePattern>) ((BGP) query).getTriplePatterns();
+				final BasicPattern bgp = new BasicPattern();
+				for (TriplePattern tp : tps) {
+					bgp.add( tp.asJenaTriple() );
+				}
+				return new OpBGP(bgp);
+			}
+			else return ((SPARQLGraphPattern)query).asJenaOp();
 		}
 		else
-			return query.asJenaOp();
+			throw new IllegalArgumentException("Unsupported type of query pattern: " + query.getClass().getName() );
 	}
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpGenericBindJoinWithRequestOps.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpGenericBindJoinWithRequestOps.java
@@ -98,9 +98,8 @@ public abstract class ExecOpGenericBindJoinWithRequestOps<QueryType extends Quer
 				return new OpTriple( ((TriplePattern)query).asJenaTriple());
 			}
 			else if (query instanceof BGP) {
-				final Set<TriplePattern> tps = (Set<TriplePattern>) ((BGP) query).getTriplePatterns();
 				final BasicPattern bgp = new BasicPattern();
-				for (TriplePattern tp : tps) {
+				for ( final TriplePattern tp : ((BGP) query).getTriplePatterns() ) {
 					bgp.add( tp.asJenaTriple() );
 				}
 				return new OpBGP(bgp);

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpGenericBindJoinWithRequestOps.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpGenericBindJoinWithRequestOps.java
@@ -1,13 +1,22 @@
 package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
+import org.apache.jena.sparql.algebra.Op;
+import org.apache.jena.sparql.algebra.op.OpBGP;
+import org.apache.jena.sparql.algebra.op.OpTriple;
+import org.apache.jena.sparql.core.BasicPattern;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.data.utils.SolutionMappingUtils;
 import se.liu.ida.hefquin.engine.federation.FederationMember;
+import se.liu.ida.hefquin.engine.query.BGP;
 import se.liu.ida.hefquin.engine.query.Query;
+import se.liu.ida.hefquin.engine.query.SPARQLGraphPattern;
+import se.liu.ida.hefquin.engine.query.TriplePattern;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultBlock;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
+
+import java.util.Set;
 
 /**
  * Abstract base class to implement bind joins by using request operators.
@@ -77,5 +86,23 @@ public abstract class ExecOpGenericBindJoinWithRequestOps<QueryType extends Quer
 			}
 		}
     } // end of helper class MyIntermediateResultElementSink
+
+	// ------- helper function ------
+	/* Convert a SPARQL graph pattern to jena Op based on the type of pattern*/
+	protected Op createOpBasedOnQuery( final SPARQLGraphPattern query ) {
+		if ( query instanceof TriplePattern) {
+			return new OpTriple( ((TriplePattern)query).asJenaTriple());
+		}
+		else if (query instanceof BGP) {
+			final Set<TriplePattern> tps = (Set<TriplePattern>) ((BGP) query).getTriplePatterns();
+			final BasicPattern bgp = new BasicPattern();
+			for (TriplePattern tp : tps) {
+				bgp.add( tp.asJenaTriple() );
+			}
+			return new OpBGP(bgp);
+		}
+		else
+			return query.asJenaOp();
+	}
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithFILTER.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithFILTER.java
@@ -40,6 +40,15 @@ public class PhysicalOpBindJoinWithFILTER extends BasePhysicalOpSingleInputJoin
 			else
 				throw new IllegalArgumentException("Unsupported type of federation member: " + fm.getClass().getName() );
 		}
+		else if ( lop instanceof LogicalOpBGPAdd ) {
+			final LogicalOpBGPAdd bgpAdd = (LogicalOpBGPAdd) lop;
+			final FederationMember fm = bgpAdd.getFederationMember();
+
+			if ( fm instanceof SPARQLEndpoint )
+				return new ExecOpBindJoinSPARQLwithFILTER( bgpAdd.getBGP(), (SPARQLEndpoint) fm );
+			else
+				throw new IllegalArgumentException("Unsupported type of federation member: " + fm.getClass().getName() );
+		}
 		else
 			throw new IllegalArgumentException("Unsupported type of operator: " + lop.getClass().getName() );
 	}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithUNION.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithUNION.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryplan.physical.impl;
 import se.liu.ida.hefquin.engine.federation.FederationMember;
 import se.liu.ida.hefquin.engine.federation.SPARQLEndpoint;
 import se.liu.ida.hefquin.engine.queryplan.ExpectedVariables;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithFILTER;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithUNION;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
@@ -45,6 +46,15 @@ public class PhysicalOpBindJoinWithUNION extends BasePhysicalOpSingleInputJoin
 
 			if ( fm instanceof SPARQLEndpoint )
 				return new ExecOpBindJoinSPARQLwithUNION( tpAdd.getTP(), (SPARQLEndpoint) fm );
+			else
+				throw new IllegalArgumentException("Unsupported type of federation member: " + fm.getClass().getName() );
+		}
+		else if ( lop instanceof LogicalOpBGPAdd ) {
+			final LogicalOpBGPAdd bgpAdd = (LogicalOpBGPAdd) lop;
+			final FederationMember fm = bgpAdd.getFederationMember();
+
+			if ( fm instanceof SPARQLEndpoint )
+				return new ExecOpBindJoinSPARQLwithUNION( bgpAdd.getBGP(), (SPARQLEndpoint) fm );
 			else
 				throw new IllegalArgumentException("Unsupported type of federation member: " + fm.getClass().getName() );
 		}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithUNION.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithUNION.java
@@ -3,7 +3,6 @@ package se.liu.ida.hefquin.engine.queryplan.physical.impl;
 import se.liu.ida.hefquin.engine.federation.FederationMember;
 import se.liu.ida.hefquin.engine.federation.SPARQLEndpoint;
 import se.liu.ida.hefquin.engine.queryplan.ExpectedVariables;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithFILTER;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithUNION;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithVALUES.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithVALUES.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryplan.physical.impl;
 import se.liu.ida.hefquin.engine.federation.FederationMember;
 import se.liu.ida.hefquin.engine.federation.SPARQLEndpoint;
 import se.liu.ida.hefquin.engine.queryplan.ExpectedVariables;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithFILTER;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithVALUES;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
@@ -45,6 +46,15 @@ public class PhysicalOpBindJoinWithVALUES extends BasePhysicalOpSingleInputJoin 
 
 			if ( fm instanceof SPARQLEndpoint )
 				return new ExecOpBindJoinSPARQLwithVALUES( tpAdd.getTP(), (SPARQLEndpoint) fm );
+			else
+				throw new IllegalArgumentException("Unsupported type of federation member: " + fm.getClass().getName() );
+		}
+		else if ( lop instanceof LogicalOpBGPAdd ) {
+			final LogicalOpBGPAdd bgpAdd = (LogicalOpBGPAdd) lop;
+			final FederationMember fm = bgpAdd.getFederationMember();
+
+			if ( fm instanceof SPARQLEndpoint )
+				return new ExecOpBindJoinSPARQLwithVALUES( bgpAdd.getBGP(), (SPARQLEndpoint) fm );
 			else
 				throw new IllegalArgumentException("Unsupported type of federation member: " + fm.getClass().getName() );
 		}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithVALUES.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithVALUES.java
@@ -3,7 +3,6 @@ package se.liu.ida.hefquin.engine.queryplan.physical.impl;
 import se.liu.ida.hefquin.engine.federation.FederationMember;
 import se.liu.ida.hefquin.engine.federation.SPARQLEndpoint;
 import se.liu.ida.hefquin.engine.queryplan.ExpectedVariables;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithFILTER;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithVALUES;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;


### PR DESCRIPTION
Extend three executable operators to make them applicable to SPARQL query patterns