### PR TITLE
Duplicate plans were created in DPBasedJoinPlanOptimizer

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/simple/DPBasedJoinPlanOptimizer.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/simple/DPBasedJoinPlanOptimizer.java
@@ -64,9 +64,6 @@ public class DPBasedJoinPlanOptimizer extends JoinPlanOptimizerBase {
                         if( plan_left.getRootOperator() instanceof PhysicalOpRequest){
                             PhysicalPlanFactory.enumeratePlansWithUnaryOpFromReq( (PhysicalOpRequest) plan_left.getRootOperator(), plan_right, candidatePlans );
                         }
-                        if( plan_right.getRootOperator() instanceof PhysicalOpRequest){
-                            PhysicalPlanFactory.enumeratePlansWithUnaryOpFromReq( (PhysicalOpRequest) plan_right.getRootOperator(), plan_right, candidatePlans );
-                        }
                     }
 
                     // Prune: only the best candidate plan is retained in optPlan.


### PR DESCRIPTION
Since the candidatePairs already contain two pairs in the opposite order, there is no need to create the plan twice with unaryOp