### PR TITLE
Translations with unwind

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SPARQLStar2CypherTranslatorImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SPARQLStar2CypherTranslatorImpl.java
@@ -27,13 +27,19 @@ public class SPARQLStar2CypherTranslatorImpl implements SPARQLStar2CypherTransla
     public Pair<CypherQuery, Map<CypherVar, Node>> translateTriplePattern(final TriplePattern tp,
                                                                           final LPG2RDFConfiguration conf) {
         final CypherVarGenerator generator = new CypherVarGenerator();
-        return new Pair<>(translateTriplePattern(tp, conf, generator, new HashSet<>()), generator.getReverseMap());
+        //TODO: receive the sets as an argument. left for the combination PR
+        return new Pair<>(translateTriplePattern(tp, conf, generator, new HashSet<>(), new HashSet<>(),
+                new HashSet<>(), new HashSet<>(), new HashSet<>()), generator.getReverseMap());
     }
 
     protected static CypherQuery translateTriplePattern(final TriplePattern pattern,
                                                         final LPG2RDFConfiguration configuration,
                                                         final CypherVarGenerator gen,
-                                                        final Set<Node> certainNodes) {
+                                                        final Set<Node> certainNodes,
+                                                        final Set<Node> certainEdgelabels,
+                                                        final Set<Node> certainNodeLabels,
+                                                        final Set<Node> certainPropertyNames,
+                                                        final Set<Node> certainPropertyValues) {
         final Triple b = pattern.asJenaTriple();
         final Node s = b.getSubject();
         final Node p = b.getPredicate();

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SPARQLStar2CypherTranslatorImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SPARQLStar2CypherTranslatorImpl.java
@@ -381,7 +381,8 @@ public class SPARQLStar2CypherTranslatorImpl implements SPARQLStar2CypherTransla
         final CypherMatchQuery q = new CypherQueryBuilder()
                                         .add(new NodeMatchClause(svar))
                                         .add(new UnwindIteratorImpl(innerVar, "KEYS("+svar+")",
-                                                null, Collections.singletonList("k"), iterVar))
+                                                List.of(new PropertyValueConditionWithVar(svar, innerVar, literal)),
+                                                Collections.singletonList("k"), iterVar))
                                         .add(new VariableReturnStatement(svar, gen.getRetVar(s)))
                                         .add(new VariableGetItemReturnStatement(iterVar, 0, gen.getRetVar(p)))
                                         .build();
@@ -393,7 +394,8 @@ public class SPARQLStar2CypherTranslatorImpl implements SPARQLStar2CypherTransla
                 new CypherQueryBuilder()
                         .add(new EdgeMatchClause(sedge.get(0), sedge.get(1), sedge.get(2)))
                         .add(new UnwindIteratorImpl(innerVar, "KEYS("+sedge.get(1)+")",
-                                null, Collections.singletonList("k"), iterVar2))
+                                List.of(new PropertyValueConditionWithVar(sedge.get(1), innerVar, literal)),
+                                Collections.singletonList("k"), iterVar2))
                         .add(new TripleMapReturnStatement(sedge.get(0), sedge.get(1), sedge.get(2), gen.getRetVar(s)))
                         .add(new VariableGetItemReturnStatement(iterVar2 , 0, gen.getRetVar(p)))
                         .build(),
@@ -407,10 +409,10 @@ public class SPARQLStar2CypherTranslatorImpl implements SPARQLStar2CypherTransla
         final LPGNode node = configuration.unmapNode(s);
         final CypherVar a1 = gen.getAnonVar();
         final CypherVar a2 = gen.getAnonVar();
-        final CypherVar a3 = gen.getAnonVar();
+        final CypherVar iterVar = gen.getAnonVar();
         final CypherVar a4 = gen.getAnonVar();
         final CypherVar a5 = gen.getAnonVar();
-        final CypherVar iterVar = gen.getAnonVar();
+        final CypherVar a6 = gen.getAnonVar();
         final CypherVar pvar = gen.getVarFor(p);
         final CypherVar ovar = gen.getVarFor(o);
         final CypherVar innerVar = new CypherVar("k");
