### PR TITLE
Physical Filter Operator

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/PhysicalPlanVisitor.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/PhysicalPlanVisitor.java
@@ -16,4 +16,6 @@ public interface PhysicalPlanVisitor {
     void visit(final PhysicalOpSymmetricHashJoin op);
 
     void visit(final PhysicalOpBinaryUnion op);
+
+    void visit(final PhysicalOpFilter op);
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpFilter.java
@@ -31,9 +31,8 @@ public class PhysicalOpFilter  implements UnaryPhysicalOpForLogicalOp {
 	}
 
 	@Override
-	public UnaryExecutableOp createExecOp(ExpectedVariables... inputVars) {
-		ExecOpFilter executableOp = new ExecOpFilter(logicalFilter.getFilterExpression());
-		return executableOp;
+	public UnaryExecutableOp createExecOp( final ExpectedVariables... inputVars ) {
+		return new ExecOpFilter(logicalFilter.getFilterExpression());
 	}
 
 	@Override

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpFilter.java
@@ -17,7 +17,7 @@ public class PhysicalOpFilter  implements UnaryPhysicalOpForLogicalOp {
 	}
 	
 	@Override
-	public ExpectedVariables getExpectedVariables(ExpectedVariables... inputVars) {
+	public ExpectedVariables getExpectedVariables( final ExpectedVariables... inputVars ) {
 		if(inputVars.length == 1) {
 			return inputVars[1];
 		} else {

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpFilter.java
@@ -26,7 +26,7 @@ public class PhysicalOpFilter  implements UnaryPhysicalOpForLogicalOp {
 	}
 
 	@Override
-	public void visit(PhysicalPlanVisitor visitor) {
+	public void visit( final PhysicalPlanVisitor visitor ) {
 		visitor.visit(this);
 	}
 

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpFilter.java
@@ -21,7 +21,7 @@ public class PhysicalOpFilter  implements UnaryPhysicalOpForLogicalOp {
 		if(inputVars.length == 1) {
 			return inputVars[1];
 		} else {
-			throw new IllegalArgumentException("There are more than 1 input variable.");
+			throw new IllegalArgumentException("There is more than 1 input variable.");
 		}
 	}
 

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpFilter.java
@@ -19,7 +19,7 @@ public class PhysicalOpFilter  implements UnaryPhysicalOpForLogicalOp {
 	@Override
 	public ExpectedVariables getExpectedVariables( final ExpectedVariables... inputVars ) {
 		if(inputVars.length == 1) {
-			return inputVars[1];
+			return inputVars[0];
 		} else {
 			throw new IllegalArgumentException("There is more than 1 input variable.");
 		}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpFilter.java
@@ -12,7 +12,7 @@ public class PhysicalOpFilter  implements UnaryPhysicalOpForLogicalOp {
 
 	protected final LogicalOpFilter logicalFilter;
 	
-	public PhysicalOpFilter(LogicalOpFilter lf) {
+	public PhysicalOpFilter( final LogicalOpFilter lf ) {
 		this.logicalFilter = lf;
 	}
 	

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpFilter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpFilter.java
@@ -1,0 +1,44 @@
+package se.liu.ida.hefquin.engine.queryplan.physical.impl;
+
+import se.liu.ida.hefquin.engine.queryplan.ExpectedVariables;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpFilter;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.UnaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.logical.UnaryLogicalOp;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFilter;
+import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
+import se.liu.ida.hefquin.engine.queryplan.physical.UnaryPhysicalOpForLogicalOp;
+
+public class PhysicalOpFilter  implements UnaryPhysicalOpForLogicalOp {
+
+	protected final LogicalOpFilter logicalFilter;
+	
+	public PhysicalOpFilter(LogicalOpFilter lf) {
+		this.logicalFilter = lf;
+	}
+	
+	@Override
+	public ExpectedVariables getExpectedVariables(ExpectedVariables... inputVars) {
+		if(inputVars.length == 1) {
+			return inputVars[1];
+		} else {
+			throw new IllegalArgumentException("There are more than 1 input variable.");
+		}
+	}
+
+	@Override
+	public void visit(PhysicalPlanVisitor visitor) {
+		visitor.visit(this);
+	}
+
+	@Override
+	public UnaryExecutableOp createExecOp(ExpectedVariables... inputVars) {
+		ExecOpFilter executableOp = new ExecOpFilter(logicalFilter.getFilterExpression());
+		return executableOp;
+	}
+
+	@Override
+	public UnaryLogicalOp getLogicalOperator() {
+		return logicalFilter;
+	}
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/PhysicalPlanPrinter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/PhysicalPlanPrinter.java
@@ -96,6 +96,14 @@ public class PhysicalPlanPrinter extends PlanPrinter{
             indentLevel++;
         }
 
+        @Override
+        public void visit( final PhysicalOpFilter op ) {
+            addTabs();
+            builder.append( op.toString() );
+            builder.append(System.lineSeparator());
+            indentLevel++;
+        }
+
     }
 
     private class PhysicalPlanPrinterAfterVisitor implements PhysicalPlanVisitor {
@@ -146,6 +154,11 @@ public class PhysicalPlanPrinter extends PlanPrinter{
 
         @Override
         public void visit(final PhysicalOpBinaryUnion op) {
+            indentLevel--;
+        }
+
+        @Override
+        public void visit(final PhysicalOpFilter op) {
             indentLevel--;
         }
     }


### PR DESCRIPTION
> You need to create a new class called `PhysicalOpFilter`. This class should go into the Java package `se.liu.ida.hefquin.engine.queryplan.physical.impl` and it should implement the `UnaryPhysicalOpForLogicalOp` interface.
> 
> It should have a `LogicalOpFilter` as a member variable, assigned through the constructor.
> 
> The `createExecOp` function that you need to implement in this class should create and return an `ExecOpFilter` and it can ignore the `inputVars` argument.
> 
> The `getExpectedVariables` function that you need to implement in this class should check that the `inputVars` argument is an array of length 1 (otherwise throw an IllegalArgumentException) and, then, it should simply return the one `ExpectedVariables` object contained in that array.

Done as far as my current understanding goes. Builds well and all tests should run.