### PR TITLE
LocalToGlobal operator functionality.

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLocalToGlobal.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLocalToGlobal.java
@@ -34,8 +34,7 @@ public class ExecOpLocalToGlobal extends UnaryExecutableOpBase{
 	@Override
 	protected void _concludeExecution( final IntermediateResultElementSink sink, final ExecutionContext execCxt )
 			throws ExecOpExecutionException {
-		// TODO Auto-generated method stub
-		
+		// This function is empty on purpose. There is nothing to be done here for this operator.
 	}
 	
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLocalToGlobal.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLocalToGlobal.java
@@ -1,0 +1,41 @@
+package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
+
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+import se.liu.ida.hefquin.engine.data.VocabularyMapping;
+import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
+import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultBlock;
+import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
+import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
+
+public class ExecOpLocalToGlobal extends UnaryExecutableOpBase{
+
+	VocabularyMapping vocabularyMapping;
+	
+	public ExecOpLocalToGlobal(VocabularyMapping mapping) {
+		this.vocabularyMapping = mapping;
+	}
+	
+	@Override
+	public int preferredInputBlockSize() {
+		// TODO Auto-generated method stub
+		return 0;
+	}
+
+	@Override
+	protected void _process(IntermediateResultBlock input, IntermediateResultElementSink sink, ExecutionContext execCxt)
+			throws ExecOpExecutionException {
+		for (final SolutionMapping solution : input.getSolutionMappings() ) {
+			for (final SolutionMapping sm : vocabularyMapping.translateSolutionMapping( solution )) {
+				sink.send(sm);
+			}
+		}	
+	}
+
+	@Override
+	protected void _concludeExecution(IntermediateResultElementSink sink, ExecutionContext execCxt)
+			throws ExecOpExecutionException {
+		// TODO Auto-generated method stub
+		
+	}
+	
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLocalToGlobal.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLocalToGlobal.java
@@ -22,7 +22,7 @@ public class ExecOpLocalToGlobal extends UnaryExecutableOpBase{
 	}
 
 	@Override
-	protected void _process(IntermediateResultBlock input, IntermediateResultElementSink sink, ExecutionContext execCxt)
+	protected void _process( final IntermediateResultBlock input, final IntermediateResultElementSink sink, final ExecutionContext execCxt )
 			throws ExecOpExecutionException {
 		for (final SolutionMapping solution : input.getSolutionMappings() ) {
 			for (final SolutionMapping sm : vocabularyMapping.translateSolutionMapping( solution )) {

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLocalToGlobal.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLocalToGlobal.java
@@ -9,9 +9,10 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 public class ExecOpLocalToGlobal extends UnaryExecutableOpBase{
 
-	VocabularyMapping vocabularyMapping;
+	protected final VocabularyMapping vocabularyMapping;
 	
-	public ExecOpLocalToGlobal(VocabularyMapping mapping) {
+	public ExecOpLocalToGlobal( final VocabularyMapping mapping ) {
+		assert mapping != null;
 		this.vocabularyMapping = mapping;
 	}
 	

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLocalToGlobal.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLocalToGlobal.java
@@ -32,7 +32,7 @@ public class ExecOpLocalToGlobal extends UnaryExecutableOpBase{
 	}
 
 	@Override
-	protected void _concludeExecution(IntermediateResultElementSink sink, ExecutionContext execCxt)
+	protected void _concludeExecution( final IntermediateResultElementSink sink, final ExecutionContext execCxt )
 			throws ExecOpExecutionException {
 		// TODO Auto-generated method stub
 		

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLocalToGlobal.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLocalToGlobal.java
@@ -17,8 +17,7 @@ public class ExecOpLocalToGlobal extends UnaryExecutableOpBase{
 	
 	@Override
 	public int preferredInputBlockSize() {
-		// TODO Auto-generated method stub
-		return 0;
+		return 1;
 	}
 
 	@Override


### PR DESCRIPTION
This should implement the Local2Global functionality assuming I remembered it correctly that it is the sink object which the 'result' is sent to. The preferredInputBlockSize and _concludeExecution methods have been left empty for now.