@@ -435,14 +437,14 @@ public class SPARQLStar2CypherTranslatorImpl implements SPARQLStar2CypherTransla
                         .add(new NodeIDCondition(a2, node.getId()))
                         .add(new UnwindIteratorImpl(innerVar, "KEYS("+a2+")", null,
                                 List.of("k", a2+"[k]"), iterVar))
-                        .add(new VariableGetItemReturnStatement(a2, 0, gen.getRetVar(p)))
-                        .add(new VariableGetItemReturnStatement(a2, 1, gen.getRetVar(o)))
+                        .add(new VariableGetItemReturnStatement(iterVar, 0, gen.getRetVar(p)))
+                        .add(new VariableGetItemReturnStatement(iterVar, 1, gen.getRetVar(o)))
                         .build(),
                 new CypherQueryBuilder()
-                        .add(new EdgeMatchClause(a3, a4, a5))
-                        .add(new NodeIDCondition(a3, node.getId()))
-                        .add(new RelationshipTypeReturnStatement(a4, gen.getRetVar(p)))
-                        .add(new VariableReturnStatement(a5, gen.getRetVar(o)))
+                        .add(new EdgeMatchClause(a4, a5, a6))
+                        .add(new NodeIDCondition(a4, node.getId()))
+                        .add(new RelationshipTypeReturnStatement(a5, gen.getRetVar(p)))
+                        .add(new VariableReturnStatement(a6, gen.getRetVar(o)))
                         .build()
         );
     }
@@ -465,10 +467,10 @@ public class SPARQLStar2CypherTranslatorImpl implements SPARQLStar2CypherTransla
 
         final CypherVar a4 = gen.getAnonVar();
         final CypherVar a5 = gen.getAnonVar();
-        final CypherVar a6 = gen.getAnonVar();
+        final CypherVar iterVar = gen.getAnonVar();
         final CypherVar a7 = gen.getAnonVar();
         final CypherVar a8 = gen.getAnonVar();
-        final CypherVar iterVar = gen.getAnonVar();
+        final CypherVar a9 = gen.getAnonVar();
         final CypherVar iterVar2 = gen.getAnonVar();
         final CypherVar innerVar = new CypherVar("k");
         return new CypherUnionQueryImpl(
@@ -484,16 +486,16 @@ public class SPARQLStar2CypherTranslatorImpl implements SPARQLStar2CypherTransla
                         .add(new UnwindIteratorImpl(innerVar, "KEYS("+a5+")", null,
                                 List.of("k", a5+"[k]"), iterVar))
                         .add(new VariableReturnStatement(a5, gen.getRetVar(s)))
-                        .add(new VariableGetItemReturnStatement(a5, 0, gen.getRetVar(p)))
-                        .add(new VariableGetItemReturnStatement(a5, 1, gen.getRetVar(o)))
+                        .add(new VariableGetItemReturnStatement(iterVar, 0, gen.getRetVar(p)))
+                        .add(new VariableGetItemReturnStatement(iterVar, 1, gen.getRetVar(o)))
                         .build(),
                 new CypherQueryBuilder()
-                        .add(new EdgeMatchClause(a6, a7, a8))
-                        .add(new UnwindIteratorImpl(innerVar, "KEYS("+a7+")", null,
-                                List.of("k", a7+"[k]"), iterVar2))
-                        .add(new TripleMapReturnStatement(a6, a7, a8, gen.getRetVar(s)))
-                        .add(new VariableGetItemReturnStatement(a7, 0, gen.getRetVar(p)))
-                        .add(new VariableGetItemReturnStatement(a7, 1, gen.getRetVar(o)))
+                        .add(new EdgeMatchClause(a7, a8, a9))
+                        .add(new UnwindIteratorImpl(innerVar, "KEYS("+a8+")", null,
+                                List.of("k", a8+"[k]"), iterVar2))
+                        .add(new TripleMapReturnStatement(a7, a8, a9, gen.getRetVar(s)))
+                        .add(new VariableGetItemReturnStatement(iterVar2, 0, gen.getRetVar(p)))
+                        .add(new VariableGetItemReturnStatement(iterVar2, 1, gen.getRetVar(o)))
                         .build()
         );
     }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/CypherMatchQueryImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/CypherMatchQueryImpl.java
