### PR TITLE
GraphQLEndpoint initializer now checks that types have id

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/federation/GraphQLEndpoint.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/federation/GraphQLEndpoint.java
@@ -59,8 +59,4 @@ public interface GraphQLEndpoint extends FederationMember {
      */
     public GraphQLEntrypoint getEntrypoint(final String objectTypeName, final GraphQLEntrypointType fieldType);
 
-    /*
-     * Uses System.out to print information about the endpoint such as GraphQL object types and their fields.
-     */
-    public void printInformation();
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/federation/GraphQLEndpoint.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/federation/GraphQLEndpoint.java
@@ -58,4 +58,9 @@ public interface GraphQLEndpoint extends FederationMember {
      * If the parameter names provided doesn't correspond to an object type or a GraphQLEntrypointType for the endpoint return null.
      */
     public GraphQLEntrypoint getEntrypoint(final String objectTypeName, final GraphQLEntrypointType fieldType);
+
+    /*
+     * Uses System.out to print information about the endpoint such as GraphQL object types and their fields.
+     */
+    public void printInformation();
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/graphqlwrapper/impl/GraphQLEndpointImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/graphqlwrapper/impl/GraphQLEndpointImpl.java
@@ -91,41 +91,4 @@ public class GraphQLEndpointImpl implements GraphQLEndpoint {
         }
         return null;
     }
-
-    @Override
-    public void printInformation() {
-
-        // Print object types and fields
-        System.out.println("Object types and fields\n");
-        for(final String typeName : objectTypeToFields.keySet()){
-            System.out.println("Object type: " + typeName);
-                final Map<String,GraphQLField> fields = objectTypeToFields.get(typeName);
-                for(final String fieldName : fields.keySet()){
-                    final GraphQLField currentField = fields.get(fieldName);
-                    System.out.println("---- Field name: " + fieldName);
-                    System.out.println("---- ---- Value type: " + currentField.getValueType());
-                    System.out.println("---- ---- Field type: " + currentField.getFieldType());
-                }
-            System.out.println("\n");
-        }
-
-        System.out.println("==================================================================\n");
-        System.out.println("Entrypoints\n");
-
-        for(final String typeName : objectTypeToEntrypoint.keySet()){
-            System.out.println("Entrypoint for type: " + typeName);
-            final Map<GraphQLEntrypointType,GraphQLEntrypoint> entrypoints = objectTypeToEntrypoint.get(typeName);
-            for(final GraphQLEntrypointType epType : entrypoints.keySet()){
-                System.out.println("---- Entrypoint Type: " + epType.toString());
-                System.out.println("---- Entrypoint field name: " + entrypoints.get(epType).getFieldName());
-                System.out.println("---- Args:");
-                final Map<String,String> argDefs = entrypoints.get(epType).getArgumentDefinitions();
-                for(String argName: argDefs.keySet()){
-                    System.out.println("---- ---- " + argName + " of type " + argDefs.get(argName));
-                }
-            }
-            System.out.println("\n");
-        }
-        
-    }
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/graphqlwrapper/impl/GraphQLEndpointImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/graphqlwrapper/impl/GraphQLEndpointImpl.java
@@ -76,7 +76,9 @@ public class GraphQLEndpointImpl implements GraphQLEndpoint {
 
     @Override
     public GraphQLEntrypoint getEntrypoint(final String objectTypeName, final GraphQLEntrypointType fieldType) {
-        if(containsGraphQLObjectType(objectTypeName) && objectTypeToEntrypoint.get(objectTypeName).containsKey(fieldType)){
+        if(containsGraphQLObjectType(objectTypeName) && objectTypeToEntrypoint.containsKey(objectTypeName) && 
+                objectTypeToEntrypoint.get(objectTypeName).containsKey(fieldType)){
+                    
             return objectTypeToEntrypoint.get(objectTypeName).get(fieldType);
         }
         return null;
@@ -88,5 +90,42 @@ public class GraphQLEndpointImpl implements GraphQLEndpoint {
             return objectTypeToFields.get(objectTypeName);
         }
         return null;
+    }
+
+    @Override
+    public void printInformation() {
+
+        // Print object types and fields
+        System.out.println("Object types and fields\n");
+        for(final String typeName : objectTypeToFields.keySet()){
+            System.out.println("Object type: " + typeName);
+                final Map<String,GraphQLField> fields = objectTypeToFields.get(typeName);
+                for(final String fieldName : fields.keySet()){
+                    final GraphQLField currentField = fields.get(fieldName);
+                    System.out.println("---- Field name: " + fieldName);
+                    System.out.println("---- ---- Value type: " + currentField.getValueType());
+                    System.out.println("---- ---- Field type: " + currentField.getFieldType());
+                }
+            System.out.println("\n");
+        }
+
+        System.out.println("==================================================================\n");
+        System.out.println("Entrypoints\n");
+
+        for(final String typeName : objectTypeToEntrypoint.keySet()){
+            System.out.println("Entrypoint for type: " + typeName);
+            final Map<GraphQLEntrypointType,GraphQLEntrypoint> entrypoints = objectTypeToEntrypoint.get(typeName);
+            for(final GraphQLEntrypointType epType : entrypoints.keySet()){
+                System.out.println("---- Entrypoint Type: " + epType.toString());
+                System.out.println("---- Entrypoint field name: " + entrypoints.get(epType).getFieldName());
+                System.out.println("---- Args:");
+                final Map<String,String> argDefs = entrypoints.get(epType).getArgumentDefinitions();
+                for(String argName: argDefs.keySet()){
+                    System.out.println("---- ---- " + argName + " of type " + argDefs.get(argName));
+                }
+            }
+            System.out.println("\n");
+        }
+        
     }
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/graphqlwrapper/impl/GraphQLEndpointInitializerImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/graphqlwrapper/impl/GraphQLEndpointInitializerImpl.java
@@ -85,7 +85,10 @@ public class GraphQLEndpointInitializerImpl implements GraphQLEndpointInitialize
                 throw new FederationAccessException("Error at endpoint.", req, tmpEndpoint);
             }
             final JsonObject data = jsonObject.getObj("data");
-            return new GraphQLEndpointImpl(parseTypesAndFields(data), parseEntrypoints(data), iface);
+            final Map<String, Map<String, GraphQLField>> typesAndFields = parseTypesAndFields(data);
+            final Map<String, Map<GraphQLEntrypointType,GraphQLEntrypoint>> entrypoints = parseEntrypoints(data);
+
+            return validateTypesAndEntrypoints(typesAndFields, entrypoints,iface);
         } 
         catch (final FederationAccessException e) {
             throw e;
@@ -152,6 +155,67 @@ public class GraphQLEndpointInitializerImpl implements GraphQLEndpointInitialize
     }
 
     /**
+     * Removes the types, fields and entrypoints from the @param typesAndFields and @param entrypoints
+     * and notes their removal if they don't meet the criteria for the approach. (each type needs an id field etc.)
+     */
+    protected GraphQLEndpoint validateTypesAndEntrypoints(final Map<String, Map<String, GraphQLField>> typesAndFields,
+            final Map<String, Map<GraphQLEntrypointType,GraphQLEntrypoint>> entrypoints,
+            final GraphQLInterface iface){
+
+        final Set<String> typesToRemove = new HashSet<>();
+
+        // Check if any types needs to be removed
+        for(final String type : typesAndFields.keySet()){
+            final Map<String,GraphQLField> fields = typesAndFields.get(type);
+
+            // Check if type has an id field
+            if(!fields.containsKey("id")){
+                System.out.println("Type: " + type + " is removed due to not having an id field!");
+                typesToRemove.add(type);
+                continue;
+            }
+
+            // Check if type has atleast one valid entrypoint
+            if(!entrypoints.containsKey(type) || entrypoints.get(type).isEmpty()){
+                System.out.println("Type: " + type + " is removed due to not having a valid entrypoint!");
+                typesToRemove.add(type);
+                continue;
+            }
+        }
+
+        // Remove fields that links to types that will be removed
+        for(final String type : typesAndFields.keySet()) {
+
+            // If entire type is to be removed, skip removing individual fields
+            if(typesToRemove.contains(type)){
+                continue;
+            }
+
+            final Map<String,GraphQLField> fields = typesAndFields.get(type);
+            final Set<String> fieldsToRemove = new HashSet<>();
+
+            for(final String field : fields.keySet()){
+                final GraphQLField fieldInfo = fields.get(field);
+
+                // Check if value type of current field is a type that will be removed
+                if(fieldInfo.getFieldType() == GraphQLFieldType.OBJECT && typesToRemove.contains(fieldInfo.getValueType())){
+                    System.out.println("Field: " + field + " from type: " + type + " was removed!");
+                    fieldsToRemove.add(field);
+                }
+            }
+
+            // Remove fields from type
+            fields.keySet().removeAll(fieldsToRemove);
+        }
+
+        // Remove specific types and their entrypoints
+        typesAndFields.keySet().removeAll(typesToRemove);
+        entrypoints.keySet().removeAll(typesToRemove);
+
+        return new GraphQLEndpointImpl(typesAndFields,entrypoints,iface);
+    }
+
+    /**
      * Parses introspection data to determine information about a specific GraphQL
      * field.
      * 
@@ -204,7 +268,6 @@ public class GraphQLEndpointInitializerImpl implements GraphQLEndpointInitialize
             final Map<String, String> argumentDefinitions = new HashMap<>();
 
             for (final JsonObject argument : field.getArray(iQueryArgs).toArray(JsonObject[]::new)) {
-                // System.out.println(argument.toString());
                 final String argName = argument.getString(iName);
                 final JsonObject argType = argument.getObj(iType);
                 if (argType.get(iOfType).isNull()) {

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/graphqlwrapper/impl/GraphQLEndpointInitializerImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/graphqlwrapper/impl/GraphQLEndpointInitializerImpl.java
@@ -85,10 +85,8 @@ public class GraphQLEndpointInitializerImpl implements GraphQLEndpointInitialize
                 throw new FederationAccessException("Error at endpoint.", req, tmpEndpoint);
             }
             final JsonObject data = jsonObject.getObj("data");
-            final Map<String, Map<String, GraphQLField>> typesAndFields = parseTypesAndFields(data);
-            final Map<String, Map<GraphQLEntrypointType,GraphQLEntrypoint>> entrypoints = parseEntrypoints(data);
 
-            return validateTypesAndEntrypoints(typesAndFields, entrypoints,iface);
+            return validateTypesAndEntrypoints(parseTypesAndFields(data),parseEntrypoints(data),iface);
         } 
         catch (final FederationAccessException e) {
             throw e;

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/graphqlwrapper/impl/GraphQLEndpointInitializerImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/graphqlwrapper/impl/GraphQLEndpointInitializerImpl.java
@@ -168,16 +168,13 @@ public class GraphQLEndpointInitializerImpl implements GraphQLEndpointInitialize
 
             // Check if type has an id field
             if(!fields.containsKey("id")){
-                System.out.println("Type: " + type + " is removed due to not having an id field!");
                 typesToRemove.add(type);
                 continue;
             }
 
             // Check if type has atleast one valid entrypoint
             if(!entrypoints.containsKey(type) || entrypoints.get(type).isEmpty()){
-                System.out.println("Type: " + type + " is removed due to not having a valid entrypoint!");
                 typesToRemove.add(type);
-                continue;
             }
         }
 
@@ -197,7 +194,6 @@ public class GraphQLEndpointInitializerImpl implements GraphQLEndpointInitialize
 
                 // Check if value type of current field is a type that will be removed
                 if(fieldInfo.getFieldType() == GraphQLFieldType.OBJECT && typesToRemove.contains(fieldInfo.getValueType())){
-                    System.out.println("Field: " + field + " from type: " + type + " was removed!");
                     fieldsToRemove.add(field);
                 }
             }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/graphqlwrapper/utils/SPARQL2GraphQLHelper.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/graphqlwrapper/utils/SPARQL2GraphQLHelper.java
@@ -54,7 +54,11 @@ public class SPARQL2GraphQLHelper
         final Set<String> objectTypeNames = endpoint.getGraphQLObjectTypes();
         for(final String objectTypeName : objectTypeNames){
             // Get the full list entrypoint
+            
             final GraphQLEntrypoint e = endpoint.getEntrypoint(objectTypeName,GraphQLEntrypointType.FULL);
+            if(e == null){
+                continue;
+            }
             final String currentPath = new GraphQLEntrypointPath(e, entrypointCounter).toString();
             finishedFieldPaths.add(currentPath + new GraphQLIDPath(objectTypeName,config.getJsonIDKeyPrefix()));
 

--- a/src/test/java/se/liu/ida/hefquin/engine/federation/access/impl/reqproc/GraphQLRequestProcessorImplTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/federation/access/impl/reqproc/GraphQLRequestProcessorImplTest.java
@@ -2,12 +2,10 @@ package se.liu.ida.hefquin.engine.federation.access.impl.reqproc;
 
 import static org.junit.Assert.assertEquals;
 
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.apache.jena.atlas.json.JsonObject;
 import org.apache.jena.atlas.json.JsonString;
 import org.junit.Test;
 
@@ -85,6 +83,12 @@ public class GraphQLRequestProcessorImplTest extends EngineTestBase {
 		public GraphQLEntrypoint getEntrypoint(String className, GraphQLEntrypointType type) {
 			// TODO Auto-generated method stub
 			return null;
+		}
+
+		@Override
+		public void printInformation() {
+			// TODO Auto-generated method stub
+			
 		}
 	}
 

--- a/src/test/java/se/liu/ida/hefquin/engine/federation/access/impl/reqproc/GraphQLRequestProcessorImplTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/federation/access/impl/reqproc/GraphQLRequestProcessorImplTest.java
@@ -85,11 +85,6 @@ public class GraphQLRequestProcessorImplTest extends EngineTestBase {
 			return null;
 		}
 
-		@Override
-		public void printInformation() {
-			// TODO Auto-generated method stub
-			
-		}
 	}
 
     @Test


### PR DESCRIPTION
Necessary fix that makes sure no types are initialized in GraphQLEndpoint initializer unless they have the ID field. Removes initialized fields if they would lead to such a removed type.