### PR TITLE
Address issue #168

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/utils/CardinalityEstimationUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/utils/CardinalityEstimationUtils.java
@@ -46,9 +46,10 @@ public class CardinalityEstimationUtils
 	                                      final List<PhysicalPlan> plans )
 			throws CardinalityEstimationException
 	{
-		final List<Integer> costsOfPlans= new ArrayList<>();
+//		TODO: Temporarily set the batch size as 50
 		final List<List<PhysicalPlan>> blockOfPlans = PhysicalPlanWithCostUtils.slicePlans(plans, 50);
 
+		final List<Integer> costsOfPlans= new ArrayList<>();
 		for ( List<PhysicalPlan> oneBlockOfPlans: blockOfPlans ){
 			@SuppressWarnings("unchecked")
 			final CompletableFuture<Integer>[] futures = new CompletableFuture[oneBlockOfPlans.size()];

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/utils/CardinalityEstimationUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/utils/CardinalityEstimationUtils.java
@@ -1,5 +1,6 @@
 package se.liu.ida.hefquin.engine.queryproc.impl.optimizer.utils;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -45,24 +46,28 @@ public class CardinalityEstimationUtils
 	                                      final List<PhysicalPlan> plans )
 			throws CardinalityEstimationException
 	{
-		@SuppressWarnings("unchecked")
-		final CompletableFuture<Integer>[] futures = new CompletableFuture[plans.size()];
+		final List<Integer> costsOfPlans= new ArrayList<>();
+		final List<List<PhysicalPlan>> blockOfPlans = PhysicalPlanWithCostUtils.slicePlans(plans, 50);
 
-		for ( int i = 0; i < plans.size(); ++i ) {
-			futures[i] = cardEstimate.initiateCardinalityEstimation( plans.get(i) );
-		}
+		for ( List<PhysicalPlan> oneBlockOfPlans: blockOfPlans ){
+			@SuppressWarnings("unchecked")
+			final CompletableFuture<Integer>[] futures = new CompletableFuture[oneBlockOfPlans.size()];
+			for (int i = 0; i < oneBlockOfPlans.size(); ++i) {
+				futures[i] = cardEstimate.initiateCardinalityEstimation(oneBlockOfPlans.get(i));
+			}
 
-		try {
-			return CompletableFutureUtils.getAll(futures, Integer.class);
-		}
-		catch ( final CompletableFutureUtils.GetAllException ex ) {
-			if ( ex.getCause() != null && ex.getCause() instanceof InterruptedException ) {
-				throw new CardinalityEstimationException("Unexpected interruption when getting a cardinality estimate.", ex.getCause(), plans.get(ex.i) );
+			try {
+				Integer[] cardinalities= CompletableFutureUtils.getAll(futures, Integer.class);
+				costsOfPlans.addAll(List.of(cardinalities));
+			} catch (final CompletableFutureUtils.GetAllException ex) {
+				if (ex.getCause() != null && ex.getCause() instanceof InterruptedException) {
+					throw new CardinalityEstimationException("Unexpected interruption when getting a cardinality estimate.", ex.getCause(), plans.get(ex.i));
+				} else {
+					throw new CardinalityEstimationException("Getting a cardinality estimate caused an exception.", ex.getCause(), plans.get(ex.i));
+				}
 			}
-			else {
-				throw new CardinalityEstimationException("Getting a cardinality estimate caused an exception.", ex.getCause(), plans.get(ex.i) );
-			}
 		}
+		return costsOfPlans.toArray(new Integer[plans.size()]);
 	}
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/utils/CostEstimationUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/utils/CostEstimationUtils.java
@@ -37,9 +37,10 @@ public class CostEstimationUtils
 	                                     final List<PhysicalPlan> plans )
 			throws CostEstimationException
 	{
-		final List<Double> costsOfPlans= new ArrayList<>();
-
+//		TODO: Temporarily set the batch size as 50
 		final List<List<PhysicalPlan>> blockOfPlans = PhysicalPlanWithCostUtils.slicePlans(plans, 50);
+
+		final List<Double> costsOfPlans= new ArrayList<>();
 		for ( List<PhysicalPlan> oneBlockOfPlans : blockOfPlans ) {
 			@SuppressWarnings("unchecked")
 			final CompletableFuture<Double>[] futures = new CompletableFuture[oneBlockOfPlans.size()];

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/utils/CostEstimationUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/utils/CostEstimationUtils.java
@@ -1,5 +1,6 @@
 package se.liu.ida.hefquin.engine.queryproc.impl.optimizer.utils;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -36,24 +37,30 @@ public class CostEstimationUtils
 	                                     final List<PhysicalPlan> plans )
 			throws CostEstimationException
 	{
-		@SuppressWarnings("unchecked")
-		final CompletableFuture<Double>[] futures = new CompletableFuture[plans.size()];
+		final List<Double> costsOfPlans= new ArrayList<>();
 
-		for ( int i = 0; i < plans.size(); ++i ) {
-			futures[i] = costModel.initiateCostEstimation( plans.get(i) );
-		}
+		final List<List<PhysicalPlan>> blockOfPlans = PhysicalPlanWithCostUtils.slicePlans(plans, 50);
+		for ( List<PhysicalPlan> oneBlockOfPlans : blockOfPlans ) {
+			@SuppressWarnings("unchecked")
+			final CompletableFuture<Double>[] futures = new CompletableFuture[oneBlockOfPlans.size()];
+			for (int i = 0; i < oneBlockOfPlans.size(); ++i) {
+				futures[i] = costModel.initiateCostEstimation(oneBlockOfPlans.get(i));
+			}
 
-		try {
-			return CompletableFutureUtils.getAll(futures, Double.class);
-		}
-		catch ( final CompletableFutureUtils.GetAllException ex ) {
-			if ( ex.getCause() != null && ex.getCause() instanceof InterruptedException ) {
-				throw new CostEstimationException("Unexpected interruption when getting a cost estimate.", ex.getCause(), plans.get(ex.i) );
+			try {
+				Double[] costs= CompletableFutureUtils.getAll(futures, Double.class);
+				costsOfPlans.addAll(List.of(costs));
 			}
-			else {
-				throw new CostEstimationException("Getting a cost estimate caused an exception.", ex.getCause(), plans.get(ex.i) );
+			catch ( final CompletableFutureUtils.GetAllException ex ) {
+				if ( ex.getCause() != null && ex.getCause() instanceof InterruptedException ) {
+					throw new CostEstimationException("Unexpected interruption when getting a cost estimate.", ex.getCause(), plans.get(ex.i) );
+				}
+				else {
+					throw new CostEstimationException("Getting a cost estimate caused an exception.", ex.getCause(), plans.get(ex.i) );
+				}
 			}
 		}
+		return costsOfPlans.toArray(new Double[plans.size()]);
 	}
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/utils/PhysicalPlanWithCostUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/optimizer/utils/PhysicalPlanWithCostUtils.java
@@ -37,6 +37,23 @@ public class PhysicalPlanWithCostUtils {
         return plansWithCost;
     }
 
+    public static <T> List<List<T>> slicePlans( final List<T> plans, final int batchSize ) {
+        final List<List<T>> planBatches = new ArrayList<>();
+        if (plans ==null || plans.size() == 0) {
+            return planBatches;
+        }
+
+        int from = 0, to = 0, slicedItems = 0;
+        while ( slicedItems < plans.size() ) {
+            to = from + Math.min(batchSize, plans.size() - to);
+            final List<T> slice = plans.subList(from, to);
+            planBatches.add(slice);
+            slicedItems += slice.size();
+            from = to;
+        }
+        return planBatches;
+    }
+
     public static PhysicalPlanWithCost findPlanWithLowestCost( final List<PhysicalPlanWithCost> plansWithCost ) {
         if ( plansWithCost.size() == 0 ) {
             throw new IllegalArgumentException( "Cannot find the plan with lowest cost from an empty set" );


### PR DESCRIPTION
Extend the implementation of CostEstimationUtils.getEstimates and CostEstimationUtils.getEstimates: 
instead of creating CompletableFutures for all given plans, takes plans in batches (temporarily set the batch size as 50).