@@ -74,17 +74,8 @@ public class CypherMatchQueryImpl implements CypherMatchQuery {
         }
         if (iterators!=null && iterators.size()>0) {
             for (final UnwindIterator it : iterators) {
-                builder.append("UNWIND [")
-                        .append(it.getInnerVar())
-                        .append(" IN ")
-                        .append(it.getListExpression());
-                if (it.getFilters() != null && !it.getFilters().isEmpty()) {
-                    builder.append(" WHERE ");
-                    builder.append(it.getFilters().stream().map(Objects::toString).collect(Collectors.joining(" AND ")));
-                }
-                builder.append(" | ")
-                        .append(String.join(", ", it.getReturnExpressions()))
-                        .append("]]\n");
+                builder.append(it);
+                builder.append("\n");
             }
         }
         if (returnExprs.size()>0) {

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/UnwindIteratorImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/UnwindIteratorImpl.java
@@ -6,6 +6,7 @@ import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.WhereCondition;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 public class UnwindIteratorImpl implements UnwindIterator {
 
@@ -70,4 +71,24 @@ public class UnwindIteratorImpl implements UnwindIterator {
     public int hashCode() {
         return Objects.hash(innerVar, listExpression, filters, returnExpressions, alias);
     }
+
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("UNWIND [")
+                .append(innerVar)
+                .append(" IN ")
+                .append(listExpression);
+        if (filters != null && !filters.isEmpty()) {
+            System.out.println("hola");
+            builder.append(" WHERE ");
+            builder.append(filters.stream().map(Objects::toString).collect(Collectors.joining(" AND ")));
+        }
+        builder.append(" | [")
+                .append(String.join(", ", returnExpressions))
+                .append("]] AS ")
+                .append(alias);
+        return builder.toString();
+    }
+
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/condition/PropertyValueConditionWithVar.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/condition/PropertyValueConditionWithVar.java
@@ -1,0 +1,48 @@
+package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.condition;
+
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherVar;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.WhereCondition;
+
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+public class PropertyValueConditionWithVar implements WhereCondition {
+
+    protected final CypherVar var;
+    protected final CypherVar propVar;
+    protected final String literal;
+
+    public PropertyValueConditionWithVar(final CypherVar var, final CypherVar propVar, final String literal) {
+        assert var != null;
+        assert propVar != null;
+        assert literal != null;
+        this.var = var;
+        this.propVar = propVar;
+        this.literal = literal;
+    }
+
+    @Override
+    public Set<CypherVar> getVars() {
+        return Collections.singleton(var);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PropertyValueConditionWithVar that = (PropertyValueConditionWithVar) o;
+        return var.equals(that.var) && propVar.equals(that.propVar) && literal.equals(that.literal);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(var, propVar, literal);
+    }
+
+    @Override
+    public String toString() {
+        return var+"["+propVar+"]='"+literal+"'";
+    }
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/CountLargerThanZeroReturnStatement.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/CountLargerThanZeroReturnStatement.java
@@ -1,10 +1,13 @@
 package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.returns;
 
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherVar;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.ReturnStatement;
 
+import java.util.Collections;
 import java.util.Objects;
+import java.util.Set;
 
-public class CountLargerThanZeroReturnStatement {
+public class CountLargerThanZeroReturnStatement implements ReturnStatement {
 
     protected final CypherVar alias;
 
@@ -29,5 +32,15 @@ public class CountLargerThanZeroReturnStatement {
     @Override
     public String toString() {
         return "COUNT(*) > 0 AS " + alias;
+    }
+
+    @Override
+    public Set<CypherVar> getVars() {
+        return Collections.singleton(alias);
+    }
+
+    @Override
+    public CypherVar getAlias() {
+        return alias;
     }
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/CountLargerThanZeroReturnStatement.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/CountLargerThanZeroReturnStatement.java
@@ -1,0 +1,33 @@
+package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.returns;
+
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherVar;
+
+import java.util.Objects;
+
+public class CountLargerThanZeroReturnStatement {
+
+    protected final CypherVar alias;
+
+    public CountLargerThanZeroReturnStatement(final CypherVar alias) {
+        assert alias != null;
+        this.alias = alias;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CountLargerThanZeroReturnStatement that = (CountLargerThanZeroReturnStatement) o;
+        return alias.equals(that.alias);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(alias);
+    }
+
+    @Override
+    public String toString() {
+        return "COUNT(*) > 0 AS " + alias;
+    }
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/VariableGetItemReturnStatement.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/VariableGetItemReturnStatement.java
@@ -1,0 +1,51 @@
+package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.returns;
+
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherVar;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.ReturnStatement;
+
+import java.util.Objects;
+import java.util.Set;
+
+public class VariableGetItemReturnStatement implements ReturnStatement {
+
+    protected final CypherVar var;
+    protected final int i;
+    protected final CypherVar alias;
+
+
+    public VariableGetItemReturnStatement(final CypherVar var, final int i, final CypherVar alias) {
+        assert var != null;
+        assert i >= 0;
+        this.var = var;
+        this.i = i;
+        this.alias = alias;
+    }
+
+    @Override
+    public Set<CypherVar> getVars() {
+        return Set.of(var, alias);
+    }
+
+    @Override
+    public CypherVar getAlias() {
+        return alias;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        VariableGetItemReturnStatement that = (VariableGetItemReturnStatement) o;
+        return i == that.i && var.equals(that.var) && Objects.equals(alias, that.alias);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(var, i, alias);
+    }
+
+    @Override
+    public String toString() {
+        return var+"["+i+"]" + (alias==null? "" : " AS "+alias);
+    }
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherQueryBuilder.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherQueryBuilder.java
@@ -56,6 +56,6 @@ public class CypherQueryBuilder {
     }
 
     public CypherMatchQuery build() {
-        return new CypherMatchQueryImpl(matches, conditions, null, returns);
+        return new CypherMatchQueryImpl(matches, conditions, iterators, returns);
     }
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslatorTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslatorTest.java
@@ -7,16 +7,18 @@ import org.junit.Test;
 import se.liu.ida.hefquin.engine.query.impl.TriplePatternImpl;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.data.impl.LPGNode;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl.DefaultConfiguration;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl.SPARQLStar2CypherTranslatorImpl;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherQuery;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherVar;
-import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.CypherMatchQueryImpl;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.CypherUnionQueryImpl;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.UnwindIteratorImpl;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.condition.*;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.match.EdgeMatchClause;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.match.NodeMatchClause;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.returns.*;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherQueryBuilder;
-import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl.SPARQLStar2CypherTranslatorImpl;
+
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 
@@ -41,6 +43,10 @@ public class SPARQLStar2CypherTranslatorTest {
     final CypherVar a6 = new CypherVar("a6");
     final CypherVar a7 = new CypherVar("a7");
     final CypherVar a8 = new CypherVar("a8");
+    final CypherVar a9 = new CypherVar("a9");
+    final CypherVar a10 = new CypherVar("a10");
+
+    final CypherVar vark = new CypherVar("k");
 
     final LPGNode node22 = new LPGNode("22", null, null);
     final LPGNode node23 = new LPGNode("23", null, null);
@@ -221,10 +227,12 @@ public class SPARQLStar2CypherTranslatorTest {
                 .translateTriplePattern(new TriplePatternImpl(t), conf).object1;
         assertEquals(
                 new CypherQueryBuilder()
-                    .add(new NodeMatchClause(a1))
-                    .add(new NodeIDCondition(a1, "22"))
-                    .add(new FilterEmptyPropertyListsCondition(a1, "Quentin Tarantino"))
-                    .add(new FilteredPropertiesReturnStatement(a1, "Quentin Tarantino", ret1))
+                        .add(new NodeMatchClause(a1))
+                        .add(new NodeIDCondition(a1, "22"))
+                        .add(new UnwindIteratorImpl(vark, "KEYS("+a1+")",
+                                List.of(new PropertyValueConditionWithVar(a1, vark, "Quentin Tarantino")),
+                                List.of("k"), a2))
+                        .add(new VariableGetItemReturnStatement(a2, 0, ret1))
                     .build(),
                 translation);
     }
@@ -340,15 +348,19 @@ public class SPARQLStar2CypherTranslatorTest {
                 new CypherUnionQueryImpl(
                         new CypherQueryBuilder()
                                 .add(new EdgeMatchClause(src1, edge1, tgt1))
-                                .add(new FilterEmptyPropertyListsCondition(edge1, "The Matrix"))
+                                .add(new UnwindIteratorImpl(vark, "KEYS("+edge1+")",
+                                        List.of(new PropertyValueConditionWithVar(edge1, vark, "The Matrix")),
+                                        List.of("k"), a2))
                                 .add(new TripleMapReturnStatement(src1, edge1, tgt1, ret1))
-                                .add(new FilteredPropertiesReturnStatement(edge1, "The Matrix", ret2))
+                                .add(new VariableGetItemReturnStatement(a2, 0, ret2))
                                 .build(),
                         new CypherQueryBuilder()
                                 .add(new NodeMatchClause(v1))
+                                .add(new UnwindIteratorImpl(vark, "KEYS("+v1+")",
+                                        List.of(new PropertyValueConditionWithVar(v1, vark, "The Matrix")),
+                                        List.of("k"), a1))
                                 .add(new VariableReturnStatement(v1, ret1))
-                                .add(new FilterEmptyPropertyListsCondition(v1, "The Matrix"))
-                                .add(new FilteredPropertiesReturnStatement(v1, "The Matrix", ret2))
+                                .add(new VariableGetItemReturnStatement(a1, 0, ret2))
                                 .build()),
                 translation);
     }
@@ -370,14 +382,16 @@ public class SPARQLStar2CypherTranslatorTest {
                         new CypherQueryBuilder()
                                 .add(new NodeMatchClause(a2))
                                 .add(new NodeIDCondition(a2, "22"))
-                                .add(new PropertyListReturnStatement(a2, ret1))
-                                .add(new AllPropertyValuesReturnStatement(a2, ret2))
+                                .add(new UnwindIteratorImpl(vark, "KEYS("+a2+")", null,
+                                        List.of("k", a2+"[k]"), a3))
+                                .add(new VariableGetItemReturnStatement(a3, 0, ret1))
+                                .add(new VariableGetItemReturnStatement(a3, 1, ret2))
                                 .build(),
                         new CypherQueryBuilder()
-                                .add(new EdgeMatchClause(a3, a4, a5))
-                                .add(new NodeIDCondition(a3, "22"))
-                                .add(new RelationshipTypeReturnStatement(a4, ret1))
-                                .add(new VariableReturnStatement(a5, ret2))
+                                .add(new EdgeMatchClause(a4, a5, a6))
+                                .add(new NodeIDCondition(a4, "22"))
+                                .add(new RelationshipTypeReturnStatement(a5, ret1))
+                                .add(new VariableReturnStatement(a6, ret2))
                                 .build()),
                 translation);
     }
@@ -404,15 +418,19 @@ public class SPARQLStar2CypherTranslatorTest {
                                 .build(),
                         new CypherQueryBuilder()
                                 .add(new NodeMatchClause(a5))
+                                .add(new UnwindIteratorImpl(vark, "KEYS("+a5+")",
+                                        null, List.of("k", a5+"[k]"), a6))
                                 .add(new VariableReturnStatement(a5, ret1))
-                                .add(new PropertyListReturnStatement(a5, ret2))
-                                .add(new AllPropertyValuesReturnStatement(a5, ret3))
+                                .add(new VariableGetItemReturnStatement(a6, 0, ret2))
+                                .add(new VariableGetItemReturnStatement(a6, 1, ret3))
                                 .build(),
                         new CypherQueryBuilder()
-                                .add(new EdgeMatchClause(a6, a7, a8))
-                                .add(new TripleMapReturnStatement(a6, a7, a8, ret1))
-                                .add(new PropertyListReturnStatement(a7, ret2))
-                                .add(new AllPropertyValuesReturnStatement(a7, ret3))
+                                .add(new EdgeMatchClause(a7, a8, a9))
+                                .add(new UnwindIteratorImpl(vark, "KEYS("+a8+")",
+                                        null, List.of("k", a8+"[k]"), a10))
+                                .add(new TripleMapReturnStatement(a7, a8, a9, ret1))
+                                .add(new VariableGetItemReturnStatement(a10, 0, ret2))
+                                .add(new VariableGetItemReturnStatement(a10, 1, ret3))
                                 .build()),
                 translation);
     }

--- a/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslatorTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslatorTest.java
@@ -9,6 +9,7 @@ import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.data.impl.LPGNode;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl.DefaultConfiguration;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherQuery;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherVar;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.CypherMatchQueryImpl;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.CypherUnionQueryImpl;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.condition.*;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.match.EdgeMatchClause;
@@ -43,6 +44,57 @@ public class SPARQLStar2CypherTranslatorTest {
 
     final LPGNode node22 = new LPGNode("22", null, null);
     final LPGNode node23 = new LPGNode("23", null, null);
+
+    @Test
+    public void translateNodeLabelLabelTest() {
+        final LPG2RDFConfiguration conf = new DefaultConfiguration();
+        final Triple tp = new Triple(conf.mapNode(node22), conf.getLabel(), conf.mapNodeLabel("Person"));
+        final CypherQuery translation = new SPARQLStar2CypherTranslatorImpl()
+                .translateTriplePattern(new TriplePatternImpl(tp), conf).object1;
+        assertEquals(
+                new CypherQueryBuilder()
+                        .add(new NodeMatchClause(a1))
+                        .add(new NodeIDCondition(a1, "22"))
+                        .add(new NodeLabelCondition(a1, "Person"))
+                        .add(new CountLargerThanZeroReturnStatement(a2))
+                        .build(),
+                translation
+        );
+    }
+
+    @Test
+    public void translateNodePropertyLiteralTest() {
+        final LPG2RDFConfiguration conf = new DefaultConfiguration();
+        final Triple tp = new Triple(conf.mapNode(node22), conf.mapProperty("name"),
+                NodeFactory.createLiteral("Uma Thurman"));
+        final CypherQuery translation = new SPARQLStar2CypherTranslatorImpl()
+                .translateTriplePattern(new TriplePatternImpl(tp), conf).object1;
+        assertEquals(
+                new CypherQueryBuilder()
+                        .add(new NodeMatchClause(a1))
+                        .add(new NodeIDCondition(a1, "22"))
+                        .add(new PropertyValueCondition(a1, "name", "Uma Thurman"))
+                        .add(new CountLargerThanZeroReturnStatement(a2))
+                        .build(),
+                translation);
+    }
+
+    @Test
+    public void translateNodeRelationshipNodeTest() {
+        final LPG2RDFConfiguration conf = new DefaultConfiguration();
+        final Triple tp = new Triple(conf.mapNode(node22), conf.mapEdgeLabel("directed"), conf.mapNode(node23));
+        final CypherQuery translation = new SPARQLStar2CypherTranslatorImpl()
+                .translateTriplePattern(new TriplePatternImpl(tp), conf).object1;
+        assertEquals(
+                new CypherQueryBuilder()
+                        .add(new EdgeMatchClause(a1, a2, a3))
+                        .add(new NodeIDCondition(a1, "22"))
+                        .add(new EdgeLabelCondition(a2, "directed"))
+                        .add(new NodeIDCondition(a3, "23"))
+                        .add(new CountLargerThanZeroReturnStatement(a4))
+                        .build(),
+                translation);
+    }
 
     @Test
     public void translateVarPropertyLiteralTest() {


### PR DESCRIPTION
This PR adds translations for triple patterns without variables, and updates the rules that require the use of UNWIND. Tests are also updated and bugs were fixed.

Since this PR already handles a lot, after this is merged it will come a second one that handles nested triple pattern translation, and the special rules for variables with boundedness properties.