### PR TITLE
RW and rewriteReqOf

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
@@ -97,12 +97,13 @@ public class LogicalOpUtils {
 		}
 		
 		if(P instanceof SPARQLUnionPattern) {
-			final LogicalOpMultiwayUnion newRoot = LogicalOpMultiwayUnion.getInstance();
-			final List<LogicalPlan> subPlans = new ArrayList<LogicalPlan>();
+			final List<LogicalPlan> subPlans = new ArrayList<>();
 			for ( final SPARQLGraphPattern subP : ((SPARQLUnionPattern) P).getSubPatterns() ) {
 				final LogicalPlan subPlan = rewriteReqOf(subP,fm);
 				subPlans.add(subPlan);
 			}
+
+			final LogicalOpMultiwayUnion newRoot = LogicalOpMultiwayUnion.getInstance();
 			final LogicalPlan newPlan = new LogicalPlanWithNaryRootImpl(newRoot, subPlans);
 			return newPlan;
 		}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
@@ -110,12 +110,13 @@ public class LogicalOpUtils {
 		}
 		
 		if(P instanceof SPARQLGroupPattern) {
-			final LogicalOpMultiwayJoin newRoot = LogicalOpMultiwayJoin.getInstance();
-			final List<LogicalPlan> subPlans = new ArrayList<LogicalPlan>();
+			final List<LogicalPlan> subPlans = new ArrayList<>();
 			for ( final SPARQLGraphPattern subP : ((SPARQLGroupPattern) P).getSubPatterns() ) {
 				final LogicalPlan subPlan = rewriteReqOf(subP,fm);
 				subPlans.add(subPlan);
 			}
+
+			final LogicalOpMultiwayJoin newRoot = LogicalOpMultiwayJoin.getInstance();
 			final LogicalPlan newPlan = new LogicalPlanWithNaryRootImpl(newRoot, subPlans);
 			return newPlan;
 		}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
@@ -2,6 +2,8 @@ package se.liu.ida.hefquin.engine.queryplan.utils;
 
 import org.apache.jena.sparql.core.BasicPattern;
 import org.apache.jena.sparql.syntax.*;
+
+import se.liu.ida.hefquin.engine.data.VocabularyMapping;
 import se.liu.ida.hefquin.engine.federation.FederationMember;
 import se.liu.ida.hefquin.engine.federation.access.BGPRequest;
 import se.liu.ida.hefquin.engine.federation.access.DataRetrievalRequest;
