### PR TITLE
Bgp translation

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/utils/CypherQueryUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/utils/CypherQueryUtils.java
@@ -67,12 +67,12 @@ public class CypherQueryUtils {
             }
         }
         final List<ReturnStatement> returns = new ArrayList<>();
-        for ( final ReturnStatement r : q1.getReturnExprs() ) {
+        for ( final ReturnStatement r : q1.getReturnStatements() ) {
             if (!returns.contains(r) && compatibleVars(r.getVars(), matchVars)) {
                 returns.add(r);
             }
         }
-        for ( final ReturnStatement r : q2.getReturnExprs() ) {
+        for ( final ReturnStatement r : q2.getReturnStatements() ) {
             if (!returns.contains(r) && compatibleVars(r.getVars(), matchVars)) {
                 returns.add(r);
             }
@@ -82,7 +82,7 @@ public class CypherQueryUtils {
 
     public static CypherUnionQuery combine(final CypherUnionQuery q1, final CypherMatchQuery q2) {
         final List<CypherMatchQuery> union = new ArrayList<>();
-        for (final CypherMatchQuery q : q1.getUnion()) {
+        for (final CypherMatchQuery q : q1.getSubqueries()) {
             final CypherMatchQuery combination = combine(q, q2);
             if (!union.contains(combination)) {
                 union.add(combination);
@@ -97,8 +97,8 @@ public class CypherQueryUtils {
 
     public static CypherUnionQuery combine(final CypherUnionQuery q1, final CypherUnionQuery q2) {
         final List<CypherMatchQuery> union = new ArrayList<>();
-        for (final CypherMatchQuery q3 : q1.getUnion()) {
-            for (final CypherMatchQuery q4 : q2.getUnion()){
+        for (final CypherMatchQuery q3 : q1.getSubqueries()) {
+            for (final CypherMatchQuery q4 : q2.getSubqueries()){
                 final CypherMatchQuery combination = combine(q3, q4);
                 if (!union.contains(combination)) {
                     union.add(combination);

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslator.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslator.java
@@ -28,7 +28,8 @@ public interface SPARQLStar2CypherTranslator {
      */
     Pair<CypherQuery, Map<CypherVar, Node>> translateTriplePattern(final TriplePattern tp,
                                                                    final LPG2RDFConfiguration conf,
-                                                                   CypherVarGenerator gen, final Set<Node> certainNodes,
+                                                                   final CypherVarGenerator generator,
+                                                                   final Set<Node> certainNodes,
                                                                    final Set<Node> certainEdgeLabels,
                                                                    final Set<Node> certainNodeLabels,
                                                                    final Set<Node> certainPropertyNames,

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslator.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslator.java
@@ -1,6 +1,7 @@
 package se.liu.ida.hefquin.engine.wrappers.lpgwrapper;
 
 import org.apache.jena.graph.Node;
+import se.liu.ida.hefquin.engine.query.BGP;
 import se.liu.ida.hefquin.engine.query.TriplePattern;
 import se.liu.ida.hefquin.engine.utils.Pair;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherQuery;
@@ -16,7 +17,6 @@ public interface SPARQLStar2CypherTranslator {
      * This method returns a {@link CypherQuery} object and a SPARQL-to-Cypher variable mapping.
      * If the Triple Pattern has a shape for which the configuration-specific RDF-star view of the
      * LPG is guaranteed to obtain no matching triples, this method returns null.
-     * @return
      */
     Pair<CypherQuery, Map<CypherVar, Node>> translateTriplePattern(final TriplePattern tp,
                                                                    final LPG2RDFConfiguration conf);
@@ -32,5 +32,13 @@ public interface SPARQLStar2CypherTranslator {
                                                                    final Set<Node> certainNodeLabels,
                                                                    final Set<Node> certainPropertyNames,
                                                                    final Set<Node> certainPropertyValues);
+
+    /**
+     * Translates each individual triple pattern in the given BGP, and then combines the individual
+     * translations into one Cypher query that represents the whole BGP.
+     * This method statically analyzes the BGP to obtain insight on the boundedness properties
+     * of the variables in the BGP to prune unuseful subqueries.
+     */
+    Pair<CypherQuery, Map<CypherVar, Node>> translateBGP(final BGP bgp, final LPG2RDFConfiguration conf);
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SPARQLStar2CypherTranslatorImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SPARQLStar2CypherTranslatorImpl.java
@@ -87,13 +87,12 @@ public class SPARQLStar2CypherTranslatorImpl implements SPARQLStar2CypherTransla
     @Override
     public Pair<CypherQuery, Map<CypherVar, Node>> translateTriplePattern(final TriplePattern tp,
                                                                           final LPG2RDFConfiguration conf,
-                                                                          final CypherVarGenerator gen,
+                                                                          final CypherVarGenerator generator,
                                                                           final Set<Node> certainNodes,
                                                                           final Set<Node> certainEdgeLabels,
                                                                           final Set<Node> certainNodeLabels,
                                                                           final Set<Node> certainPropertyNames,
                                                                           final Set<Node> certainPropertyValues) {
-        final CypherVarGenerator generator = new CypherVarGenerator();
         return new Pair<>(handleTriplePattern(tp, conf, generator, certainNodes, certainEdgeLabels,
                 certainNodeLabels, certainPropertyNames, certainPropertyValues), generator.getReverseMap());
     }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/CypherMatchQuery.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/CypherMatchQuery.java
@@ -1,5 +1,6 @@
 package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query;
 
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -41,6 +42,7 @@ public interface CypherMatchQuery extends CypherQuery {
      * For the example query, this method returns a list with 2 elements, representing the 2 columns being returned
      * @return a list of ReturnStatement objects
      */
-    List<ReturnStatement> getReturnExprs();
+    List<ReturnStatement> getReturnStatements();
 
+    List<CypherVar> getAliases();
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/CypherUnionQuery.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/CypherUnionQuery.java
@@ -25,5 +25,5 @@ public interface CypherUnionQuery extends CypherQuery {
      * query, this method returns a list with two elements, one representing each MATCH query.
      * @return a List of CypherMatchQuery objects
      */
-    List<CypherMatchQuery> getUnion();
+    List<CypherMatchQuery> getSubqueries();
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/ReturnStatement.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/ReturnStatement.java
@@ -17,7 +17,13 @@ public interface ReturnStatement {
 
     /**
      * @return the optional alias variable of the return statement, or null if it is not defined
-     * For instance, this method for RETURN label(x) as l returns l
+     * For instance, this method for RETURN labels(x) as l returns l
      */
     CypherVar getAlias();
+
+    /**
+     * Returns the Cypher expression being returned by the statement.
+     * For instance, this method for RETURN labels(x) as l returns the String "labels(x)"
+     */
+    String getExpression();
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/CypherMatchQueryImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/CypherMatchQueryImpl.java
@@ -47,8 +47,13 @@ public class CypherMatchQueryImpl implements CypherMatchQuery {
     }
 
     @Override
-    public List<ReturnStatement> getReturnExprs() {
+    public List<ReturnStatement> getReturnStatements() {
         return returnExprs;
+    }
+
+    @Override
+    public List<CypherVar> getAliases() {
+        return returnExprs.stream().map(ReturnStatement::getAlias).collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/CypherUnionQueryImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/CypherUnionQueryImpl.java
@@ -26,7 +26,7 @@ public class CypherUnionQueryImpl implements CypherUnionQuery {
     }
 
     @Override
-    public List<CypherMatchQuery> getUnion() {
+    public List<CypherMatchQuery> getSubqueries() {
         return union;
     }
 

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/condition/JoinCondition.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/condition/JoinCondition.java
@@ -1,0 +1,44 @@
+package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.condition;
+
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherVar;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.WhereCondition;
+
+import java.util.Objects;
+import java.util.Set;
+
+public class JoinCondition implements WhereCondition {
+
+    protected final String expr1;
+    protected final String expr2;
+
+    public JoinCondition(final String expr1, final String expr2) {
+        assert expr1 != null;
+        assert expr2 != null;
+
+        this.expr1 = expr1;
+        this.expr2 = expr2;
+    }
+
+    @Override
+    public Set<CypherVar> getVars() {
+        return null;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        JoinCondition that = (JoinCondition) o;
+        return expr1.equals(that.expr1) && expr2.equals(that.expr2);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(expr1, expr2);
+    }
+
+    @Override
+    public String toString() {
+        return expr1+"="+expr2;
+    }
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/EdgeMatchClause.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/EdgeMatchClause.java
@@ -44,8 +44,7 @@ public class EdgeMatchClause implements MatchClause {
         builder.append("MATCH (")
                 .append(sourceNode.getName())
                 .append(")-[");
-        if (edge != null)
-            builder.append(edge.getName());
+        builder.append(edge.getName());
         builder.append("]->(")
                 .append(targetNode.getName())
                 .append(")");
@@ -68,7 +67,12 @@ public class EdgeMatchClause implements MatchClause {
 
     @Override
     public boolean isRedundantWith(final MatchClause match) {
-        return this.equals(match);
+        if (match instanceof EdgeMatchClause)
+            return this.equals(match);
+        else if (match instanceof NodeMatchClause)
+            return ((NodeMatchClause) match).getNode().equals(sourceNode) ||
+                    ((NodeMatchClause) match).getNode().equals(targetNode);
+        else return false;
     }
 
     @Override
@@ -76,7 +80,7 @@ public class EdgeMatchClause implements MatchClause {
         final Set<CypherVar> vars = new HashSet<>();
         vars.add(sourceNode);
         vars.add(targetNode);
-        if (edge != null) vars.add(edge);
+        vars.add(edge);
         return vars;
     }
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/NodeMatchClause.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/NodeMatchClause.java
@@ -51,4 +51,8 @@ public class NodeMatchClause implements MatchClause {
     public int hashCode() {
         return Objects.hash(node);
     }
+
+    public CypherVar getNode() {
+        return node;
+    }
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/AllPropertyValuesReturnStatement.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/AllPropertyValuesReturnStatement.java
@@ -32,6 +32,11 @@ public class AllPropertyValuesReturnStatement implements ReturnStatement {
     }
 
     @Override
+    public String getExpression() {
+        return "";
+    }
+
+    @Override
     public String toString() {
         return "[" + innerVar + " IN KEYS(" + var.getName() + ") | " + var.getName() + "[" + innerVar + "]]"
                 +(alias != null ? " AS " + alias.getName() : "");

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/CountLargerThanZeroReturnStatement.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/CountLargerThanZeroReturnStatement.java
@@ -43,4 +43,9 @@ public class CountLargerThanZeroReturnStatement implements ReturnStatement {
     public CypherVar getAlias() {
         return alias;
     }
+
+    @Override
+    public String getExpression() {
+        return "COUNT(*) > 0";
+    }
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/EmptyReturnStatement.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/EmptyReturnStatement.java
@@ -23,6 +23,11 @@ public class EmptyReturnStatement implements ReturnStatement {
     }
 
     @Override
+    public String getExpression() {
+        return "\"\"";
+    }
+
+    @Override
     public String toString() {
         return "\"\"" + (alias != null? " AS " + alias.getName() : "");
     }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/FilteredPropertiesReturnStatement.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/FilteredPropertiesReturnStatement.java
@@ -34,6 +34,11 @@ public class FilteredPropertiesReturnStatement implements ReturnStatement {
         return alias;
     }
 
+    @Override
+    public String getExpression() {
+        return "";
+    }
+
     public String getFilterValue() {
         return filterValue;
     }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/LabelsReturnStatement.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/LabelsReturnStatement.java
@@ -31,6 +31,11 @@ public class LabelsReturnStatement implements ReturnStatement {
     }
 
     @Override
+    public String getExpression() {
+        return "head(labels("+node+"))";
+    }
+
+    @Override
     public String toString() {
         return "head(labels(" + node.getName() + "))" + (alias != null? " AS " + alias.getName() : "");
     }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/LiteralValueReturnStatement.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/LiteralValueReturnStatement.java
@@ -31,6 +31,11 @@ public class LiteralValueReturnStatement implements ReturnStatement {
     }
 
     @Override
+    public String getExpression() {
+        return value;
+    }
+
+    @Override
     public String toString() {
         return "'" + value + "'" + (alias != null? " AS " + alias.getName() : "");
     }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/PropertyListReturnStatement.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/PropertyListReturnStatement.java
@@ -31,6 +31,11 @@ public class PropertyListReturnStatement implements ReturnStatement {
     }
 
     @Override
+    public String getExpression() {
+        return "";
+    }
+
+    @Override
     public String toString() {
         return "KEYS(" + var.getName() + ")" + (alias != null? " AS "+ alias.getName() : "");
     }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/PropertyValueReturnStatement.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/PropertyValueReturnStatement.java
@@ -38,6 +38,11 @@ public class PropertyValueReturnStatement implements ReturnStatement {
     }
 
     @Override
+    public String getExpression() {
+        return var+"."+property;
+    }
+
+    @Override
     public String toString() {
         return var.getName() + "." + property + (alias != null? " AS " + alias.getName() : "");
     }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/RelationshipTypeReturnStatement.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/RelationshipTypeReturnStatement.java
@@ -33,6 +33,11 @@ public class RelationshipTypeReturnStatement implements ReturnStatement {
     }
 
     @Override
+    public String getExpression() {
+        return "TYPE("+relationshipVar+")";
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof RelationshipTypeReturnStatement)) return false;

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/TripleMapReturnStatement.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/TripleMapReturnStatement.java
@@ -42,13 +42,18 @@ public class TripleMapReturnStatement implements ReturnStatement {
     }
 
     @Override
+    public String getExpression() {
+        return "{s: "+source+", e: "+ edge + ", t: "+target+"}";
+    }
+
+    @Override
     public String toString() {
         StringBuilder res = new StringBuilder();
-        res.append("{source: ")
+        res.append("{s: ")
                 .append(source.getName())
-                .append(", edge: TYPE(")
+                .append(", e: TYPE(")
                 .append(edge.getName())
-                .append("), target: ")
+                .append("), t: ")
                 .append(target.getName())
                 .append("}");
         if( alias != null ) {

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/VariableGetItemReturnStatement.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/VariableGetItemReturnStatement.java
@@ -32,6 +32,11 @@ public class VariableGetItemReturnStatement implements ReturnStatement {
     }
 
     @Override
+    public String getExpression() {
+        return var+"["+i+"]";
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/VariableReturnStatement.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/returns/VariableReturnStatement.java
@@ -37,6 +37,11 @@ public class VariableReturnStatement implements ReturnStatement {
     }
 
     @Override
+    public String getExpression() {
+        return returnVar.getName();
+    }
+
+    @Override
     public String toString() {
         return returnVar.getName() + ( alias != null? " AS "+ alias.getName() : "");
     }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherQueryBuilder.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherQueryBuilder.java
@@ -69,7 +69,7 @@ public class CypherQueryBuilder {
         for (final UnwindIterator i : q.getIterators()) {
             this.addIterator(i);
         }
-        for (final ReturnStatement r : q.getReturnExprs()) {
+        for (final ReturnStatement r : q.getReturnStatements()) {
             this.addReturn(r);
         }
         return this;

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherQueryCombinator.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherQueryCombinator.java
@@ -1,11 +1,17 @@
 package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils;
 
-import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherMatchQuery;
-import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherQuery;
-import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherUnionQuery;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.*;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.CypherUnionQueryImpl;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.condition.JoinCondition;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.match.EdgeMatchClause;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.match.NodeMatchClause;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class CypherQueryCombinator {
-    public static CypherQuery combine(CypherQuery q1, CypherQuery q2) {
+    public static CypherQuery combine(final CypherQuery q1, final CypherQuery q2) {
         if (q1 instanceof CypherMatchQuery && q2 instanceof CypherMatchQuery) {
             return combineMatchMatch((CypherMatchQuery) q1, (CypherMatchQuery) q2);
         } else if (q1 instanceof  CypherUnionQuery && q2 instanceof CypherMatchQuery) {
@@ -19,16 +25,84 @@ public class CypherQueryCombinator {
         }
     }
 
-    private static CypherQuery combineMatchMatch(CypherMatchQuery q1, CypherMatchQuery q2) {
+    private static CypherMatchQuery combineMatchMatch(final CypherMatchQuery q1, final CypherMatchQuery q2) {
+        final CypherQueryBuilder builder = new CypherQueryBuilder();
+
+        final List<MatchClause> matches1 = q1.getMatches();
+        final List<MatchClause> matches2 = q2.getMatches();
+        final List<NodeMatchClause> nodes1 = matches1.stream().filter(x->x instanceof NodeMatchClause)
+                .map(x->(NodeMatchClause) x).collect(Collectors.toList());
+        final List<NodeMatchClause> nodes2 = matches2.stream().filter(x->x instanceof NodeMatchClause)
+                .map(x->(NodeMatchClause) x).collect(Collectors.toList());
+        final List<EdgeMatchClause> edges1 = matches1.stream().filter(x->x instanceof EdgeMatchClause)
+                .map(x->(EdgeMatchClause) x).collect(Collectors.toList());
+        final List<EdgeMatchClause> edges2 = matches1.stream().filter(x->x instanceof EdgeMatchClause)
+                .map(x->(EdgeMatchClause) x).collect(Collectors.toList());
+        for (final EdgeMatchClause m : edges1){
+            builder.add(m);
+        }
+        for (final EdgeMatchClause m : edges2) {
+            if (! edges1.contains(m)) {
+                builder.add(m);
+            }
+        }
+        for (final NodeMatchClause m : nodes1) {
+            if (edges1.stream().noneMatch(x->x.isRedundantWith(m)) &&
+                edges2.stream().noneMatch(x -> x.isRedundantWith(m))) {
+                builder.add(m);
+            }
+        }
+        for (final NodeMatchClause m : nodes2) {
+            if ((!nodes1.contains(m)) && edges1.stream().noneMatch(x->x.isRedundantWith(m)) &&
+                    edges2.stream().noneMatch(x -> x.isRedundantWith(m))) {
+                builder.add(m);
+            }
+        }
+        for (final WhereCondition c : q1.getConditions())
+            builder.add(c);
+        for (final WhereCondition c : q2.getConditions())
+            builder.add(c);
+        for (final UnwindIterator i : q1.getIterators())
+            builder.add(i);
+        for (final UnwindIterator i : q2.getIterators())
+            builder.add(i);
+        for (final ReturnStatement r : q1.getReturnStatements())
+            builder.add(r);
+        for (final ReturnStatement r : q2.getReturnStatements()) {
+            if (q1.getReturnStatements().contains(r)) continue;
+            if (q1.getAliases().contains(r.getAlias())) {
+                builder.add(new JoinCondition(r.getExpression(),
+                        q1.getReturnStatements().stream().filter(x -> x.getAlias().equals(r.getAlias()))
+                                .findFirst().get().getExpression()));
+            } else {
+                builder.add(r);
+            }
+        }
         return null;
     }
 
-    private static CypherQuery combineUnionMatch(CypherUnionQuery q1, CypherMatchQuery q2) {
-        return null;
+    private static CypherUnionQuery combineUnionMatch(final CypherUnionQuery q1, final CypherMatchQuery q2) {
+        final List<CypherMatchQuery> subqueries = new ArrayList<>();
+        for (final CypherMatchQuery q : q1.getSubqueries()) {
+            final CypherMatchQuery combination = combineMatchMatch(q, q2);
+            if (combination == null){
+                return null;
+            }
+            subqueries.add(combination);
+        }
+        return new CypherUnionQueryImpl(subqueries);
     }
 
-    private static CypherQuery combineUnionUnion(CypherUnionQuery q1, CypherUnionQuery q2) {
-        return null;
+    private static CypherUnionQuery combineUnionUnion(final CypherUnionQuery q1, final CypherUnionQuery q2) {
+        final List<CypherMatchQuery> subqueries = new ArrayList<>();
+        for (final CypherMatchQuery q : q1.getSubqueries()) {
+            final CypherUnionQuery combination = combineUnionMatch(q2, q);
+            if (combination == null) {
+                return null;
+            }
+            subqueries.addAll(combination.getSubqueries());
+        }
+        return new CypherUnionQueryImpl(subqueries);
     }
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherQueryCombinator.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherQueryCombinator.java
@@ -30,14 +30,14 @@ public class CypherQueryCombinator {
 
         final List<MatchClause> matches1 = q1.getMatches();
         final List<MatchClause> matches2 = q2.getMatches();
-        final List<NodeMatchClause> nodes1 = matches1.stream().filter(x->x instanceof NodeMatchClause)
-                .map(x->(NodeMatchClause) x).collect(Collectors.toList());
-        final List<NodeMatchClause> nodes2 = matches2.stream().filter(x->x instanceof NodeMatchClause)
-                .map(x->(NodeMatchClause) x).collect(Collectors.toList());
-        final List<EdgeMatchClause> edges1 = matches1.stream().filter(x->x instanceof EdgeMatchClause)
-                .map(x->(EdgeMatchClause) x).collect(Collectors.toList());
-        final List<EdgeMatchClause> edges2 = matches1.stream().filter(x->x instanceof EdgeMatchClause)
-                .map(x->(EdgeMatchClause) x).collect(Collectors.toList());
+        final List<NodeMatchClause> nodes1 = matches1.stream().filter(x -> x instanceof NodeMatchClause)
+                .map(x -> (NodeMatchClause) x).collect(Collectors.toList());
+        final List<NodeMatchClause> nodes2 = matches2.stream().filter(x -> x instanceof NodeMatchClause)
+                .map(x -> (NodeMatchClause) x).collect(Collectors.toList());
+        final List<EdgeMatchClause> edges1 = matches1.stream().filter(x -> x instanceof EdgeMatchClause)
+                .map(x -> (EdgeMatchClause) x).collect(Collectors.toList());
+        final List<EdgeMatchClause> edges2 = matches2.stream().filter(x -> x instanceof EdgeMatchClause)
+                .map(x -> (EdgeMatchClause) x).collect(Collectors.toList());
         for (final EdgeMatchClause m : edges1){
             builder.add(m);
         }
@@ -78,7 +78,7 @@ public class CypherQueryCombinator {
                 builder.add(r);
             }
         }
-        return null;
+        return builder.build();
     }
 
     private static CypherUnionQuery combineUnionMatch(final CypherUnionQuery q1, final CypherMatchQuery q2) {

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherQueryCombinator.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherQueryCombinator.java
@@ -1,0 +1,34 @@
+package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils;
+
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherMatchQuery;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherQuery;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherUnionQuery;
+
+public class CypherQueryCombinator {
+    public static CypherQuery combine(CypherQuery q1, CypherQuery q2) {
+        if (q1 instanceof CypherMatchQuery && q2 instanceof CypherMatchQuery) {
+            return combineMatchMatch((CypherMatchQuery) q1, (CypherMatchQuery) q2);
+        } else if (q1 instanceof  CypherUnionQuery && q2 instanceof CypherMatchQuery) {
+            return combineUnionMatch((CypherUnionQuery) q1, (CypherMatchQuery) q2);
+        } else if (q1 instanceof CypherMatchQuery && q2 instanceof CypherUnionQuery) {
+            return combineUnionMatch((CypherUnionQuery) q2, (CypherMatchQuery) q1);
+        } else if (q1 instanceof CypherUnionQuery && q2 instanceof CypherUnionQuery) {
+            return combineUnionUnion((CypherUnionQuery) q1, (CypherUnionQuery) q2);
+        } else {
+            return null;
+        }
+    }
+
+    private static CypherQuery combineMatchMatch(CypherMatchQuery q1, CypherMatchQuery q2) {
+        return null;
+    }
+
+    private static CypherQuery combineUnionMatch(CypherUnionQuery q1, CypherMatchQuery q2) {
+        return null;
+    }
+
+    private static CypherQuery combineUnionUnion(CypherUnionQuery q1, CypherUnionQuery q2) {
+        return null;
+    }
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherUtils.java
@@ -68,7 +68,7 @@ public class CypherUtils {
             return isPropertyColumn( (CypherMatchQuery) query, colName );
         }
         else if (query instanceof CypherUnionQuery) {
-            for (final CypherMatchQuery q : ((CypherUnionQuery) query).getUnion()) {
+            for (final CypherMatchQuery q : ((CypherUnionQuery) query).getSubqueries()) {
                 if (isPropertyColumn(q, colName)) {
                     return true;
                 }
@@ -81,7 +81,7 @@ public class CypherUtils {
     }
 
     public static boolean isPropertyColumn( final CypherMatchQuery query, final CypherVar colName ) {
-        final List<ReturnStatement> returns = query.getReturnExprs();
+        final List<ReturnStatement> returns = query.getReturnStatements();
         for (final ReturnStatement r : returns) {
             if (colName.equals(r.getAlias()) && (r instanceof PropertyListReturnStatement
                                              || r instanceof FilteredPropertiesReturnStatement)) {
@@ -96,7 +96,7 @@ public class CypherUtils {
             return isLabelColumn( (CypherMatchQuery) query, colName );
         }
         else if (query instanceof CypherUnionQuery) {
-            for (final CypherMatchQuery q : ((CypherUnionQuery) query).getUnion()) {
+            for (final CypherMatchQuery q : ((CypherUnionQuery) query).getSubqueries()) {
                 if (isLabelColumn(q, colName)) {
                     return true;
                 }
@@ -109,7 +109,7 @@ public class CypherUtils {
     }
 
     public static boolean isLabelColumn(final CypherMatchQuery query, final CypherVar colName) {
-        final List<ReturnStatement> returns = query.getReturnExprs();
+        final List<ReturnStatement> returns = query.getReturnStatements();
         for (final ReturnStatement r : returns) {
             if (colName.equals(r.getAlias()) && r instanceof LabelsReturnStatement) {
                 return true;
@@ -123,7 +123,7 @@ public class CypherUtils {
             return isRelationshipTypeColumn( (CypherMatchQuery) query, colName );
         }
         else if (query instanceof CypherUnionQuery) {
-            for (final CypherMatchQuery q : ((CypherUnionQuery) query).getUnion()) {
+            for (final CypherMatchQuery q : ((CypherUnionQuery) query).getSubqueries()) {
                 if (isRelationshipTypeColumn(q, colName)) {
                     return true;
                 }
@@ -136,7 +136,7 @@ public class CypherUtils {
     }
 
     public static boolean isRelationshipTypeColumn(final CypherMatchQuery query, final CypherVar colName) {
-        final List<ReturnStatement> returns = query.getReturnExprs();
+        final List<ReturnStatement> returns = query.getReturnStatements();
         for (final ReturnStatement r : returns) {
             if (colName.equals(r.getAlias()) && r instanceof RelationshipTypeReturnStatement) {
                 return true;

--- a/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslatorTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslatorTest.java
@@ -5,7 +5,10 @@ import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.Triple;
 import org.apache.jena.sparql.core.Var;
 import org.junit.Test;
+import se.liu.ida.hefquin.engine.query.BGP;
+import se.liu.ida.hefquin.engine.query.impl.BGPImpl;
 import se.liu.ida.hefquin.engine.query.impl.TriplePatternImpl;
+import se.liu.ida.hefquin.engine.utils.Pair;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.data.impl.LPGNode;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl.DefaultConfiguration;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl.SPARQLStar2CypherTranslatorImpl;
@@ -21,6 +24,7 @@ import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherQueryBuilder;
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
@@ -706,6 +710,24 @@ public class SPARQLStar2CypherTranslatorTest {
                                 .add(new VariableReturnStatement(a3, ret3))
                                 .build(),
                 translation);
+    }
+
+    @Test
+    public void translateBGPTest() {
+        final LPG2RDFConfiguration conf = new DefaultConfiguration();
+        final Var m = Var.alloc("m");
+        final Var p = Var.alloc("p");
+        final BGP bgp = new BGPImpl(
+                new TriplePatternImpl(new Triple(m, conf.getLabel(), conf.mapNodeLabel("Movie"))),
+                new TriplePatternImpl(new Triple(p, conf.getLabel(), conf.mapNodeLabel("Person"))),
+                new TriplePatternImpl(new Triple(p, conf.mapProperty("name"), NodeFactory.createLiteral("Uma Thurman"))),
+                new TriplePatternImpl(new Triple(m, conf.mapProperty("released"), NodeFactory.createLiteral("2004"))),
+                new TriplePatternImpl(new Triple(NodeFactory.createTripleNode(p, conf.mapEdgeLabel("ACTED_IN"), m),
+                        conf.mapProperty("source"), NodeFactory.createLiteral("IMDB")))
+        );
+        final Pair<CypherQuery, Map<CypherVar, Node>> translation = new SPARQLStar2CypherTranslatorImpl()
+                .translateBGP(bgp, conf);
+        System.out.println(translation.object1); //null, since we don't have nested translations here
     }
 
 }


### PR DESCRIPTION
Adds initial support to BGP translations to Cypher. It does not support joins on the predicate position, since I need to do some refactor to be able to reproduce the function from the paper. This refactor will contain a new interface: `CypherExpression` that will replace some of the strings that are being used, specially in `UnwindIteratorImpl`.

There's initial test on leveraging boundedness properties, as well as on capturing joins on literals.