### PR TITLE
Filter Operators

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanUtils.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryplan.logical;
 import se.liu.ida.hefquin.engine.federation.access.*;
 import se.liu.ida.hefquin.engine.queryplan.LogicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFilter;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayUnion;
@@ -66,6 +67,11 @@ public class LogicalPlanUtils
 
 		@Override
 		public void visit( final LogicalOpMultiwayUnion op )     {
+			subplanCount++;
+		}
+
+		@Override
+		public void visit( final LogicalOpFilter op )     {
 			subplanCount++;
 		}
 	}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanVisitor.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanVisitor.java
@@ -1,6 +1,7 @@
 package se.liu.ida.hefquin.engine.queryplan.logical;
 
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFilter;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayUnion;
@@ -20,4 +21,6 @@ public interface LogicalPlanVisitor
 
 	void visit( final LogicalOpMultiwayJoin op );
 	void visit( final LogicalOpMultiwayUnion op );
+	
+	void visit( final LogicalOpFilter op );
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanVisitorBase.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanVisitorBase.java
@@ -1,6 +1,7 @@
 package se.liu.ida.hefquin.engine.queryplan.logical;
 
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFilter;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayUnion;
@@ -23,4 +24,6 @@ public class LogicalPlanVisitorBase implements LogicalPlanVisitor
 	public void visit( final LogicalOpMultiwayJoin op )      {}
 
 	public void visit( final LogicalOpMultiwayUnion op )     {}
+
+	public void visit( final LogicalOpFilter op )     {}
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalOpFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalOpFilter.java
@@ -1,0 +1,51 @@
+package se.liu.ida.hefquin.engine.queryplan.logical.impl;
+
+import org.apache.jena.sparql.expr.Expr;
+
+import se.liu.ida.hefquin.engine.federation.FederationMember;
+import se.liu.ida.hefquin.engine.query.TriplePattern;
+import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanVisitor;
+import se.liu.ida.hefquin.engine.queryplan.logical.UnaryLogicalOp;
+
+public class LogicalOpFilter implements UnaryLogicalOp
+{
+	protected final Expr filterExpression;
+
+	public LogicalOpFilter( final Expr filterExpression) {
+		assert filterExpression != null;
+
+		this.filterExpression = filterExpression;
+	}
+
+	@Override
+	public boolean equals( final Object o ) {
+		if ( ! (o instanceof LogicalOpTPAdd) )
+			return false;
+
+		final LogicalOpFilter oo = (LogicalOpFilter) o;
+		if ( oo == this )
+			return true;
+		else
+			return oo.filterExpression.equals(filterExpression); 
+	}
+
+	public Expr getFilterExpression() {
+		return filterExpression;
+	}
+
+	@Override
+	public void visit( final LogicalPlanVisitor visitor ) {
+		visitor.visit(this);
+	}
+
+	@Override
+	public String toString(){ // Unsure about what to do with this one.
+		final int codeOfExpr = filterExpression.toString().hashCode();
+
+		return "> filter" +
+				"[" + codeOfExpr + "]"+
+				" ( "
+				+ filterExpression.getVarName()
+				+ " )";
+	}
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalOpFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalOpFilter.java
@@ -2,8 +2,6 @@ package se.liu.ida.hefquin.engine.queryplan.logical.impl;
 
 import org.apache.jena.sparql.expr.Expr;
 
-import se.liu.ida.hefquin.engine.federation.FederationMember;
-import se.liu.ida.hefquin.engine.query.TriplePattern;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanVisitor;
 import se.liu.ida.hefquin.engine.queryplan.logical.UnaryLogicalOp;
 

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalOpFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalOpFilter.java
@@ -17,15 +17,11 @@ public class LogicalOpFilter implements UnaryLogicalOp
 
 	@Override
 	public boolean equals( final Object o ) {
-		if ( ! (o instanceof LogicalOpFilter) )
-
-			return false;
+		if ( o == this ) return true;
+		if ( ! (o instanceof LogicalOpFilter) ) return false;
 
 		final LogicalOpFilter oo = (LogicalOpFilter) o;
-		if ( oo == this )
-			return true;
-		else
-			return oo.filterExpression.equals(filterExpression); 
+		return oo.filterExpression.equals(filterExpression); 
 	}
 
 	public Expr getFilterExpression() {

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalOpFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalOpFilter.java
@@ -38,13 +38,7 @@ public class LogicalOpFilter implements UnaryLogicalOp
 	}
 
 	@Override
-	public String toString(){ // Unsure about what to do with this one.
-		final int codeOfExpr = filterExpression.toString().hashCode();
-
-		return "> filter" +
-				"[" + codeOfExpr + "]"+
-				" ( "
-				+ filterExpression.getVarName()
-				+ " )";
+	public String toString() {
+		return "> filter ( " + filterExpression.toString() + " )";
 	}
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalOpFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalOpFilter.java
@@ -17,7 +17,8 @@ public class LogicalOpFilter implements UnaryLogicalOp
 
 	@Override
 	public boolean equals( final Object o ) {
-		if ( ! (o instanceof LogicalOpTPAdd) )
+		if ( ! (o instanceof LogicalOpFilter) )
+
 			return false;
 
 		final LogicalOpFilter oo = (LogicalOpFilter) o;

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalPlanPrinter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalPlanPrinter.java
@@ -4,6 +4,7 @@ import se.liu.ida.hefquin.engine.queryplan.LogicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanVisitor;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanWalker;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFilter;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayUnion;
@@ -78,6 +79,14 @@ public class LogicalPlanPrinter extends PlanPrinter{
 			builder.append(System.lineSeparator());
 			indentLevel++;
 		}
+		
+		@Override
+		public void visit(final LogicalOpFilter op) {
+			addTabs();
+			builder.append( op.toString() );
+			builder.append(System.lineSeparator());
+			indentLevel++;
+		}
 	}
 
 	private class LogicalPlanPrinterAfterVisitor implements LogicalPlanVisitor {
@@ -114,6 +123,11 @@ public class LogicalPlanPrinter extends PlanPrinter{
 
 		@Override
 		public void visit(final LogicalOpMultiwayUnion op) {
+			indentLevel--;
+		}
+
+		@Override
+		public void visit(final LogicalOpFilter op) {
 			indentLevel--;
 		}
 	}


### PR DESCRIPTION
>Add a corresponding logical operator and a corresponding physical operator. Begin with the logical one (because for implementing the physical one, you will need the logical one).
> 
> The class for the logical operator should be called `LogicalOpFilter`, it should go into the Java package `se.liu.ida.hefquin.engine.queryplan.logical.impl`, and it should implement the `UnaryLogicalOp` interface.
> 
> As an example of another such logical operator, take a look at `LogicalOpTPAdd`. You can essentially copy this class and replace its two member variables by a member variable of type `Expr` (i.e., exactly as you have it in the new executable operator in this PR here).
> 
> When you do this, you will notice that you also have to extend the `LogicalPlanVisitor` interface with an additional function for the new logical operator, and then you will also have to extend all classes that implement this interface (because they need to provide this additional function). The following list lists all these classes and what the added function should do:
> 
> * LogicalPlanCounter: do the same as for LogicalOpTPAdd
> * LogicalPlanPrinterAfterVisitor: do the same as for LogicalOpTPAdd
> * LogicalPlanPrinterBeforeVisitor: do the same as for LogicalOpTPAdd
> * LogicalPlanVisitorBase: do the same as for LogicalOpTPAdd

I've started with LogicalOpFilter, am I doing this correctly? My main pondering here is what to do with the toString() function. I made *a* toString(), but I don't know what utility it's supposed to serve.