### PR TITLE
Adds JoiningIteratorForSolMaps and JoiningIterableForSolMaps

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/JoiningIterableForSolMaps.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/JoiningIterableForSolMaps.java
@@ -8,6 +8,9 @@ import se.liu.ida.hefquin.engine.data.SolutionMapping;
  * This is an iterable of solution mappings that enumerates the result of
  * joining two collections of solution mappings. The implementation uses
  * a {@link JoiningIteratorForSolMaps}.
+ *
+ * If you need the join result materialized, use
+ * {@link SolutionMappingUtils#nestedLoopJoin(Iterable, Iterable)} instead.
  */
 public class JoiningIterableForSolMaps implements Iterable<SolutionMapping>
 {

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/JoiningIterableForSolMaps.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/JoiningIterableForSolMaps.java
@@ -1,0 +1,31 @@
+package se.liu.ida.hefquin.engine.data.utils;
+
+import java.util.Iterator;
+
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+
+/**
+ * This is an iterable of solution mappings that enumerates the result of
+ * joining two collections of solution mappings. The implementation uses
+ * a {@link JoiningIteratorForSolMaps}.
+ */
+public class JoiningIterableForSolMaps implements Iterable<SolutionMapping>
+{
+	protected final Iterable<SolutionMapping> input1;
+	protected final Iterable<SolutionMapping> input2;
+
+	public JoiningIterableForSolMaps( final Iterable<SolutionMapping> input1,
+	                                  final Iterable<SolutionMapping> input2 ) {
+		assert input1 != null;
+		assert input2 != null;
+
+		this.input1 = input1;
+		this.input2 = input2;
+	}
+
+	@Override
+	public Iterator<SolutionMapping> iterator() {
+		return new JoiningIteratorForSolMaps(input1, input2);
+	}
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/JoiningIteratorForSolMaps.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/JoiningIteratorForSolMaps.java
@@ -1,0 +1,66 @@
+package se.liu.ida.hefquin.engine.data.utils;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+
+/**
+ * This iterator enumerates the result of joining two collections of solution
+ * mappings. The current implementation of this iterator performs a nested
+ * loops join.
+ */
+public class JoiningIteratorForSolMaps implements Iterator<SolutionMapping>
+{
+	protected final Iterable<SolutionMapping> input2;
+
+	protected Iterator<SolutionMapping> it1;
+	protected Iterator<SolutionMapping> it2;
+
+	protected SolutionMapping currentInputElement;
+	protected SolutionMapping nextOutputElement;
+
+	public JoiningIteratorForSolMaps( final Iterable<SolutionMapping> input1,
+	                                  final Iterable<SolutionMapping> input2 ) {
+		this.input2 = input2;
+
+		it1 = input1.iterator();
+		it2 = input2.iterator();
+
+		currentInputElement = it1.hasNext() ? it1.next() : null;
+		nextOutputElement   = null;
+	}
+
+	@Override
+	public boolean hasNext() {
+		while ( nextOutputElement == null && currentInputElement != null ) {
+			if ( it2.hasNext() ) {
+				final SolutionMapping s = it2.next();  // advance in the inner loop
+				if ( SolutionMappingUtils.compatible(s, currentInputElement) ) {
+					nextOutputElement = SolutionMappingUtils.merge(s, currentInputElement);
+				}
+			}
+			else if ( it1.hasNext() ) {
+				currentInputElement = it1.next();  // advance in the outer loop
+				it2 = input2.iterator();           // and restart the inner loop
+			}
+			else {
+				currentInputElement = null; // prepare to terminate
+			}
+		}
+
+		return ( nextOutputElement != null );
+	}
+
+	@Override
+	public SolutionMapping next() {
+		if ( ! hasNext() ) {
+			throw new NoSuchElementException();
+		}
+
+		final SolutionMapping r = nextOutputElement;
+		nextOutputElement = null;
+		return r;
+	}
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/JoiningIteratorForSolMaps.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/JoiningIteratorForSolMaps.java
@@ -9,6 +9,9 @@ import se.liu.ida.hefquin.engine.data.SolutionMapping;
  * This iterator enumerates the result of joining two collections of solution
  * mappings. The current implementation of this iterator performs a nested
  * loops join.
+ *
+ * If you need the join result materialized, use
+ * {@link SolutionMappingUtils#nestedLoopJoin(Iterable, Iterable)} instead.
  */
 public class JoiningIteratorForSolMaps implements Iterator<SolutionMapping>
 {

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingUtils.java
@@ -129,7 +129,11 @@ public class SolutionMappingUtils
 	}
 
 	/**
-	 * Performs a nested-loop join between two Solution Mapping iterables
+	 * Performs a nested-loop join between two Solution Mapping iterables.
+	 *
+	 * If you do not need the join result materialized (as done by this function),
+	 * it is better to use {@link JoiningIterableForSolMaps} instead (or the
+	 * iterator version: {@link JoiningIteratorForSolMaps}).
 	 */
 	public static Set<SolutionMapping> nestedLoopJoin( final Iterable<SolutionMapping> i1,
 													   final Iterable<SolutionMapping> i2) {

--- a/src/test/java/se/liu/ida/hefquin/engine/data/utils/JoiningIteratorForSolMapsTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/data/utils/JoiningIteratorForSolMapsTest.java
@@ -1,0 +1,107 @@
+package se.liu.ida.hefquin.engine.data.utils;
+
+import static org.junit.Assert.assertFalse;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.binding.BindingBuilder;
+import org.junit.Test;
+
+import se.liu.ida.hefquin.engine.EngineTestBase;
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+import se.liu.ida.hefquin.engine.data.impl.SolutionMappingImpl;
+
+public class JoiningIteratorForSolMapsTest extends EngineTestBase
+{
+	@Test
+	public void joinTest() {
+		// create solution mappings for first input
+		final List<SolutionMapping> i1 = new ArrayList<>();
+		// - will have one join partner
+		i1.add( createSolMap("x", "http://example1.org", "y", "http://example1.org") );
+		// - will have the same join partner as the previous sol.map.
+		i1.add( createSolMap("x", "http://example1.org", "y", "http://example2.org") );
+		// - will have two join partners
+		i1.add( createSolMap("x", "http://example2.org") );
+		// - will have no join partners
+		i1.add( createSolMap("x", "http://example3.org") );
+
+		// create solution mappings for second input
+		final List<SolutionMapping> i2 = new ArrayList<>();
+		// - will not be join partner
+		i2.add( createSolMap("x", "http://example4.org") );
+		// - will be one of the two join partners for third
+		i2.add( createSolMap("x", "http://example2.org", "z", "http://example1.org") );
+		// - will be join partner for first and second
+		i2.add( createSolMap("x", "http://example1.org") );
+		// - will be one of the two join partners for third
+		i2.add( createSolMap("x", "http://example2.org", "z", "http://example2.org") );
+
+		final Iterator<SolutionMapping> it = new JoiningIteratorForSolMaps(i1, i2);
+
+		final Var x = Var.alloc("x");
+		final Var y = Var.alloc("y");
+		final Var z = Var.alloc("z");
+
+		assertHasNext( it, "http://example1.org", x, "http://example1.org", y );
+		assertHasNext( it, "http://example1.org", x, "http://example2.org", y );
+		assertHasNext( it, "http://example2.org", x, "http://example1.org", z );
+		assertHasNext( it, "http://example2.org", x, "http://example2.org", z );
+		assertFalse( it.hasNext() );
+
+		final Iterator<SolutionMapping> itSwap = new JoiningIteratorForSolMaps(i2, i1);
+
+		assertHasNext( itSwap, "http://example2.org", x, "http://example1.org", z );
+		assertHasNext( itSwap, "http://example1.org", x, "http://example1.org", y );
+		assertHasNext( itSwap, "http://example1.org", x, "http://example2.org", y );
+		assertHasNext( itSwap, "http://example2.org", x, "http://example2.org", z );
+		assertFalse( itSwap.hasNext() );
+	}
+
+	@Test
+	public void joinTestEmpty() {
+		// create solution mappings for first input
+		final List<SolutionMapping> i1 = new ArrayList<>();
+		// - will have no join partner
+		i1.add( createSolMap("x", "http://example1.org", "y", "http://example1.org") );
+
+		// second input is empty!
+		final List<SolutionMapping> i2 = new ArrayList<>();
+
+		final Iterator<SolutionMapping> it = new JoiningIteratorForSolMaps(i1, i2);
+		assertFalse( it.hasNext() );
+
+		final Iterator<SolutionMapping> itSwap = new JoiningIteratorForSolMaps(i2, i1);
+		assertFalse( itSwap.hasNext() );
+	}
+
+
+	// ----- helper methods ------------
+
+	/**
+	 * Use this method instead of {@link SolutionMappingUtils#createSolutionMapping(Var, Node)}
+	 * to make ensure new java objects for the variables and RDF terms.
+	 */
+	protected SolutionMapping createSolMap( final String varName, final String uriString ) {
+		final BindingBuilder b = BindingBuilder.create();
+		b.add( Var.alloc(varName), NodeFactory.createURI(uriString) );
+		return new SolutionMappingImpl( b.build() );
+	}
+
+	/**
+	 * Use this method instead of {@link SolutionMappingUtils#createSolutionMapping(Var, Node, Var, Node)}
+	 * to make ensure new java objects for the variables and RDF terms.
+	 */
+	protected SolutionMapping createSolMap( final String varName1, final String uriString1, final String varName2, final String uriString2 ) {
+		final BindingBuilder b = BindingBuilder.create();
+		b.add( Var.alloc(varName1), NodeFactory.createURI(uriString1) );
+		b.add( Var.alloc(varName2), NodeFactory.createURI(uriString2) );
+		return new SolutionMappingImpl( b.build() );
+	}
+
+}


### PR DESCRIPTION
This PR adds `JoiningIteratorForSolMaps` and `JoiningIterableForSolMaps` where the latter uses the former. These helper classes can be used to enumerate the result of a join of two collections of solution mappings. This is a streaming alternative to [SolutionMappingUtils.nestedLoopJoin](https://github.com/LiUSemWeb/HeFQUIN/blob/f21134e657c875705ee14d8269f0a38ff25dc656/src/main/java/se/liu/ida/hefquin/engine/data/utils/SolutionMappingUtils.java#L134) (see PR #183).

/cc @scferrada @JulietteVV 

