### PR TITLE
Loading of RDF file with federation members

### DIFF
--- a/ExampleFederation.ttl
+++ b/ExampleFederation.ttl
@@ -1,0 +1,37 @@
+PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+PREFIX fd:     <http://www.example.org/se/liu/ida/hefquin/fd#>
+PREFIX ex:     <http://example.org/>
+
+ex:dbpediaSPARQL
+      a            fd:FederationMember ;
+      fd:interface [ a                  fd:SPARQLEndpointInterface ;
+                     fd:endpointAddress <http://dbpedia.org/sparql> ] .
+
+ex:dbpediaTPF
+      a            fd:FederationMember ;
+      fd:interface [ a                         fd:TPFInterface ;
+                     fd:exampleFragmentAddress <http://fragments.dbpedia.org/2016-04/en> ] .
+
+ex:wikidataSPARQL
+      a            fd:FederationMember ;
+      fd:interface [ a                  fd:SPARQLEndpointInterface ;
+                     fd:endpointAddress <https://query.wikidata.org/sparql> ] .
+
+#ex:neo4jTest
+#      a            fd:FederationMember ;
+#      fd:interface [ a                  fd:BoltInterface ;
+#                     fd:endpointAddress <http://localhost:7474/db/neo4j/tx> ;
+#                     fd:mappingConfiguration  [ a fd:LPGToRDFConfiguration ;
+#                                                # ...
+#                                              ]
+#                   ] .
+
+#ex:graphqlTest
+#      a            fd:FederationMember ;
+#      fd:interface [ a                  fd:GraphQLEndpointInterface ;
+#                     fd:endpointAddress <http://localhost:4000/graphql> ;
+#                     fd:mappingConfiguration  [ a fd:GraphQLToRDFConfiguration ;
+#                                                # ...
+#                                              ]
+#                   ] .

--- a/src/main/java/se/liu/ida/hefquin/cli/modules/ModFederation.java
+++ b/src/main/java/se/liu/ida/hefquin/cli/modules/ModFederation.java
@@ -6,24 +6,27 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.jena.atlas.json.io.parserjavacc.javacc.ParseException;
 import org.apache.jena.cmd.ArgDecl;
 import org.apache.jena.cmd.CmdArgModule;
 import org.apache.jena.cmd.CmdGeneral;
 import org.apache.jena.cmd.ModBase;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.ResIterator;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.vocabulary.RDF;
 
 import se.liu.ida.hefquin.engine.data.VocabularyMapping;
-import se.liu.ida.hefquin.engine.federation.BRTPFServer;
-import se.liu.ida.hefquin.engine.federation.FederationMember;
-import se.liu.ida.hefquin.engine.federation.SPARQLEndpoint;
-import se.liu.ida.hefquin.engine.federation.TPFServer;
-import se.liu.ida.hefquin.engine.federation.access.BRTPFInterface;
-import se.liu.ida.hefquin.engine.federation.access.SPARQLEndpointInterface;
-import se.liu.ida.hefquin.engine.federation.access.TPFInterface;
-import se.liu.ida.hefquin.engine.federation.access.impl.iface.BRTPFInterfaceUtils;
-import se.liu.ida.hefquin.engine.federation.access.impl.iface.SPARQLEndpointInterfaceImpl;
-import se.liu.ida.hefquin.engine.federation.access.impl.iface.TPFInterfaceUtils;
+import se.liu.ida.hefquin.engine.federation.*;
+import se.liu.ida.hefquin.engine.federation.access.*;
+import se.liu.ida.hefquin.engine.federation.access.impl.iface.*;
 import se.liu.ida.hefquin.engine.federation.catalog.FederationCatalog;
 import se.liu.ida.hefquin.engine.federation.catalog.impl.FederationCatalogImpl;
+import se.liu.ida.hefquin.engine.wrappers.graphqlwrapper.GraphQLEndpointInitializer;
+import se.liu.ida.hefquin.engine.wrappers.graphqlwrapper.impl.GraphQLEndpointInitializerImpl;
+import se.liu.ida.hefquin.vocabulary.FD;
 
 public class ModFederation extends ModBase
 {
@@ -36,14 +39,20 @@ public class ModFederation extends ModBase
 
 	@Override
 	public void registerWith( final CmdGeneral cmdLine ) {
-        cmdLine.getUsage().startCategory("Federation") ;
-        cmdLine.add(sparqlEndpointDecl,  "--considerSPARQLEndpoint",  "URI of a SPARQL endpoint that is part of the federation (this argument can be used multiple times for multiple endpoints)");
-        cmdLine.add(tpfServerDecl,       "--considerTPFServer",  "URI of a fragment provided by a TPF server that is part of the federation (this argument can be used multiple times for multiple TPF servers)");
-        cmdLine.add(brtpfServerDecl,     "--considerBRTPFServer",  "URI of a fragment provided by a brTPF server that is part of the federation (this argument can be used multiple times for multiple brTPF servers)");
+		cmdLine.getUsage().startCategory("Federation");
+		cmdLine.add(fedDescrDecl,  "--federationDescription",  "file with an RDF description of the federation");
+		cmdLine.add(sparqlEndpointDecl,  "--considerSPARQLEndpoint",  "URI of a SPARQL endpoint that is part of the federation (this argument can be used multiple times for multiple endpoints)");
+		cmdLine.add(tpfServerDecl,       "--considerTPFServer",  "URI of a fragment provided by a TPF server that is part of the federation (this argument can be used multiple times for multiple TPF servers)");
+		cmdLine.add(brtpfServerDecl,     "--considerBRTPFServer",  "URI of a fragment provided by a brTPF server that is part of the federation (this argument can be used multiple times for multiple brTPF servers)");
 	}
 
 	@Override
 	public void processArgs( final CmdArgModule cmdLine ) {
+		if ( cmdLine.contains(fedDescrDecl) ) {
+			final String fedDescrFilename = cmdLine.getValue(fedDescrDecl);
+			parseFedDescr(fedDescrFilename);
+		}
+
 		if ( cmdLine.contains(sparqlEndpointDecl) ) {
 			try {
 				addSPARQLEndpoints( cmdLine.getValues(sparqlEndpointDecl) );
@@ -75,6 +84,105 @@ public class ModFederation extends ModBase
 
 	public FederationCatalog getFederationCatalog() {
 		return new FederationCatalogImpl(membersByURI);
+	}
+
+	protected void parseFedDescr( final String filename ) {
+		final Model fd = RDFDataMgr.loadModel(filename);
+
+		final ResIterator itSPARQL = fd.listResourcesWithProperty(RDF.type, FD.SPARQLEndpointInterface);
+		while ( itSPARQL.hasNext() ) {
+			final Resource iface = itSPARQL.next();
+			final RDFNode addr = fd.getRequiredProperty(iface, FD.endpointAddress).getObject();
+
+			final String addrStr;
+			if ( addr.isLiteral() ) {
+				addrStr = addr.asLiteral().getLexicalForm();
+			}
+			else if ( addr.isURIResource() ) {
+				addrStr = addr.asResource().getURI();
+			}
+			else {
+				throw new IllegalArgumentException();
+			}
+
+			addSPARQLEndpoint(addrStr);
+		}
+
+		final ResIterator itTPF = fd.listResourcesWithProperty(RDF.type, FD.TPFInterface);
+		while ( itTPF.hasNext() ) {
+			final Resource iface = itTPF.next();
+			final RDFNode addr = fd.getRequiredProperty(iface, FD.exampleFragmentAddress).getObject();
+
+			final String addrStr;
+			if ( addr.isLiteral() ) {
+				addrStr = addr.asLiteral().getLexicalForm();
+			}
+			else if ( addr.isURIResource() ) {
+				addrStr = addr.asResource().getURI();
+			}
+			else {
+				throw new IllegalArgumentException();
+			}
+
+			addTPFServer(addrStr);
+		}
+
+		final ResIterator itBRTPF = fd.listResourcesWithProperty(RDF.type, FD.brTPFInterface);
+		while ( itBRTPF.hasNext() ) {
+			final Resource iface = itBRTPF.next();
+			final RDFNode addr = fd.getRequiredProperty(iface, FD.exampleFragmentAddress).getObject();
+
+			final String addrStr;
+			if ( addr.isLiteral() ) {
+				addrStr = addr.asLiteral().getLexicalForm();
+			}
+			else if ( addr.isURIResource() ) {
+				addrStr = addr.asResource().getURI();
+			}
+			else {
+				throw new IllegalArgumentException();
+			}
+
+			addBRTPFServer(addrStr);
+		}
+
+		final ResIterator itNeo4j = fd.listResourcesWithProperty(RDF.type, FD.BoltInterface);
+		while ( itNeo4j.hasNext() ) {
+			final Resource iface = itNeo4j.next();
+			final RDFNode addr = fd.getRequiredProperty(iface, FD.endpointAddress).getObject();
+
+			final String addrStr;
+			if ( addr.isLiteral() ) {
+				addrStr = addr.asLiteral().getLexicalForm();
+			}
+			else if ( addr.isURIResource() ) {
+				addrStr = addr.asResource().getURI();
+			}
+			else {
+				throw new IllegalArgumentException();
+			}
+
+			addNeo4jServer(addrStr);
+		}
+
+		final ResIterator itGraphQL = fd.listResourcesWithProperty(RDF.type, FD.GraphQLEndpointInterface);
+		while ( itGraphQL.hasNext() ) {
+			final Resource iface = itGraphQL.next();
+			final RDFNode addr = fd.getRequiredProperty(iface, FD.endpointAddress).getObject();
+
+			final String addrStr;
+			if ( addr.isLiteral() ) {
+				addrStr = addr.asLiteral().getLexicalForm();
+			}
+			else if ( addr.isURIResource() ) {
+				addrStr = addr.asResource().getURI();
+			}
+			else {
+				throw new IllegalArgumentException();
+			}
+
+			addGraphQLServer(addrStr);
+		}
 	}
 
 	protected void addSPARQLEndpoints( final List<String> sparqlEndpointValues ) {
@@ -110,7 +218,7 @@ public class ModFederation extends ModBase
 		final TPFInterface iface = TPFInterfaceUtils.createTPFInterface(uri);
 		final TPFServer fm = new TPFServer() {
 			@Override public VocabularyMapping getVocabularyMapping() { return null; }
-			@Override public TPFInterface getInterface() { return iface;}
+			@Override public TPFInterface getInterface() { return iface; }
 		};
 
 		membersByURI.put(uri, fm);
@@ -122,7 +230,42 @@ public class ModFederation extends ModBase
 		final BRTPFInterface iface = BRTPFInterfaceUtils.createBRTPFInterface(uri);
 		final BRTPFServer fm = new BRTPFServer() {
 			@Override public VocabularyMapping getVocabularyMapping() { return null; }
-			@Override public BRTPFInterface getInterface() { return iface;}
+			@Override public BRTPFInterface getInterface() { return iface; }
+		};
+
+		membersByURI.put(uri, fm);
+	}
+
+	protected void addGraphQLServer( final String uri ) {
+		verifyExpectedURI(uri);
+
+		final GraphQLEndpointInitializer init = new GraphQLEndpointInitializerImpl();
+
+		final int connTimeout = 5000;
+        final int readTimeout = 5000;
+
+		final GraphQLEndpoint fm;
+		try {
+			fm = init.initializeEndpoint(uri, connTimeout, readTimeout);
+			membersByURI.put(uri, fm);
+		}
+		catch ( final FederationAccessException e ) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+		catch ( final ParseException e ) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+	}
+
+	protected void addNeo4jServer( final String uri ) {
+		verifyExpectedURI(uri);
+
+		final Neo4jInterface iface = new Neo4jInterfaceImpl(uri);
+		final Neo4jServer fm = new Neo4jServer() {
+			@Override public VocabularyMapping getVocabularyMapping() { return null; }
+			@Override public Neo4jInterface getInterface() { return iface; }
 		};
 
 		membersByURI.put(uri, fm);

--- a/src/main/java/se/liu/ida/hefquin/vocabulary/FD.java
+++ b/src/main/java/se/liu/ida/hefquin/vocabulary/FD.java
@@ -1,0 +1,33 @@
+package se.liu.ida.hefquin.vocabulary;
+
+import org.apache.jena.rdf.model.Property;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.rdf.model.ResourceFactory;
+
+public class FD
+{
+	public static final String uri = "http://www.example.org/se/liu/ida/hefquin/fd#";
+
+	protected static final Resource resource( final String local ) {
+		return ResourceFactory.createResource( uri + local );
+	}
+
+	protected static final Property property( final String local ) {
+		return ResourceFactory.createProperty(uri, local);
+	}
+
+	public static final Resource FederationMember    = resource("FederationMember");
+	public static final Resource SPARQLEndpoint      = resource("SPARQLEndpoint");
+	public static final Resource TPFServer           = resource("TPFServer");
+	public static final Resource brTPFServer         = resource("brTPFServer");
+
+	public static final Resource SPARQLEndpointInterface    = resource("SPARQLEndpointInterface");
+	public static final Resource TPFInterface               = resource("TPFInterface");
+	public static final Resource brTPFInterface             = resource("brTPFInterface");
+	public static final Resource GraphQLEndpointInterface   = resource("GraphQLEndpointInterface");
+	public static final Resource BoltInterface              = resource("BoltInterface");
+
+	public static final Property interface_               = property("interface");
+	public static final Property endpointAddress          = property("endpointAddress");
+	public static final Property exampleFragmentAddress   = property("exampleFragmentAddress");
+}


### PR DESCRIPTION
This PR extends the CLI with a new argument (`--federationDescription`) which can be used to load an RDF description of the federation members. With this, it is not necessary anymore to declare all the federation members separately using `--considerSPARQLEndpoint` etc arguments.

The PR also adds an example Turtle file which illustrates how such RDF descriptions need to look like. The RDF vocabulary used for such descriptions is just an initial proposal and may change.

This PR presents a basis for addressing #24.

/cc @chengsijin0817 @scferrada 