### PR TITLE
Parallel multiway left join

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsIndexNoJoinVars.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/datastructures/impl/SolutionMappingsIndexNoJoinVars.java
@@ -1,0 +1,74 @@
+package se.liu.ida.hefquin.engine.datastructures.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.Var;
+
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+
+/**
+ * This is a special implementation of {@link SolutionMappingsIndex} that
+ * can be used for cases in which ALL indexed solution mappings should be
+ * returned as join partners. This is useful for joins between subpatterns
+ * that do not have any variable in common (i.e., no join variables).
+ */
+public class SolutionMappingsIndexNoJoinVars extends SolutionMappingsIndexBase
+{
+	protected final List<SolutionMapping> indexedSolMaps = new ArrayList<>();
+
+	@Override
+	public boolean add( final SolutionMapping sm ) {
+		return indexedSolMaps.add(sm);
+	}
+
+	@Override
+	public Iterable<SolutionMapping> getJoinPartners( final SolutionMapping sm ) throws UnsupportedOperationException {
+		return indexedSolMaps;
+	}
+
+	@Override
+	public Iterable<SolutionMapping> findSolutionMappings( final Var var, final Node value ) throws UnsupportedOperationException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Iterable<SolutionMapping> findSolutionMappings( final Var var1, final Node value1,
+	                                                       final Var var2, final Node value2 ) throws UnsupportedOperationException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Iterable<SolutionMapping> findSolutionMappings( final Var var1, final Node value1,
+	                                                       final Var var2, final Node value2,
+	                                                       final Var var3, final Node value3 ) throws UnsupportedOperationException {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public Iterable<SolutionMapping> getAllSolutionMappings() {
+		return indexedSolMaps;
+	}
+
+	@Override
+	public void clear() {
+		indexedSolMaps.clear();
+	}
+
+	@Override
+	public boolean contains( final Object obj ) {
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public boolean isEmpty() {
+		return indexedSolMaps.isEmpty();
+	}
+
+	@Override
+	public int size() {
+		return indexedSolMaps.size();
+	}
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpIndexNestedLoopsJoinWithRequestOps.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpIndexNestedLoopsJoinWithRequestOps.java
@@ -107,10 +107,16 @@ public abstract class BaseForExecOpIndexNestedLoopsJoinWithRequestOps<
 			final ExecutionContext execCxt) throws ExecOpExecutionException
 	{
 		final NullaryExecutableOp reqOp = createExecutableRequestOperator(sm);
+
 		if ( reqOp == null ) {
 			// this may happen if the given solution mapping
 			// contains a blank node for any of the variables
 			// that is used when creating the request
+
+			if ( useOuterJoinSemantics ) {
+				sink.send(sm);
+			}
+
 			return null;
 		}
 

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoin.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoin.java
@@ -2,6 +2,7 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import java.util.List;
 
+import se.liu.ida.hefquin.engine.queryplan.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultBlock;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
@@ -10,9 +11,12 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 public class ExecOpParallelMultiwayLeftJoin extends UnaryExecutableOpBase
 {
-	public ExecOpParallelMultiwayLeftJoin( final List<LogicalOpRequest<?,?>> optionalParts ) {
-		// TODO ...
-		
+	protected final List<LogicalOpRequest<?,?>> optionalParts;
+
+	public ExecOpParallelMultiwayLeftJoin( final List<LogicalOpRequest<?,?>> optionalParts,
+	                                       final ExpectedVariables inputVarsFromNonOptionalPart ) {
+		assert ! optionalParts.isEmpty();
+		this.optionalParts = optionalParts;
 	}
 
 	@Override

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoin.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoin.java
@@ -1,17 +1,41 @@
 package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.Var;
+
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultBlock;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
+import se.liu.ida.hefquin.engine.queryplan.logical.UnaryLogicalOp;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
+import se.liu.ida.hefquin.engine.queryplan.utils.LogicalOpUtils;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 public class ExecOpParallelMultiwayLeftJoin extends UnaryExecutableOpBase
 {
+/*
+	protected final List<UnaryPhysicalOp> optionalParts;
+
+
+	public ExecOpParallelMultiwayLeftJoin( final List<UnaryPhysicalOp> optionalParts,
+	                                       final ExpectedVariables inputVarsFromNonOptionalPart ) {
+		assert ! optionalParts.isEmpty();
+		//BasePhysicalOpSingleInputJoin
+		this.optionalParts = optionalParts;
+	}
+*/
 	protected final List<LogicalOpRequest<?,?>> optionalParts;
+	protected final List<?> indexes = null;
+	protected final Set<Node> sldjgkrjg = null;
 
 	public ExecOpParallelMultiwayLeftJoin( final List<LogicalOpRequest<?,?>> optionalParts,
 	                                       final ExpectedVariables inputVarsFromNonOptionalPart ) {
@@ -28,14 +52,54 @@ public class ExecOpParallelMultiwayLeftJoin extends UnaryExecutableOpBase
 	protected void _process( final IntermediateResultBlock input,
 	                         final IntermediateResultElementSink sink,
 	                         final ExecutionContext execCxt ) throws ExecOpExecutionException {
+		final List<SolutionMapping> inputForParallelProcess = new ArrayList<>();
+		for ( final SolutionMapping sm : input.getSolutionMappings() ) {
+			
+		}
+
 		// TODO ...
-		
+		final CompletableFuture<?>[] futures = new CompletableFuture<?>[ optionalParts.size() ];
+		for ( int i = 0; i < optionalParts.size(); i++ ) {
+			final LogicalOpRequest<?,?> req = optionalParts.get(i);
+			final ? index = indexes.get(i);
+			Worker w = new Worker(req, index);
+			futures[i] = CompletableFuture.runAsync( w, execCxt.getExecutorServiceForPlanTasks() );
+		}
+
+		// wait for all the futures to be completed
+		if ( futures.length > 0 ) {
+			try {
+				CompletableFuture.allOf(futures).get();
+			}
+			catch ( final InterruptedException e ) {
+				throw new ExecOpExecutionException("interruption of the futures that run the executable operators", e, this);
+			}
+			catch ( final ExecutionException e ) {
+				throw new ExecOpExecutionException("The execution of the futures that run the executable operators caused an exception.", e, this);
+			}
+		}
+
 	}
 
 	@Override
 	protected void _concludeExecution( final IntermediateResultElementSink sink,
 	                                   final ExecutionContext execCxt ) throws ExecOpExecutionException {
 		// nothing to be done here
+	}
+
+
+	protected static class Worker implements Runnable {
+		protected final LogicalOpRequest<?,?> req;
+		protected final 
+
+		public Worker( final LogicalOpRequest<?,?> req ) { this.req = req; }
+
+		@Override
+		public void run() {
+			UnaryLogicalOp addOp = LogicalOpUtils.createLogicalAddOpFromLogicalReqOp(req);
+			// TODO ...
+		}
+		
 	}
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoin.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoin.java
@@ -1,0 +1,37 @@
+package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
+
+import java.util.List;
+
+import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
+import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultBlock;
+import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
+import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
+
+public class ExecOpParallelMultiwayLeftJoin extends UnaryExecutableOpBase
+{
+	public ExecOpParallelMultiwayLeftJoin( final List<LogicalOpRequest<?,?>> optionalParts ) {
+		// TODO ...
+		
+	}
+
+	@Override
+	public int preferredInputBlockSize() {
+		return 30;
+	}
+
+	@Override
+	protected void _process( final IntermediateResultBlock input,
+	                         final IntermediateResultElementSink sink,
+	                         final ExecutionContext execCxt ) throws ExecOpExecutionException {
+		// TODO ...
+		
+	}
+
+	@Override
+	protected void _concludeExecution( final IntermediateResultElementSink sink,
+	                                   final ExecutionContext execCxt ) throws ExecOpExecutionException {
+		// nothing to be done here
+	}
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoin.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoin.java
@@ -34,6 +34,11 @@ public class ExecOpParallelMultiwayLeftJoin extends UnaryExecutableOpBase
 	protected final Set<List<Node>> bindingsForJoinVariable = new HashSet<>();
 
 	public ExecOpParallelMultiwayLeftJoin( final ExpectedVariables inputVarsFromNonOptionalPart,
+	                                       final LogicalOpRequest<?,?> ... optionalParts ) {
+		this( inputVarsFromNonOptionalPart, Arrays.asList(optionalParts) );
+	}
+
+	public ExecOpParallelMultiwayLeftJoin( final ExpectedVariables inputVarsFromNonOptionalPart,
 	                                       final List<LogicalOpRequest<?,?>> optionalParts ) {
 		assert ! optionalParts.isEmpty();
 

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/PhysicalPlanVisitor.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/PhysicalPlanVisitor.java
@@ -15,6 +15,8 @@ public interface PhysicalPlanVisitor
 	void visit( PhysicalOpNaiveNestedLoopsJoin op );
 	void visit( PhysicalOpIndexNestedLoopsJoin op );
 
+	void visit( PhysicalOpParallelMultiLeftJoin op );
+
 	void visit( PhysicalOpHashJoin op );
 	void visit( PhysicalOpSymmetricHashJoin op );
 

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpParallelMultiLeftJoin.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpParallelMultiLeftJoin.java
@@ -1,0 +1,73 @@
+package se.liu.ida.hefquin.engine.queryplan.physical.impl;
+
+import java.util.List;
+import java.util.Set;
+
+import org.apache.jena.sparql.core.Var;
+
+import se.liu.ida.hefquin.engine.queryplan.ExpectedVariables;
+import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpParallelMultiwayLeftJoin;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
+import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
+import se.liu.ida.hefquin.engine.queryplan.physical.UnaryPhysicalOp;
+
+public class PhysicalOpParallelMultiLeftJoin implements UnaryPhysicalOp
+{
+	protected final List<LogicalOpRequest<?,?>> optionalParts;
+
+	public PhysicalOpParallelMultiLeftJoin( final List<LogicalOpRequest<?,?>> optionalParts ) {
+		assert ! optionalParts.isEmpty();
+		this.optionalParts = optionalParts;
+	}
+
+	@Override
+	public ExpectedVariables getExpectedVariables( final ExpectedVariables... inputVars ) {
+		assert inputVars.length == 1;
+
+		final Set<Var> certainVars = inputVars[0].getCertainVariables();
+		final Set<Var> possibleVars = inputVars[0].getPossibleVariables();
+
+		for ( final LogicalOpRequest<?,?> req : optionalParts ) {
+			final ExpectedVariables ev = req.getRequest().getExpectedVariables();
+			possibleVars.addAll( ev.getCertainVariables() );
+			possibleVars.addAll( ev.getPossibleVariables() );
+		}
+
+		possibleVars.removeAll(certainVars);
+
+		return new ExpectedVariables() {
+			@Override public Set<Var> getCertainVariables() { return certainVars; }
+			@Override public Set<Var> getPossibleVariables() { return possibleVars; }
+		};
+	}
+
+	@Override
+	public UnaryExecutableOp createExecOp( final ExpectedVariables... inputVars ) {
+		assert inputVars.length == 1;
+
+		return new ExecOpParallelMultiwayLeftJoin( optionalParts, inputVars[0] );
+	}
+
+	@Override
+	public void visit( final PhysicalPlanVisitor visitor ) {
+		visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals( final Object o ) {
+		return o instanceof PhysicalOpParallelMultiLeftJoin
+				&& ((PhysicalOpParallelMultiLeftJoin) o).optionalParts.equals(optionalParts);
+	}
+
+	@Override
+	public int hashCode(){
+		return optionalParts.hashCode();
+	}
+
+	@Override
+	public String toString(){
+		return "> parallelMultiLeftJoin with " + optionalParts.size() + " optional parts";
+	}
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpParallelMultiLeftJoin.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpParallelMultiLeftJoin.java
@@ -1,5 +1,7 @@
 package se.liu.ida.hefquin.engine.queryplan.physical.impl;
 
+import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -9,11 +11,82 @@ import se.liu.ida.hefquin.engine.queryplan.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpParallelMultiwayLeftJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
+import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalOperator;
+import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
 import se.liu.ida.hefquin.engine.queryplan.physical.UnaryPhysicalOp;
+import se.liu.ida.hefquin.engine.queryplan.utils.ExpectedVariablesUtils;
 
 public class PhysicalOpParallelMultiLeftJoin implements UnaryPhysicalOp
 {
+	/**
+	 * Checks whether a {@link LogicalOpMultiwayLeftJoin} with the given list
+	 * of physical plans can be implemented by the parallel multi-left-join
+	 * (as captured by this physical operator). If yes, this method returns
+	 * the optional parts of that multi-left-join. If not, this method returns
+	 * <code>null</code>.
+	 */
+	public static List<LogicalOpRequest<?,?>> checkApplicability( final List<PhysicalPlan> children )
+	{
+		final List<LogicalOpRequest<?,?>> optionalParts = new ArrayList<>( children.size()-1 );
+		final List<ExpectedVariables> expVarsOfOptionalParts = new ArrayList<>( children.size()-1 );
+
+		final Iterator<PhysicalPlan> it = children.iterator();
+		final PhysicalPlan firstChildPlan = it.next(); // the non-optional part
+
+		// condition 1: every non-optional part is just a request operator
+		while ( it.hasNext() ) {
+			final PhysicalOperator childRootOp = it.next().getRootOperator();
+			final LogicalOpRequest<?,?> reqOp;
+			if ( childRootOp instanceof PhysicalOpRequest<?,?> ) {
+				reqOp = ((PhysicalOpRequest<?,?>) childRootOp).getLogicalOperator();
+			}
+			else if ( childRootOp instanceof PhysicalOpRequestWithTranslation<?,?>  ) {
+				reqOp = ((PhysicalOpRequestWithTranslation<?,?>) childRootOp).getLogicalOperator();
+			}
+			else {
+				return null;
+			}
+
+			optionalParts.add(reqOp);
+			expVarsOfOptionalParts.add( reqOp.getRequest().getExpectedVariables() );
+		}
+
+		// condition 2: the join variable(s) between the non-optional part
+		//              and an optional part must be the same for each of
+		//              the optional parts
+		final ExpectedVariables expVarsNonOptPart = firstChildPlan.getExpectedVariables();
+
+		final Iterator<ExpectedVariables> it2 = expVarsOfOptionalParts.iterator();
+		final ExpectedVariables expVarsFirstOptPart = it2.next();
+		final Set<Var> joinVarsFirstOptPart = ExpectedVariablesUtils.intersectionOfAllVariables(expVarsNonOptPart, expVarsFirstOptPart);
+
+		while ( it2.hasNext() ) {
+			final ExpectedVariables expVarsNextOptPart = it2.next();
+			final Set<Var> joinVarsNextOptPart = ExpectedVariablesUtils.intersectionOfAllVariables(expVarsNonOptPart, expVarsNextOptPart);
+			if ( ! joinVarsNextOptPart.equals(joinVarsFirstOptPart) ) {
+				return null;
+			}
+		}
+
+		// condition 3: the only variables that different optional parts
+		//              have in common are the join variable(s)
+		// hence, we need to do a pairwise comparison
+		for ( int i = 0; i < expVarsOfOptionalParts.size()-1; i++ ) {
+			final ExpectedVariables iExpVarsOptPart = expVarsOfOptionalParts.get(i);
+			for ( int j = i+1; j < expVarsOfOptionalParts.size(); j++ ) {
+				final ExpectedVariables jExpVarsOptPart = expVarsOfOptionalParts.get(j);
+				final Set<Var> test = ExpectedVariablesUtils.intersectionOfAllVariables(iExpVarsOptPart, jExpVarsOptPart);
+				if ( ! test.equals(joinVarsFirstOptPart) ) {
+					return null;
+				}
+			}
+		}
+
+		return optionalParts;
+	}
+
+
 	protected final List<LogicalOpRequest<?,?>> optionalParts;
 
 	public PhysicalOpParallelMultiLeftJoin( final List<LogicalOpRequest<?,?>> optionalParts ) {

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpParallelMultiLeftJoin.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpParallelMultiLeftJoin.java
@@ -46,7 +46,7 @@ public class PhysicalOpParallelMultiLeftJoin implements UnaryPhysicalOp
 	public UnaryExecutableOp createExecOp( final ExpectedVariables... inputVars ) {
 		assert inputVars.length == 1;
 
-		return new ExecOpParallelMultiwayLeftJoin( optionalParts, inputVars[0] );
+		return new ExecOpParallelMultiwayLeftJoin( inputVars[0], optionalParts );
 	}
 
 	@Override

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
@@ -192,7 +192,10 @@ public class LogicalOpUtils {
             throw new IllegalArgumentException( "unsupported type of logical operator: " + lop.getClass().getName() );
         }
 
-        final LogicalOpRequest<?, ?> reqOp = (LogicalOpRequest<?, ?>) lop;
+        return createLogicalAddOpFromLogicalReqOp( (LogicalOpRequest<?, ?>) lop );
+    }
+
+    public static UnaryLogicalOp createLogicalAddOpFromLogicalReqOp( final LogicalOpRequest<?, ?> reqOp ) {
         final DataRetrievalRequest req = reqOp.getRequest();
         final FederationMember fm = reqOp.getFederationMember();
 

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalToPhysicalPlanConverterImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalToPhysicalPlanConverterImpl.java
@@ -179,7 +179,7 @@ public class LogicalToPhysicalPlanConverterImpl implements LogicalToPhysicalPlan
 		// Before going to the generic option that works for all cases,
 		// check whether we have a case in which the parallel multi-left-
 		// join can be used.
-		final List<LogicalOpRequest<?,?>> optionalParts = getOptionalPartsForParallelMultiLeftJoin(children);
+		final List<LogicalOpRequest<?,?>> optionalParts = PhysicalOpParallelMultiLeftJoin.checkApplicability(children);
 		if ( optionalParts != null ) {
 			// If the parallel multi-left-join can indeed be used, do so.
 			final UnaryPhysicalOp rootOp = new PhysicalOpParallelMultiLeftJoin(optionalParts);

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalToPhysicalPlanConverterImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalToPhysicalPlanConverterImpl.java
@@ -1,7 +1,11 @@
 package se.liu.ida.hefquin.engine.queryplan.utils;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+
+import org.apache.jena.sparql.core.Var;
 
 import se.liu.ida.hefquin.engine.queryplan.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.NaryExecutableOp;
@@ -15,15 +19,19 @@ import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayLeftJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayUnion;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRightJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpUnion;
 import se.liu.ida.hefquin.engine.queryplan.physical.NaryPhysicalOp;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
+import se.liu.ida.hefquin.engine.queryplan.physical.UnaryPhysicalOp;
 import se.liu.ida.hefquin.engine.queryplan.physical.impl.BasePhysicalOpMultiwayJoin;
 import se.liu.ida.hefquin.engine.queryplan.physical.impl.BasePhysicalOpMultiwayLeftJoin;
+import se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpParallelMultiLeftJoin;
 import se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpRequest;
+import se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpRequestWithTranslation;
 
 public class LogicalToPhysicalPlanConverterImpl implements LogicalToPhysicalPlanConverter
 {
@@ -168,6 +176,18 @@ public class LogicalToPhysicalPlanConverterImpl implements LogicalToPhysicalPlan
 			return children.get(0);
 		}
 
+		// Before going to the generic option that works for all cases,
+		// check whether we have a case in which the parallel multi-left-
+		// join can be used.
+		final List<LogicalOpRequest<?,?>> optionalParts = getOptionalPartsForParallelMultiLeftJoin(children);
+		if ( optionalParts != null ) {
+			// If the parallel multi-left-join can indeed be used, do so.
+			final UnaryPhysicalOp rootOp = new PhysicalOpParallelMultiLeftJoin(optionalParts);
+			return PhysicalPlanFactory.createPlan( rootOp, children.get(0) );
+		}
+
+		// Now comes the generic option that works for all cases.
+
 		if ( keepMultiwayJoins ) {
 			final NaryPhysicalOp pop = new BasePhysicalOpMultiwayLeftJoin(lop) {
 				@Override public void visit(PhysicalPlanVisitor visitor) { throw new UnsupportedOperationException(); }
@@ -201,6 +221,71 @@ public class LogicalToPhysicalPlanConverterImpl implements LogicalToPhysicalPlan
 		}
 
 		return currentSubPlan;
+	}
+
+	/**
+	 * Checks whether we have a case in which the parallel multi-left-join can
+	 * be used. If so, this method returns the optional parts of that multi-left-
+	 * join. If not, this method returns <code>null</code>.
+	 */
+	protected static List<LogicalOpRequest<?,?>> getOptionalPartsForParallelMultiLeftJoin( final List<PhysicalPlan> children )
+	{
+		final List<LogicalOpRequest<?,?>> optionalParts = new ArrayList<>( children.size()-1 );
+		final List<ExpectedVariables> expVarsOfOptionalParts = new ArrayList<>( children.size()-1 );
+
+		final Iterator<PhysicalPlan> it = children.iterator();
+		final PhysicalPlan firstChildPlan = it.next(); // the non-optional part
+
+		// condition 1: every non-optional part is just a request operator
+		while ( it.hasNext() ) {
+			final PhysicalOperator childRootOp = it.next().getRootOperator();
+			final LogicalOpRequest<?,?> reqOp;
+			if ( childRootOp instanceof PhysicalOpRequest<?,?> ) {
+				reqOp = ((PhysicalOpRequest<?,?>) childRootOp).getLogicalOperator();
+			}
+			else if ( childRootOp instanceof PhysicalOpRequestWithTranslation<?,?>  ) {
+				reqOp = ((PhysicalOpRequestWithTranslation<?,?>) childRootOp).getLogicalOperator();
+			}
+			else {
+				return null;
+			}
+
+			optionalParts.add(reqOp);
+			expVarsOfOptionalParts.add( reqOp.getRequest().getExpectedVariables() );
+		}
+
+		// condition 2: the join variable(s) between the non-optional part
+		//              and an optional part must be the same for each of
+		//              the optional parts
+		final ExpectedVariables expVarsNonOptPart = firstChildPlan.getExpectedVariables();
+
+		final Iterator<ExpectedVariables> it2 = expVarsOfOptionalParts.iterator();
+		final ExpectedVariables expVarsFirstOptPart = it2.next();
+		final Set<Var> joinVarsFirstOptPart = ExpectedVariablesUtils.intersectionOfAllVariables(expVarsNonOptPart, expVarsFirstOptPart);
+
+		while ( it2.hasNext() ) {
+			final ExpectedVariables expVarsNextOptPart = it2.next();
+			final Set<Var> joinVarsNextOptPart = ExpectedVariablesUtils.intersectionOfAllVariables(expVarsNonOptPart, expVarsNextOptPart);
+			if ( ! joinVarsNextOptPart.equals(joinVarsFirstOptPart) ) {
+				return null;
+			}
+		}
+
+		// condition 3: the only variables that different optional parts
+		//              have in common are the join variable(s)
+		// hence, we need to do a pairwise comparison
+		for ( int i = 0; i < expVarsOfOptionalParts.size()-1; i++ ) {
+			final ExpectedVariables iExpVarsOptPart = expVarsOfOptionalParts.get(i);
+			for ( int j = i+1; j < expVarsOfOptionalParts.size(); j++ ) {
+				final ExpectedVariables jExpVarsOptPart = expVarsOfOptionalParts.get(j);
+				final Set<Var> test = ExpectedVariablesUtils.intersectionOfAllVariables(iExpVarsOptPart, jExpVarsOptPart);
+				if ( ! test.equals(joinVarsFirstOptPart) ) {
+					return null;
+				}
+			}
+		}
+
+		return optionalParts;
 	}
 
 	protected PhysicalPlan createPhysicalPlanForMultiwayUnion( final LogicalOpMultiwayUnion lop, final List<PhysicalPlan> children ) {

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/PhysicalPlanPrinter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/PhysicalPlanPrinter.java
@@ -88,6 +88,14 @@ public class PhysicalPlanPrinter extends PlanPrinter{
         }
 
         @Override
+        public void visit( final PhysicalOpParallelMultiLeftJoin op ) {
+            addTabs();
+            builder.append( op.toString() );
+            builder.append( System.lineSeparator() );
+            indentLevel++;
+        }
+
+        @Override
         public void visit( final PhysicalOpHashJoin op ) {
             addTabs();
             builder.append( op.toString() );
@@ -188,6 +196,11 @@ public class PhysicalPlanPrinter extends PlanPrinter{
 
         @Override
         public void visit(final PhysicalOpIndexNestedLoopsJoin op) {
+            indentLevel--;
+        }
+
+        @Override
+        public void visit(final PhysicalOpParallelMultiLeftJoin op) {
             indentLevel--;
         }
 

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinBRTPFTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinBRTPFTest.java
@@ -70,6 +70,16 @@ public class ExecOpBindJoinBRTPFTest extends TestsForTPAddAlgorithms<BRTPFServer
 		_tpWithEmptyResponses(true);
 	}
 
+	@Test
+	public void tpWithIllegalBNodeJoin_InnerJoin() throws ExecutionException {
+		_tpWithIllegalBNodeJoin(false);
+	}
+
+	@Test
+	public void tpWithIllegalBNodeJoin_OuterJoin() throws ExecutionException {
+		_tpWithIllegalBNodeJoin(true);
+	}
+
 
 	@Override
 	protected BRTPFServer createFedMemberForTest( final Graph dataForMember ) {

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinBRTPFTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinBRTPFTest.java
@@ -1,5 +1,7 @@
 package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
+import java.util.concurrent.ExecutorService;
+
 import org.apache.jena.graph.Graph;
 import org.junit.Test;
 
@@ -84,6 +86,11 @@ public class ExecOpBindJoinBRTPFTest extends TestsForTPAddAlgorithms<BRTPFServer
 	@Override
 	protected BRTPFServer createFedMemberForTest( final Graph dataForMember ) {
 		return new BRTPFServerForTest(dataForMember);
+	}
+
+	@Override
+	protected ExecutorService getExecutorServiceForTest() {
+		return null;
 	}
 
 	@Override

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithFILTERTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithFILTERTest.java
@@ -1,5 +1,7 @@
 package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
+import java.util.concurrent.ExecutorService;
+
 import org.apache.jena.graph.Graph;
 import org.junit.Test;
 
@@ -84,6 +86,11 @@ public class ExecOpBindJoinSPARQLwithFILTERTest extends TestsForTPAddAlgorithms<
 	@Override
 	protected SPARQLEndpoint createFedMemberForTest(Graph dataForMember) {
 		return new SPARQLEndpointForTest(dataForMember);
+	}
+
+	@Override
+	protected ExecutorService getExecutorServiceForTest() {
+		return null;
 	}
 
 	@Override

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithFILTERTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithFILTERTest.java
@@ -70,6 +70,16 @@ public class ExecOpBindJoinSPARQLwithFILTERTest extends TestsForTPAddAlgorithms<
 		_tpWithEmptyResponses(true);
 	}
 
+	@Test
+	public void tpWithIllegalBNodeJoin_InnerJoin() throws ExecutionException {
+		_tpWithIllegalBNodeJoin(false);
+	}
+
+	@Test
+	public void tpWithIllegalBNodeJoin_OuterJoin() throws ExecutionException {
+		_tpWithIllegalBNodeJoin(true);
+	}
+
 
 	@Override
 	protected SPARQLEndpoint createFedMemberForTest(Graph dataForMember) {

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithUNIONTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithUNIONTest.java
@@ -1,5 +1,7 @@
 package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
+import java.util.concurrent.ExecutorService;
+
 import org.apache.jena.graph.Graph;
 import org.junit.Test;
 
@@ -56,6 +58,11 @@ public class ExecOpBindJoinSPARQLwithUNIONTest extends TestsForTPAddAlgorithms<S
 	@Override
 	protected SPARQLEndpoint createFedMemberForTest( final Graph dataForMember) {
 		return new SPARQLEndpointForTest(dataForMember);
+	}
+
+	@Override
+	protected ExecutorService getExecutorServiceForTest() {
+		return null;
 	}
 
 	@Override

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithUNIONTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithUNIONTest.java
@@ -44,6 +44,11 @@ public class ExecOpBindJoinSPARQLwithUNIONTest extends TestsForTPAddAlgorithms<S
 	}
 
 	@Test
+	public void tpWithIllegalBNodeJoin() throws ExecutionException {
+		_tpWithIllegalBNodeJoin(false);
+	}
+
+	@Test
 	public void tpWithSpuriousDuplicates() throws ExecutionException {
 		_tpWithSpuriousDuplicates(false);
 	}

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithVALUESTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithVALUESTest.java
@@ -44,6 +44,11 @@ public class ExecOpBindJoinSPARQLwithVALUESTest extends TestsForTPAddAlgorithms<
 	}
 
 	@Test
+	public void tpWithIllegalBNodeJoin() throws ExecutionException {
+		_tpWithIllegalBNodeJoin(false);
+	}
+
+	@Test
 	public void tpWithSpuriousDuplicates() throws ExecutionException {
 		_tpWithSpuriousDuplicates(false);
 	}

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinSPARQLTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinSPARQLTest.java
@@ -41,6 +41,11 @@ public class ExecOpIndexNestedLoopsJoinSPARQLTest extends TestsForTPAddAlgorithm
 		_tpWithEmptyResponses(false);
 	}
 
+	@Test
+	public void tpWithIllegalBNodeJoin() throws ExecutionException {
+		_tpWithIllegalBNodeJoin(false);
+	}
+
 
 	@Override
 	protected SPARQLEndpoint createFedMemberForTest( final Graph dataForMember ) {

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinSPARQLTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinSPARQLTest.java
@@ -1,5 +1,7 @@
 package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
+import java.util.concurrent.ExecutorService;
+
 import org.apache.jena.graph.Graph;
 import org.junit.Test;
 
@@ -50,6 +52,11 @@ public class ExecOpIndexNestedLoopsJoinSPARQLTest extends TestsForTPAddAlgorithm
 	@Override
 	protected SPARQLEndpoint createFedMemberForTest( final Graph dataForMember ) {
 		return new SPARQLEndpointForTest(dataForMember);
+	}
+
+	@Override
+	protected ExecutorService getExecutorServiceForTest() {
+		return null;
 	}
 
 	@Override

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinTPFTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinTPFTest.java
@@ -70,6 +70,16 @@ public class ExecOpIndexNestedLoopsJoinTPFTest extends TestsForTPAddAlgorithms<T
 		_tpWithEmptyResponses(true);
 	}
 
+	@Test
+	public void tpWithIllegalBNodeJoin_InnerJoin() throws ExecutionException {
+		_tpWithIllegalBNodeJoin(false);
+	}
+
+	@Test
+	public void tpWithIllegalBNodeJoin_OuterJoin() throws ExecutionException {
+		_tpWithIllegalBNodeJoin(true);
+	}
+
 
 	@Override
 	protected TPFServer createFedMemberForTest( final Graph dataForMember ) {

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinTPFTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinTPFTest.java
@@ -1,5 +1,7 @@
 package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
+import java.util.concurrent.ExecutorService;
+
 import org.apache.jena.graph.Graph;
 import org.junit.Test;
 
@@ -84,6 +86,11 @@ public class ExecOpIndexNestedLoopsJoinTPFTest extends TestsForTPAddAlgorithms<T
 	@Override
 	protected TPFServer createFedMemberForTest( final Graph dataForMember ) {
 		return new TPFServerForTest(dataForMember);
+	}
+
+	@Override
+	protected ExecutorService getExecutorServiceForTest() {
+		return null;
 	}
 
 	@Override

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoinTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoinTest.java
@@ -60,10 +60,11 @@ public class ExecOpParallelMultiwayLeftJoinTest extends TestsForTPAddAlgorithms<
 		_tpWithEmptyInput(true);
 	}
 
-	@Test
-	public void tpWithEmptySolutionMappingAsInput() throws ExecutionException {
-		_tpWithEmptySolutionMappingAsInput(true);
-	}
+// This test does not make much sense for the ExecOpParallelMultiwayLeftJoin
+//	@Test
+//	public void tpWithEmptySolutionMappingAsInput() throws ExecutionException {
+//		_tpWithEmptySolutionMappingAsInput(true);
+//	}
 
 	@Test
 	public void tpWithEmptyResponses() throws ExecutionException {

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoinTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoinTest.java
@@ -1,68 +1,89 @@
 package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.jena.graph.Graph;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import se.liu.ida.hefquin.engine.federation.SPARQLEndpoint;
+import se.liu.ida.hefquin.engine.federation.access.TriplePatternRequest;
+import se.liu.ida.hefquin.engine.federation.access.impl.req.TriplePatternRequestImpl;
 import se.liu.ida.hefquin.engine.query.TriplePattern;
 import se.liu.ida.hefquin.engine.queryplan.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPAdd;
-import se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpBindJoinWithVALUES;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionException;
 
-public class ExecOpBindJoinSPARQLwithVALUESTest extends TestsForTPAddAlgorithms<SPARQLEndpoint>{
-	
+public class ExecOpParallelMultiwayLeftJoinTest extends TestsForTPAddAlgorithms<SPARQLEndpoint>
+{
+	protected static ExecutorService execService;
+
+	@BeforeClass
+	public static void createExecService() {
+		execService = Executors.newCachedThreadPool();
+	}
+
+	@AfterClass
+	public static void tearDownExecService() {
+		execService.shutdownNow();
+		try {
+			execService.awaitTermination(500L, TimeUnit.MILLISECONDS);
+		}
+		catch ( final InterruptedException ex )  {
+			System.err.println("Terminating the thread pool was interrupted." );
+			ex.printStackTrace();
+		}
+	}
+
+
 	@Test
 	public void tpWithJoinOnObject() throws ExecutionException {
-		_tpWithJoinOnObject(false);
+		_tpWithJoinOnObject(true);
 	}
 
 	@Test
 	public void tpWithJoinOnSubjectAndObject() throws ExecutionException {
-		_tpWithJoinOnSubjectAndObject(false);
+		_tpWithJoinOnSubjectAndObject(true);
 	}
 
 	@Test
 	public void tpWithoutJoinVariable() throws ExecutionException {
-		_tpWithoutJoinVariable(false);
+		_tpWithoutJoinVariable(true);
 	}
 
 	@Test
 	public void tpWithEmptyInput() throws ExecutionException {
-		_tpWithEmptyInput(false);
+		_tpWithEmptyInput(true);
 	}
 
 	@Test
 	public void tpWithEmptySolutionMappingAsInput() throws ExecutionException {
-		_tpWithEmptySolutionMappingAsInput(false);
+		_tpWithEmptySolutionMappingAsInput(true);
 	}
 
 	@Test
 	public void tpWithEmptyResponses() throws ExecutionException {
-		_tpWithEmptyResponses(false);
+		_tpWithEmptyResponses(true);
 	}
 
 	@Test
 	public void tpWithIllegalBNodeJoin() throws ExecutionException {
-		_tpWithIllegalBNodeJoin(false);
+		_tpWithIllegalBNodeJoin(true);
 	}
 
-	@Test
-	public void tpWithSpuriousDuplicates() throws ExecutionException {
-		_tpWithSpuriousDuplicates(false);
-	}
 
 	@Override
-	protected SPARQLEndpoint createFedMemberForTest( final Graph dataForMember ) {
+	protected SPARQLEndpoint createFedMemberForTest(Graph dataForMember) {
 		return new SPARQLEndpointForTest(dataForMember);
 	}
 
 	@Override
 	protected ExecutorService getExecutorServiceForTest() {
-		return null;
+		return execService;
 	}
 
 	@Override
@@ -70,12 +91,13 @@ public class ExecOpBindJoinSPARQLwithVALUESTest extends TestsForTPAddAlgorithms<
 	                                                 final SPARQLEndpoint fm,
 	                                                 final ExpectedVariables expectedVariables,
 	                                                 final boolean useOuterJoinSemantics ) {
-		if ( useOuterJoinSemantics )
+		if ( ! useOuterJoinSemantics )
 			throw new UnsupportedOperationException();
 
-		final LogicalOpTPAdd tpAdd = new LogicalOpTPAdd(fm, tp);
-		final PhysicalOpBindJoinWithVALUES physicalOp = new PhysicalOpBindJoinWithVALUES(tpAdd);
-		return physicalOp.createExecOp(expectedVariables);
+		final TriplePatternRequest req = new TriplePatternRequestImpl(tp);
+		final LogicalOpRequest<?,?> reqOp = new LogicalOpRequest<>(fm, req);
+		return new ExecOpParallelMultiwayLeftJoin( expectedVariables, reqOp );
 	}
+
 
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/TestsForTPAddAlgorithms.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/TestsForTPAddAlgorithms.java
@@ -518,7 +518,7 @@ public abstract class TestsForTPAddAlgorithms<MemberType extends FederationMembe
 		final ExecutionContext execCxt = new ExecutionContext() {
 			@Override public FederationCatalog getFederationCatalog() { return null; }
 			@Override public FederationAccessManager getFederationAccessMgr() { return fedAccessMgr; }
-			@Override public ExecutorService getExecutorServiceForPlanTasks() { return null; }
+			@Override public ExecutorService getExecutorServiceForPlanTasks() { return getExecutorServiceForTest(); }
 			@Override public CostModel getCostModel() { return null; }
 			@Override public boolean isExperimentRun() { return false; }
 		};
@@ -534,6 +534,8 @@ public abstract class TestsForTPAddAlgorithms<MemberType extends FederationMembe
 	}
 
 	protected abstract MemberType createFedMemberForTest( Graph dataForMember );
+
+	protected abstract ExecutorService getExecutorServiceForTest();
 
 	protected abstract UnaryExecutableOp createExecOpForTest( TriplePattern tp,
 	                                                          MemberType fm,

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/TestsForTPAddAlgorithms.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/TestsForTPAddAlgorithms.java
@@ -421,7 +421,51 @@ public abstract class TestsForTPAddAlgorithms<MemberType extends FederationMembe
 			assertFalse( it.hasNext() );
 		}
 	}
-	
+
+	protected void _tpWithIllegalBNodeJoin( final boolean useOuterJoinSemantics ) throws ExecutionException {
+		final Var var1 = Var.alloc("v1");
+
+		final Node p     = NodeFactory.createURI("http://example.org/p");
+		final Node uri   = NodeFactory.createURI("http://example.org/x1");
+		final Node bnode = NodeFactory.createBlankNode();
+
+		final GenericIntermediateResultBlockImpl input = new GenericIntermediateResultBlockImpl();
+		input.add( SolutionMappingUtils.createSolutionMapping(var1, bnode) );
+
+		final TriplePattern tp = new TriplePatternImpl(var1, p, uri);
+
+		final Graph dataForMember = GraphFactory.createGraphMem();
+		dataForMember.add( Triple.create(bnode, p, uri) );
+
+		final Iterator<SolutionMapping> it = runTest(input, dataForMember, tp, new ExpectedVariables() {
+			@Override
+			public Set<Var> getCertainVariables() {
+				final Set<Var> set = new HashSet<>();
+				set.add(var1);
+				return set;
+			}
+
+			@Override
+			public Set<Var> getPossibleVariables() {
+				return new HashSet<>();
+			}
+		}, useOuterJoinSemantics);
+
+		// checking
+		if ( useOuterJoinSemantics ) {
+			assertTrue( it.hasNext() );
+
+			final Binding b = it.next().asJenaBinding();
+			assertEquals( 1, b.size() );
+			assertTrue( b.get(var1).isBlank() );
+
+			assertFalse( it.hasNext() );
+		}
+		else { // useOuterJoinSemantics  == null
+			assertFalse( it.hasNext() );
+		}
+	}
+
 	protected void _tpWithSpuriousDuplicates( final boolean useOuterJoinSemantics ) {
 		final Var var1 = Var.alloc("v1");
 		final Var var2 = Var.alloc("v2");

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/TestsForTPAddAlgorithms.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/TestsForTPAddAlgorithms.java
@@ -283,7 +283,9 @@ public abstract class TestsForTPAddAlgorithms<MemberType extends FederationMembe
 		final Iterator<SolutionMapping> it = runTest(input, dataForMember, tp, new ExpectedVariables() {
 			@Override
 			public Set<Var> getCertainVariables() {
-				return new HashSet<>();
+				final Set<Var> set = new HashSet<>();
+				set.add(var2);
+				return set;
 			}
 
 			@Override


### PR DESCRIPTION
Implement ExecOpParallelMultiwayLeftJoin: 
- Create indexes structure based on the number of joinVariables for each optional part;
- Implement a runnable worker to populate intermediate results into the index; 
- Produce final output by merging intermediate results (left out join)