@@ -27,6 +29,35 @@ import java.util.HashSet;
 import java.util.Set;
 
 public class LogicalOpUtils {
+	
+	public static LogicalOperator RW(final LogicalOpRequest<?, ?> req) {
+		final FederationMember fm = req.getFederationMember();
+		final VocabularyMapping vm = fm.getVocabularyMapping();
+		// Get P from req, use reqtype?
+		// If it's not a TP, return as-is or throw error?
+		// newP = ApplyVocabularyMapping(tp,vm)
+		// return rewriteReqOf(newP, fm)
+		
+		return req;
+	}
+	
+	public static LogicalOperator rewriteReqOf(final SPARQLGraphPattern P, final FederationMember fm) {
+		if (fm.getInterface().supportsBGPRequests()) { // Are all interfaces which support BGP requests SPARQL endpoints? Based on the assumption that there are two types of interfaces: TPF-server and SPARQL-endpoint, and TPF-servers do not.
+			// return req(P,fm);
+		} // If not, continue.
+		
+		// If P is a TP
+		// Create request and return
+		
+		// If P is a BGP
+		// Do stuff and return
+		
+		// If P is UP
+		
+		// If P GP
+		
+		return null; // Return statement. When this algorithm is finished, an error should be thrown if it for some reason gets here.
+	}
 
     /**
      * Creates a BGP by merging two sets of triple patterns,

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
@@ -70,7 +70,11 @@ public class LogicalOpUtils {
 	 * for use when a federation member's interface is a TPF-server.
 	 */
 	public static LogicalPlan rewriteReqOf(final SPARQLGraphPattern P, final FederationMember fm) {
-		if (fm instanceof SPARQLEndpoint) { // Right now there are just TPF-servers and SPARQL endpoints, but there may be more in the future. For now, we will not assume that third types of interfaces will necessarily support all patterns.
+		// Right now there are just TPF-servers and SPARQL endpoints, but there may be more in the future.
+		// For now, we will not assume that third types of interfaces will necessarily support all patterns.
+
+		// For SPARQL endpoints, the whole graph pattern can be sent in a single request.
+		if ( fm instanceof SPARQLEndpoint ) {
 			final SPARQLRequest reqP = new SPARQLRequestImpl(P);
 			final LogicalOpRequest<SPARQLRequest, SPARQLEndpoint> req = new LogicalOpRequest<>( (SPARQLEndpoint) fm, reqP );
 			final LogicalPlan newPlan = new LogicalPlanWithNullaryRootImpl(req);

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
@@ -90,6 +90,8 @@ public class LogicalOpUtils {
 				final LogicalOpRequest<BGPRequest, FederationMember> req = new LogicalOpRequest<>(fm,BGPreq);
 				final LogicalPlan BGPplan = new LogicalPlanWithNullaryRootImpl(req);
 				return BGPplan;
+			} else if ( !fm.getInterface().supportsTriplePatternRequests() ) {
+				throw new IllegalArgumentException( "The federation member does not support TP-requests!" );
 			}
 			final List<LogicalPlan> subPlans = new ArrayList<>();
 			for ( final TriplePattern tp : ((BGP) P).getTriplePatterns() ) {

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
@@ -69,7 +69,7 @@ public class LogicalOpUtils {
 		
 		if(P instanceof BGP) {
 			// Create something regarding multijoin
-			for (TriplePattern tp : ((BGP) P).getTriplePatterns() ) {
+			for ( final TriplePattern tp : ((BGP) P).getTriplePatterns() ) {
 				// Add them into the multi-join-related thing.
 			}
 			// Return

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
@@ -70,7 +70,7 @@ public class LogicalOpUtils {
 	public static LogicalPlan rewriteReqOf(final SPARQLGraphPattern P, final FederationMember fm) {
 		if (fm instanceof SPARQLEndpoint) { // Right now there are just TPF-servers and SPARQL endpoints, but there may be more in the future. For now, we will not assume that third types of interfaces will necessarily support all patterns.
 			final SPARQLRequest reqP = new SPARQLRequestImpl(P);
-			final LogicalOpRequest<SPARQLRequest, FederationMember> req = new LogicalOpRequest<SPARQLRequest, FederationMember>(fm,reqP);
+			final LogicalOpRequest<SPARQLRequest, SPARQLEndpoint> req = new LogicalOpRequest<>( (SPARQLEndpoint) fm, reqP );
 			final LogicalPlan newPlan = new LogicalPlanWithNullaryRootImpl(req);
 			return newPlan;
 		} // If not, continue.

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
@@ -42,8 +42,8 @@ public class LogicalOpUtils {
 		if(!(req.getRequest() instanceof TriplePatternRequest)) {
 			throw new UnsupportedOperationException( "no support for " + req.getRequest().getClass().getName() );
 		}
-		final TriplePatternRequest tpreq = (TriplePatternRequest) req.getRequest(); // Cast the request to be a TriplePatternRequest.
-		final TriplePattern tp = tpreq.getQueryPattern(); // Get the tp.
+		final TriplePatternRequest tpreq = (TriplePatternRequest) req.getRequest();
+		final TriplePattern tp = tpreq.getQueryPattern();
 		
 		// ApplyVocabularyMapping(tp,vm)
 		final SPARQLGraphPattern newP = vm.translateTriplePattern(tp);

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
@@ -83,7 +83,7 @@ public class LogicalOpUtils {
 			// Multijoin
 		}
 		
-		return null; // Return statement. When this algorithm is finished, an error should be thrown if it for some reason gets here.
+		throw new IllegalArgumentException( P.getClass().getName() );
 	}
 
     /**

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
@@ -10,6 +10,7 @@ import se.liu.ida.hefquin.engine.federation.access.BGPRequest;
 import se.liu.ida.hefquin.engine.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.engine.federation.access.SPARQLRequest;
 import se.liu.ida.hefquin.engine.federation.access.TriplePatternRequest;
+import se.liu.ida.hefquin.engine.federation.access.impl.req.BGPRequestImpl;
 import se.liu.ida.hefquin.engine.federation.access.impl.req.SPARQLRequestImpl;
 import se.liu.ida.hefquin.engine.federation.access.impl.req.TriplePatternRequestImpl;
 import se.liu.ida.hefquin.engine.query.BGP;
@@ -84,6 +85,12 @@ public class LogicalOpUtils {
 		}
 		
 		if(P instanceof BGP) {
+			if ( fm.getInterface().supportsBGPRequests() ) {
+				final BGPRequest BGPreq = new BGPRequestImpl(((BGP)P));
+				final LogicalOpRequest<BGPRequest, FederationMember> req = new LogicalOpRequest<>(fm,BGPreq);
+				final LogicalPlan BGPplan = new LogicalPlanWithNullaryRootImpl(req);
+				return BGPplan;
+			}
 			final List<LogicalPlan> subPlans = new ArrayList<>();
 			for ( final TriplePattern tp : ((BGP) P).getTriplePatterns() ) {
 				final TriplePatternRequest reqP = new TriplePatternRequestImpl(tp);

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
@@ -82,6 +82,9 @@ public class LogicalOpUtils {
 		} // If not, continue.
 		
 		if(P instanceof TriplePattern){
+			if ( !fm.getInterface().supportsTriplePatternRequests() ) {
+				throw new IllegalArgumentException( "The federation member does not support TP-requests!" );
+			}
 			final TriplePatternRequest reqP = new TriplePatternRequestImpl((TriplePattern)P);
 			final LogicalOpRequest<SPARQLRequest, FederationMember> req = new LogicalOpRequest<>(fm,reqP);
 			final LogicalPlan newPlan = new LogicalPlanWithNullaryRootImpl(req);
@@ -111,6 +114,9 @@ public class LogicalOpUtils {
 		}
 		
 		if(P instanceof SPARQLUnionPattern) {
+			if ( !fm.getInterface().supportsTriplePatternRequests() ) {
+				throw new IllegalArgumentException( "The federation member does not support TP-requests!" );
+			}
 			final List<LogicalPlan> subPlans = new ArrayList<>();
 			for ( final SPARQLGraphPattern subP : ((SPARQLUnionPattern) P).getSubPatterns() ) {
 				final LogicalPlan subPlan = rewriteReqOf(subP,fm);
@@ -123,6 +129,9 @@ public class LogicalOpUtils {
 		}
 		
 		if(P instanceof SPARQLGroupPattern) {
+			if ( !fm.getInterface().supportsTriplePatternRequests() ) {
+				throw new IllegalArgumentException( "The federation member does not support TP-requests!" );
+			}
 			final List<LogicalPlan> subPlans = new ArrayList<>();
 			for ( final SPARQLGraphPattern subP : ((SPARQLGroupPattern) P).getSubPatterns() ) {
 				final LogicalPlan subPlan = rewriteReqOf(subP,fm);

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
@@ -40,7 +40,7 @@ public class LogicalOpUtils {
 		final VocabularyMapping vm = fm.getVocabularyMapping();
 		
 		if(!(req.getRequest() instanceof TriplePatternRequest)) {
-			// If it's not a TP, return as-is or throw error?
+			throw new UnsupportedOperationException( "no support for " + req.getRequest().getClass().getName() );
 		}
 		final TriplePatternRequest tpreq = (TriplePatternRequest) req.getRequest(); // Cast the request to be a TriplePatternRequest.
 		final TriplePattern tp = tpreq.getQueryPattern(); // Get the tp.

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
@@ -5,11 +5,13 @@ import org.apache.jena.sparql.syntax.*;
 
 import se.liu.ida.hefquin.engine.data.VocabularyMapping;
 import se.liu.ida.hefquin.engine.federation.FederationMember;
+import se.liu.ida.hefquin.engine.federation.SPARQLEndpoint;
 import se.liu.ida.hefquin.engine.federation.access.BGPRequest;
 import se.liu.ida.hefquin.engine.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.engine.federation.access.SPARQLRequest;
 import se.liu.ida.hefquin.engine.federation.access.TriplePatternRequest;
 import se.liu.ida.hefquin.engine.federation.access.impl.req.SPARQLRequestImpl;
+import se.liu.ida.hefquin.engine.federation.access.impl.req.TriplePatternRequestImpl;
 import se.liu.ida.hefquin.engine.query.BGP;
 import se.liu.ida.hefquin.engine.query.SPARQLGraphPattern;
 import se.liu.ida.hefquin.engine.query.SPARQLGroupPattern;
@@ -53,7 +55,7 @@ public class LogicalOpUtils {
 	}
 	
 	public static LogicalPlan rewriteReqOf(final SPARQLGraphPattern P, final FederationMember fm) {
-		if (fm.getInterface().supportsBGPRequests()) { // Are all interfaces which support BGP requests SPARQL endpoints? Based on the assumption that there are two types of interfaces: TPF-server and SPARQL-endpoint, and TPF-servers do not.
+		if (fm instanceof SPARQLEndpoint) { // Right now there are just TPF-servers and SPARQL endpoints, but there may be more in the future. For now, we will not assume that third types of interfaces will necessarily support all patterns.
 			final SPARQLRequest reqP = new SPARQLRequestImpl(P);
 			final LogicalOpRequest<SPARQLRequest, FederationMember> req = new LogicalOpRequest<SPARQLRequest, FederationMember>(fm,reqP);
 			final LogicalPlan newPlan = new LogicalPlanWithNullaryRootImpl(req);
@@ -61,7 +63,7 @@ public class LogicalOpUtils {
 		} // If not, continue.
 		
 		if(P instanceof TriplePattern){
-			final SPARQLRequest reqP = new SPARQLRequestImpl(P);
+			final TriplePatternRequest reqP = new TriplePatternRequestImpl((TriplePattern)P);
 			final LogicalOpRequest<SPARQLRequest, FederationMember> req = new LogicalOpRequest<SPARQLRequest, FederationMember>(fm,reqP);
 			final LogicalPlan newPlan = new LogicalPlanWithNullaryRootImpl(req);
 			return newPlan;

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
@@ -77,7 +77,7 @@ public class LogicalOpUtils {
 		
 		if(P instanceof TriplePattern){
 			final TriplePatternRequest reqP = new TriplePatternRequestImpl((TriplePattern)P);
-			final LogicalOpRequest<SPARQLRequest, FederationMember> req = new LogicalOpRequest<SPARQLRequest, FederationMember>(fm,reqP);
+			final LogicalOpRequest<SPARQLRequest, FederationMember> req = new LogicalOpRequest<>(fm,reqP);
 			final LogicalPlan newPlan = new LogicalPlanWithNullaryRootImpl(req);
 			return newPlan;
 		}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
@@ -48,14 +48,15 @@ public class LogicalOpUtils {
 	 * and can be handled by the federation member's interface.
 	 */
 	public static LogicalPlan RW(final LogicalOpRequest<?, ?> req) {
-		final FederationMember fm = req.getFederationMember();
-		final VocabularyMapping vm = fm.getVocabularyMapping();
-		
 		if(!(req.getRequest() instanceof TriplePatternRequest)) {
 			throw new UnsupportedOperationException( "no support for " + req.getRequest().getClass().getName() );
 		}
+
 		final TriplePatternRequest tpreq = (TriplePatternRequest) req.getRequest();
 		final TriplePattern tp = tpreq.getQueryPattern();
+
+		final FederationMember fm = req.getFederationMember();
+		final VocabularyMapping vm = fm.getVocabularyMapping();
 		
 		final SPARQLGraphPattern newP = vm.translateTriplePattern(tp);
 		

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
@@ -83,14 +83,15 @@ public class LogicalOpUtils {
 		}
 		
 		if(P instanceof BGP) {
-			final LogicalOpMultiwayJoin newRoot = LogicalOpMultiwayJoin.getInstance();
-			final List<LogicalPlan> subPlans = new ArrayList<LogicalPlan>();
+			final List<LogicalPlan> subPlans = new ArrayList<>();
 			for ( final TriplePattern tp : ((BGP) P).getTriplePatterns() ) {
 				final TriplePatternRequest reqP = new TriplePatternRequestImpl(tp);
-				final LogicalOpRequest<SPARQLRequest, FederationMember> req = new LogicalOpRequest<SPARQLRequest, FederationMember>(fm,reqP);
+				final LogicalOpRequest<TriplePatternRequest, FederationMember> req = new LogicalOpRequest<>(fm,reqP);
 				final LogicalPlan subPlan = new LogicalPlanWithNullaryRootImpl(req);
 				subPlans.add(subPlan);
 			}
+
+			final LogicalOpMultiwayJoin newRoot = LogicalOpMultiwayJoin.getInstance();
 			final LogicalPlan newPlan = new LogicalPlanWithNaryRootImpl(newRoot, subPlans);
 			return newPlan;
 		}


### PR DESCRIPTION
Since these are algorithms that work on operators and not operators in themselves, I found it fitting to add them to LogicalOpUtils as both their inputs and outputs are logical ops.

In HeFQUIN, the class 'LogicalOpRequest' which I assume is the request operator has in addition to a federation member also a 'reqtype'. Is the ExpectedVariables in ReqType what I should be looking at when seeing what sort of pattern the Request is requesting?