### PR TITLE
Consider tpAdd and bgpAdd in greedy join planning

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpIndexNestedLoopsJoin.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpIndexNestedLoopsJoin.java
@@ -66,7 +66,7 @@ public class PhysicalOpIndexNestedLoopsJoin extends BasePhysicalOpSingleInputJoi
 	@Override
 	public String toString(){
 
-		return "> indexNestedLoop " + lop.toString();
+		return "> indexNestedLoop" + lop.toString();
 	}
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/simple/GreedyJoinPlanOptimizerImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/simple/GreedyJoinPlanOptimizerImpl.java
@@ -1,8 +1,10 @@
 package se.liu.ida.hefquin.engine.queryproc.impl.optimizer.simple;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import se.liu.ida.hefquin.engine.queryplan.PhysicalPlan;
+import se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpRequest;
 import se.liu.ida.hefquin.engine.queryplan.utils.PhysicalPlanFactory;
 import se.liu.ida.hefquin.engine.queryproc.QueryOptimizationException;
 import se.liu.ida.hefquin.engine.queryproc.impl.optimizer.CostModel;
@@ -94,11 +96,19 @@ public class GreedyJoinPlanOptimizerImpl extends JoinPlanOptimizerBase
 		 * the right child.
 		 */
 		protected PhysicalPlan[] createNextPossiblePlans( final PhysicalPlan currentPlan ) {
-			final PhysicalPlan[] plans = new PhysicalPlan[ subplans.size() ];
+			final List<PhysicalPlan> plans = new ArrayList<>();
+
 			for ( int i = 0; i < subplans.size(); ++i ) {
-				plans[i] = PhysicalPlanFactory.createPlanWithJoin( currentPlan, subplans.get(i) );
+				plans.add( PhysicalPlanFactory.createPlanWithJoin(currentPlan, subplans.get(i)) );
+				if ( currentPlan.getRootOperator() instanceof PhysicalOpRequest ){
+					PhysicalPlanFactory.enumeratePlansWithUnaryOpFromReq( (PhysicalOpRequest) currentPlan.getRootOperator(), subplans.get(i), plans );
+				}
+				if ( subplans.get(i).getRootOperator() instanceof PhysicalOpRequest ) {
+					PhysicalPlanFactory.enumeratePlansWithUnaryOpFromReq( (PhysicalOpRequest) subplans.get(i).getRootOperator(), currentPlan, plans );
+				}
 			}
-			return plans;
+
+			return plans.toArray( new PhysicalPlan[plans.size()]);
 		}
 	}
 


### PR DESCRIPTION
1. Consider tpAdd and bgpAdd during greedy join planning;
2. Extract a helper function to enumerate possible physical plans for connecting two subplans (one of which uses PhysicalOpRequest as root operator ). This helper function can be used for greedy join planners and DB-based join planners.