### PR TITLE
Using Randomized for IterativeImprovement

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/randomized/IterativeImprovementBasedQueryOptimizer.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/randomized/IterativeImprovementBasedQueryOptimizer.java
@@ -34,7 +34,7 @@ public class IterativeImprovementBasedQueryOptimizer extends RandomizedQueryOpti
 
 	@Override
 	public Pair<PhysicalPlan, QueryOptimizationStats> optimize( final LogicalPlan initialPlan ) throws QueryOptimizationException {
-		return optimize( context.getLogicalToPhysicalPlanConverter().convert(initialPlan,false) );
+		return optimize( context.getLogicalToPhysicalPlanConverter().convert(initialPlan,true) );
 	}
 
 	public Pair<PhysicalPlan, QueryOptimizationStats> optimize( final PhysicalPlan initialPlan ) throws QueryOptimizationException {

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/randomized/IterativeImprovementBasedQueryOptimizer.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/randomized/IterativeImprovementBasedQueryOptimizer.java
@@ -45,11 +45,10 @@ public class IterativeImprovementBasedQueryOptimizer extends RandomizedQueryOpti
 		int generation = 0;
 
 		while ( ! condition.readyToStop(generation) ) {
-			// The randomized plan generator is to be used here. As a temporary measure, the initial plan is used.
+			// Selects a random plan and uses it as the starting point for the optimization.
 			PhysicalPlan randomPlan = simpleOptimizer.optimizePlan(initialPlan);
 			PhysicalPlanWithCost currentPlan = PhysicalPlanWithCostUtils.annotatePlanWithCost( context.getCostModel(), randomPlan );
-			//PhysicalPlanWithCost currentPlan = PhysicalPlanWithCostUtils.annotatePlanWithCost( context.getCostModel(), initialPlan ); // This variable will hold the plan which is currently being worked on.
-
+			
 			boolean improvementFound = false;
 
 			do {

--- a/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/randomized/IterativeImprovementBasedQueryOptimizerTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/randomized/IterativeImprovementBasedQueryOptimizerTest.java
@@ -99,28 +99,24 @@ public class IterativeImprovementBasedQueryOptimizerTest extends EngineTestBase
 		};
 	}
 
-	protected static class TestOperator implements PhysicalOperatorForLogicalOperator {
+	protected static class DummyPhysicalOperatorForTest implements PhysicalOperatorForLogicalOperator {
 		@Override
 		public ExecutableOperator createExecOp(ExpectedVariables... inputVars) {
-			// TODO Auto-generated method stub
 			return null;
 		}
 
 		@Override
 		public ExpectedVariables getExpectedVariables(ExpectedVariables... inputVars) {
-			// TODO Auto-generated method stub
 			return null;
 		}
 
 		@Override
 		public void visit(PhysicalPlanVisitor visitor) {
-			// TODO Auto-generated method stub
 			
 		}
 
 		@Override
 		public LogicalOperator getLogicalOperator() {
-			// TODO Auto-generated method stub
 			return null;
 		}
 	}
@@ -129,7 +125,7 @@ public class IterativeImprovementBasedQueryOptimizerTest extends EngineTestBase
 		public final double cost;
 		public DummyPlanForTest( final double cost ) { this.cost = cost; }
 
-		@Override public PhysicalOperator getRootOperator() { return new TestOperator(); }
+		@Override public PhysicalOperator getRootOperator() { return new DummyPhysicalOperatorForTest(); }
 		@Override public ExpectedVariables getExpectedVariables() { return null; }
 		@Override public int numberOfSubPlans() { return 0; }
 		@Override public PhysicalPlan getSubPlan(int i) { return null; }

--- a/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/randomized/IterativeImprovementBasedQueryOptimizerTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/randomized/IterativeImprovementBasedQueryOptimizerTest.java
@@ -5,9 +5,13 @@ import org.junit.Test;
 import se.liu.ida.hefquin.engine.EngineTestBase;
 import se.liu.ida.hefquin.engine.federation.access.FederationAccessManager;
 import se.liu.ida.hefquin.engine.federation.catalog.FederationCatalog;
+import se.liu.ida.hefquin.engine.queryplan.ExecutableOperator;
 import se.liu.ida.hefquin.engine.queryplan.ExpectedVariables;
+import se.liu.ida.hefquin.engine.queryplan.LogicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.PhysicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.PhysicalPlan;
+import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalOperatorForLogicalOperator;
+import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
 import se.liu.ida.hefquin.engine.queryproc.QueryOptimizationException;
 import se.liu.ida.hefquin.engine.queryproc.impl.optimizer.CostModel;
 import se.liu.ida.hefquin.engine.queryproc.impl.optimizer.LogicalToPhysicalPlanConverter;
@@ -25,6 +29,8 @@ import static org.junit.Assert.*;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+
+
 
 public class IterativeImprovementBasedQueryOptimizerTest extends EngineTestBase
 {
@@ -93,11 +99,37 @@ public class IterativeImprovementBasedQueryOptimizerTest extends EngineTestBase
 		};
 	}
 
+	protected static class TestOperator implements PhysicalOperatorForLogicalOperator {
+		@Override
+		public ExecutableOperator createExecOp(ExpectedVariables... inputVars) {
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+		@Override
+		public ExpectedVariables getExpectedVariables(ExpectedVariables... inputVars) {
+			// TODO Auto-generated method stub
+			return null;
+		}
+
+		@Override
+		public void visit(PhysicalPlanVisitor visitor) {
+			// TODO Auto-generated method stub
+			
+		}
+
+		@Override
+		public LogicalOperator getLogicalOperator() {
+			// TODO Auto-generated method stub
+			return null;
+		}
+	}
+	
 	protected static class DummyPlanForTest implements PhysicalPlan {
 		public final double cost;
 		public DummyPlanForTest( final double cost ) { this.cost = cost; }
 
-		@Override public PhysicalOperator getRootOperator() { return null; }
+		@Override public PhysicalOperator getRootOperator() { return new TestOperator(); }
 		@Override public ExpectedVariables getExpectedVariables() { return null; }
 		@Override public int numberOfSubPlans() { return 0; }
 		@Override public PhysicalPlan getSubPlan(int i) { return null; }


### PR DESCRIPTION
I'm trying out using a SimpleJoinOrderingQueryOptimizer with a Randomized as its join-plan-optimizer as per your instructions, but I'm getting an error in the test due to some operation returning null. Since I don't quite understand how the joins work on a low-level I'm having trouble scratching my brain as to what is causing this error.