### PR TITLE
Unwind support

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/utils/CypherQueryUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/utils/CypherQueryUtils.java
@@ -77,7 +77,7 @@ public class CypherQueryUtils {
                 returns.add(r);
             }
         }
-        return new CypherMatchQueryImpl(matches, conditions, returns);
+        return new CypherMatchQueryImpl(matches, conditions, null, returns);
     }
 
     public static CypherUnionQuery combine(final CypherUnionQuery q1, final CypherMatchQuery q2) {

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/CypherMatchQuery.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/CypherMatchQuery.java
@@ -8,8 +8,8 @@ import java.util.List;
  * MATCH (x)
  * MATCH (a)-[b]->(c)
  * WHERE a:CLASS AND b.property='value'
- * RETURN x AS n1, c AS n2
- *
+ * UNWIND KEYS(a) AS k
+ * RETURN x AS n1, c AS n2, k AS key
  * can be represented with this interface.
  */
 public interface CypherMatchQuery extends CypherQuery {
@@ -28,6 +28,13 @@ public interface CypherMatchQuery extends CypherQuery {
      * @return a list of WhereCondition objects
      */
     List<WhereCondition> getConditions();
+
+    /**
+     * Obtains a list of iterator expressions, of the form list AS var, present on the query.
+     * For the example query, this method returns a list of one iterator: KEYS(a) AS k
+     * @return a list of UnwindIterator objects
+     */
+    List<UnwindIterator> getIterators();
 
     /**
      * Obtains a list of expressions with optional aliases that represent the columns being returned by the query.

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/UnwindIterator.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/UnwindIterator.java
@@ -1,0 +1,4 @@
+package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query;
+
+public interface UnwindIterator {
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/UnwindIterator.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/UnwindIterator.java
@@ -1,4 +1,39 @@
 package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query;
 
+import java.util.List;
+
+/**
+ * This interface represents an UNWIND clause of a Match Query.
+ * The relevant UNWIND clauses look like this:
+ *  UNWIND [tempvar IN listExpression WHERE filters | [returnExpressions]] AS alias
+ */
 public interface UnwindIterator {
+
+    /**
+     * Returns the inner, temporary variable that iterates through the values of listExpression
+     */
+    CypherVar getInnerVar();
+
+    /**
+     * Returns the expression that evaluates to a list, whose values are iterated through.
+     * TODO: this should return a CypherExpression Object
+     */
+    String getListExpression();
+
+    /**
+     * Returns the list of conditions that must evaluate to TRUE, for an element in listExpression
+     * to be considered in the final result.
+     */
+    List<WhereCondition> getFilters();
+
+    /**
+     * Returns the list of expressions that are returned for each element in listExpression that
+     * passes the filters. E.g.: k, a[k], etc.
+     */
+    List<String> getReturnExpressions();
+
+    /**
+     * Returns the CypherVar object that each set of return expressions is aliased as.
+     */
+    CypherVar getAlias();
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/CypherMatchQueryImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/CypherMatchQueryImpl.java
@@ -1,10 +1,6 @@
 package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl;
 
-import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherMatchQuery;
-import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherVar;
-import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.MatchClause;
-import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.ReturnStatement;
-import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.WhereCondition;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.*;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -13,19 +9,23 @@ public class CypherMatchQueryImpl implements CypherMatchQuery {
 
     final protected List<MatchClause> matches;
     final protected List<WhereCondition> conditions;
+
+    final protected List<UnwindIterator> iterators;
     final protected List<ReturnStatement> returnExprs;
 
     public CypherMatchQueryImpl() {
         matches = new ArrayList<>();
         conditions = new ArrayList<>();
         returnExprs = new ArrayList<>();
+        iterators = new ArrayList<>();
     }
 
     public CypherMatchQueryImpl(final List<MatchClause> matches, final List<WhereCondition> conditions,
-                                final List<ReturnStatement> returnExprs) {
+                                final List<UnwindIterator> iterators, final List<ReturnStatement> returnExprs) {
         this.matches = matches;
         this.conditions = conditions;
         this.returnExprs = returnExprs;
+        this.iterators = iterators;
     }
 
     @Override
@@ -36,6 +36,11 @@ public class CypherMatchQueryImpl implements CypherMatchQuery {
     @Override
     public List<WhereCondition> getConditions() {
         return conditions;
+    }
+
+    @Override
+    public List<UnwindIterator> getIterators() {
+        return iterators;
     }
 
     @Override

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/UnwindIteratorImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/UnwindIteratorImpl.java
@@ -1,0 +1,38 @@
+package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl;
+
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherVar;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.UnwindIterator;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.WhereCondition;
+
+import java.util.List;
+
+public class UnwindIteratorImpl implements UnwindIterator {
+
+    protected final CypherVar innerVar;
+    protected final String listExpression;
+    protected final List<WhereCondition> filters;
+    protected final List<String> returnExpressions;
+
+    public UnwindIteratorImpl(CypherVar innerVar, String listExpression, List<WhereCondition> filters, List<String> returnExpressions) {
+        this.innerVar = innerVar;
+        this.listExpression = listExpression;
+        this.filters = filters;
+        this.returnExpressions = returnExpressions;
+    }
+
+    public CypherVar getInnerVar() {
+        return innerVar;
+    }
+
+    public String getListExpression() {
+        return listExpression;
+    }
+
+    public List<WhereCondition> getFilters() {
+        return filters;
+    }
+
+    public List<String> getReturnExpressions() {
+        return returnExpressions;
+    }
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/UnwindIteratorImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/UnwindIteratorImpl.java
@@ -9,7 +9,7 @@ import java.util.List;
 public class UnwindIteratorImpl implements UnwindIterator {
 
     protected final CypherVar innerVar;
-    //TODO: this should be a CypherExpression
+    //TODO: this below should be a CypherExpression
     protected final String listExpression;
     protected final List<WhereCondition> filters;
     protected final List<String> returnExpressions;
@@ -18,6 +18,10 @@ public class UnwindIteratorImpl implements UnwindIterator {
     public UnwindIteratorImpl(final CypherVar innerVar, final String listExpression,
                               final List<WhereCondition> filters, final List<String> returnExpressions,
                               final CypherVar alias) {
+        assert innerVar != null;
+        assert listExpression != null;
+        assert alias != null;
+
         this.innerVar = innerVar;
         this.listExpression = listExpression;
         this.filters = filters;
@@ -25,19 +29,30 @@ public class UnwindIteratorImpl implements UnwindIterator {
         this.alias = alias;
     }
 
+    @Override
     public CypherVar getInnerVar() {
         return innerVar;
     }
 
+    @Override
     public String getListExpression() {
         return listExpression;
     }
 
+    @Override
     public List<WhereCondition> getFilters() {
         return filters;
     }
 
+    @Override
     public List<String> getReturnExpressions() {
         return returnExpressions;
     }
+
+    @Override
+    public CypherVar getAlias() {
+        return alias;
+    }
+
+
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/UnwindIteratorImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/UnwindIteratorImpl.java
@@ -5,6 +5,7 @@ import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.UnwindIterator;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.WhereCondition;
 
 import java.util.List;
+import java.util.Objects;
 
 public class UnwindIteratorImpl implements UnwindIterator {
 
@@ -54,5 +55,19 @@ public class UnwindIteratorImpl implements UnwindIterator {
         return alias;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UnwindIteratorImpl that = (UnwindIteratorImpl) o;
+        return innerVar.equals(that.innerVar) && listExpression.equals(that.listExpression)
+                && Objects.equals(filters, that.filters)
+                && Objects.equals(returnExpressions, that.returnExpressions)
+                && alias.equals(that.alias);
+    }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(innerVar, listExpression, filters, returnExpressions, alias);
+    }
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/UnwindIteratorImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/UnwindIteratorImpl.java
@@ -9,15 +9,20 @@ import java.util.List;
 public class UnwindIteratorImpl implements UnwindIterator {
 
     protected final CypherVar innerVar;
+    //TODO: this should be a CypherExpression
     protected final String listExpression;
     protected final List<WhereCondition> filters;
     protected final List<String> returnExpressions;
+    protected final CypherVar alias;
 
-    public UnwindIteratorImpl(CypherVar innerVar, String listExpression, List<WhereCondition> filters, List<String> returnExpressions) {
+    public UnwindIteratorImpl(final CypherVar innerVar, final String listExpression,
+                              final List<WhereCondition> filters, final List<String> returnExpressions,
+                              final CypherVar alias) {
         this.innerVar = innerVar;
         this.listExpression = listExpression;
         this.filters = filters;
         this.returnExpressions = returnExpressions;
+        this.alias = alias;
     }
 
     public CypherVar getInnerVar() {

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/condition/ListMembershipCondition.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/condition/ListMembershipCondition.java
@@ -1,0 +1,45 @@
+package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.condition;
+
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherVar;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.WhereCondition;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+public class ListMembershipCondition implements WhereCondition {
+
+    private final CypherVar testVar;
+    private final String listExpression;
+
+    public ListMembershipCondition(final CypherVar testVar, final String listExpression) {
+        assert testVar != null;
+        assert listExpression != null;
+        this.testVar = testVar;
+        this.listExpression = listExpression;
+    }
+
+    @Override
+    public Set<CypherVar> getVars() {
+        //TODO: listExpression should be a CypherExpression, its variables should be added to the returned set
+        return Collections.singleton(testVar);
+    }
+
+    @Override
+    public String toString() {
+        return testVar + " IN " + listExpression;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if(this==o) return true;
+        if(! (o instanceof ListMembershipCondition)) return false;
+        final ListMembershipCondition that = (ListMembershipCondition) o;
+        return this.listExpression.equals(that.listExpression) && this.testVar.equals(that.testVar);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(testVar, listExpression);
+    }
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherQueryBuilder.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherQueryBuilder.java
@@ -1,9 +1,6 @@
 package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils;
 
-import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherMatchQuery;
-import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.MatchClause;
-import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.ReturnStatement;
-import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.WhereCondition;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.*;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.CypherMatchQueryImpl;
 
 import java.util.ArrayList;
@@ -13,11 +10,13 @@ public class CypherQueryBuilder {
 
     private final List<MatchClause> matches;
     private final List<WhereCondition> conditions;
+    private final List<UnwindIterator> iterators;
     private final List<ReturnStatement> returns;
 
     public CypherQueryBuilder() {
         this.matches = new ArrayList<>();
         this.conditions = new ArrayList<>();
+        this.iterators = new ArrayList<>();
         this.returns = new ArrayList<>();
     }
 
@@ -31,6 +30,11 @@ public class CypherQueryBuilder {
         return this;
     }
 
+    public CypherQueryBuilder addIterator(final UnwindIterator iterator) {
+        this.iterators.add(iterator);
+        return this;
+    }
+
     public CypherQueryBuilder addReturn(final ReturnStatement ret) {
         this.returns.add(ret);
         return this;
@@ -41,6 +45,8 @@ public class CypherQueryBuilder {
             this.addMatch((MatchClause) clause);
         } else if (clause instanceof WhereCondition) {
             this.addCondition((WhereCondition) clause);
+        } else if (clause instanceof UnwindIterator) {
+            this.addIterator((UnwindIterator) clause);
         } else if (clause instanceof ReturnStatement) {
             this.addReturn((ReturnStatement) clause);
         } else {

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherQueryBuilder.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherQueryBuilder.java
@@ -50,6 +50,6 @@ public class CypherQueryBuilder {
     }
 
     public CypherMatchQuery build() {
-        return new CypherMatchQueryImpl(matches, conditions, returns);
+        return new CypherMatchQueryImpl(matches, conditions, null, returns);
     }
 }


### PR DESCRIPTION
This PR adds the `UnwindIterator` interface and its implementation. The interface `CypherMatchQuery` now provides a method to obtain its iterators.