### PR TITLE
Extend federation description

### DIFF
--- a/ExampleFederation.ttl
+++ b/ExampleFederation.ttl
@@ -6,9 +6,8 @@ PREFIX ex:     <http://example.org/>
 ex:dbpediaSPARQL
       a            fd:FederationMember ;
       fd:interface [ a                  fd:SPARQLEndpointInterface ;
-                     fd:endpointAddress <http://dbpedia.org/sparql> ;
-                     fd:vocabularyMappings "dbpedia/vocabularyMappings.nt"
-                     ] .
+                     fd:endpointAddress <http://dbpedia.org/sparql> ] ;
+      fd:vocabularyMappingsFile "dbpedia/vocabularyMappings.nt" .
 
 ex:dbpediaTPF
       a            fd:FederationMember ;
@@ -19,6 +18,11 @@ ex:wikidataSPARQL
       a            fd:FederationMember ;
       fd:interface [ a                  fd:SPARQLEndpointInterface ;
                      fd:endpointAddress <https://query.wikidata.org/sparql> ] .
+
+ex:europaSPARQL
+      a            fd:FederationMember ;
+      fd:interface [ a                  fd:SPARQLEndpointInterface ;
+                     fd:endpointAddress <https://data.europa.eu/sparql> ] .
 
 #ex:neo4jTest
 #      a            fd:FederationMember ;

--- a/ExampleFederation.ttl
+++ b/ExampleFederation.ttl
@@ -6,7 +6,9 @@ PREFIX ex:     <http://example.org/>
 ex:dbpediaSPARQL
       a            fd:FederationMember ;
       fd:interface [ a                  fd:SPARQLEndpointInterface ;
-                     fd:endpointAddress <http://dbpedia.org/sparql> ] .
+                     fd:endpointAddress <http://dbpedia.org/sparql> ;
+                     fd:vocabularyMappings "dbpedia/vocabularyMappings.nt"
+                     ] .
 
 ex:dbpediaTPF
       a            fd:FederationMember ;

--- a/dbpedia/vocabularyMappings.nt
+++ b/dbpedia/vocabularyMappings.nt
@@ -1,0 +1,1 @@
+<http://wikidata.org/ontology/birthPlace> <http://www.w3.org/2002/07/owl#sameAs> <http://dbpedia.org/ontology/birthPlace> .

--- a/dbpedia/vocabularyMappings.nt
+++ b/dbpedia/vocabularyMappings.nt
@@ -1,3 +1,3 @@
-<http://dbpedia.org/resource/Adam_Maher> <http://www.w3.org/2002/07/owl#sameAs> <http://data.europa.eu/euodp/jrc-names/Adam_Maher> .
-<http://dbpedia.org/ontology/birthPlace> <http://www.w3.org/2002/07/owl#equivalentProperty> <http://www.wikidata.org/entity/P19> .
-#<http://dbpedia.org/ontology/birthPlace> <http://www.w3.org/2002/07/owl#equivalentProperty> <http://schema.org/birthPlace> .
+<http://data.europa.eu/euodp/jrc-names/Adam_Maher> <http://www.w3.org/2002/07/owl#sameAs> <http://dbpedia.org/resource/Adam_Maher> .
+<http://www.wikidata.org/entity/P19> <http://www.w3.org/2002/07/owl#equivalentProperty> <http://dbpedia.org/ontology/birthPlace> .
+#<http://schema.org/birthPlace> <http://www.w3.org/2002/07/owl#equivalentProperty> <http://dbpedia.org/ontology/birthPlace> .

--- a/dbpedia/vocabularyMappings.nt
+++ b/dbpedia/vocabularyMappings.nt
@@ -1,1 +1,3 @@
-<http://wikidata.org/ontology/birthPlace> <http://www.w3.org/2002/07/owl#sameAs> <http://dbpedia.org/ontology/birthPlace> .
+<http://dbpedia.org/resource/Adam_Maher> <http://www.w3.org/2002/07/owl#sameAs> <http://data.europa.eu/euodp/jrc-names/Adam_Maher> .
+<http://dbpedia.org/ontology/birthPlace> <http://www.w3.org/2002/07/owl#equivalentProperty> <http://www.wikidata.org/entity/P19> .
+#<http://dbpedia.org/ontology/birthPlace> <http://www.w3.org/2002/07/owl#equivalentProperty> <http://schema.org/birthPlace> .

--- a/src/main/java/se/liu/ida/hefquin/cli/modules/ModFederation.java
+++ b/src/main/java/se/liu/ida/hefquin/cli/modules/ModFederation.java
@@ -88,10 +88,10 @@ public class ModFederation extends ModBase
 	protected void parseFedDescr( final String filename ) {
 		final Model fd = RDFDataMgr.loadModel(filename);
 
-		final ResIterator isFedMember = fd.listResourcesWithProperty(RDF.type, FD.FederationMember);
+		final ResIterator fedMembers = fd.listResourcesWithProperty(RDF.type, FD.FederationMember);
 		// Iterate over all federation members
-		while ( isFedMember.hasNext() ) {
-			final Resource fedMember = isFedMember.next();
+		while ( fedMembers.hasNext() ) {
+			final Resource fedMember = fedMembers.next();
 			VocabularyMapping vocabMap = null;
 			if( fd.contains(fedMember, FD.vocabularyMappingsFile) ){
 				final RDFNode pathToMappingFile = fd.getRequiredProperty(fedMember, FD.vocabularyMappingsFile).getObject();
@@ -103,8 +103,9 @@ public class ModFederation extends ModBase
 			}
 
 			final Resource iface = fedMember.getProperty(FD.interface_).getResource();
+			final RDFNode ifaceType = fd.getRequiredProperty(iface, RDF.type).getObject();
 			// Check the type of interface
-			if ( fd.getRequiredProperty(iface, RDF.type).getObject().equals(FD.SPARQLEndpointInterface) ){
+			if ( ifaceType.equals(FD.SPARQLEndpointInterface) ){
 				final RDFNode addr = fd.getRequiredProperty(iface, FD.endpointAddress).getObject();
 
 				final String addrStr;
@@ -119,7 +120,7 @@ public class ModFederation extends ModBase
 				}
 				addSPARQLEndpoint(addrStr, vocabMap);
 			}
-			else if ( fd.getRequiredProperty(iface, RDF.type).getObject().equals(FD.TPFInterface) ){
+			else if ( ifaceType.equals(FD.TPFInterface) ){
 				final RDFNode addr = fd.getRequiredProperty(iface, FD.exampleFragmentAddress).getObject();
 
 				final String addrStr;
@@ -135,7 +136,7 @@ public class ModFederation extends ModBase
 
 				addTPFServer(addrStr, vocabMap);
 			}
-			else if ( fd.getRequiredProperty(iface, RDF.type).getObject().equals(FD.brTPFInterface) ){
+			else if ( ifaceType.equals(FD.brTPFInterface) ){
 				final RDFNode addr = fd.getRequiredProperty(iface, FD.exampleFragmentAddress).getObject();
 
 				final String addrStr;
@@ -151,7 +152,7 @@ public class ModFederation extends ModBase
 
 				addBRTPFServer(addrStr, vocabMap);
 			}
-			else if ( fd.getRequiredProperty(iface, RDF.type).getObject().equals(FD.BoltInterface) ){
+			else if ( ifaceType.equals(FD.BoltInterface) ){
 				final RDFNode addr = fd.getRequiredProperty(iface, FD.endpointAddress).getObject();
 
 				final String addrStr;
@@ -167,7 +168,7 @@ public class ModFederation extends ModBase
 
 				addNeo4jServer(addrStr, vocabMap);
 			}
-			else if ( fd.getRequiredProperty(iface, RDF.type).getObject().equals(FD.GraphQLEndpointInterface) ){
+			else if ( ifaceType.equals(FD.GraphQLEndpointInterface) ){
 				final RDFNode addr = fd.getRequiredProperty(iface, FD.endpointAddress).getObject();
 
 				final String addrStr;
@@ -292,9 +293,8 @@ public class ModFederation extends ModBase
 
 	protected boolean verifyValidVocabMappingFile(final String pathString ) {
 		File f = new File(pathString);
-		if ( f.exists() ){
-			// TODO: .nt file?
-			return f.isFile();
+		if ( f.exists() && f.isFile() ){
+			return true;
 		}
 		else
 			throw new IllegalArgumentException( "The following path to vocab.mapping does not exist:" + pathString );

--- a/src/main/java/se/liu/ida/hefquin/cli/modules/ModFederation.java
+++ b/src/main/java/se/liu/ida/hefquin/cli/modules/ModFederation.java
@@ -1,5 +1,6 @@
 package se.liu.ida.hefquin.cli.modules;
 
+import java.io.File;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
@@ -87,165 +88,151 @@ public class ModFederation extends ModBase
 	protected void parseFedDescr( final String filename ) {
 		final Model fd = RDFDataMgr.loadModel(filename);
 
-		final ResIterator itSPARQL = fd.listResourcesWithProperty(RDF.type, FD.SPARQLEndpointInterface);
-		while ( itSPARQL.hasNext() ) {
-			final Resource iface = itSPARQL.next();
-			final RDFNode addr = fd.getRequiredProperty(iface, FD.endpointAddress).getObject();
+		final ResIterator isFedMember = fd.listResourcesWithProperty(RDF.type, FD.FederationMember);
+		// Iterate over all federation members
+		while ( isFedMember.hasNext() ) {
+			final Resource fedMember = isFedMember.next();
+			VocabularyMapping vocabMap = null;
+			if( fd.contains(fedMember, FD.vocabularyMappingsFile) ){
+				final RDFNode pathToMappingFile = fd.getRequiredProperty(fedMember, FD.vocabularyMappingsFile).getObject();
 
-			final String addrStr;
-			if ( addr.isLiteral() ) {
-				addrStr = addr.asLiteral().getLexicalForm();
-			}
-			else if ( addr.isURIResource() ) {
-				addrStr = addr.asResource().getURI();
-			}
-			else {
-				throw new IllegalArgumentException();
+				final String path = pathToMappingFile.toString();
+				if ( verifyValidVocabMappingFile( path ) ) {
+					vocabMap = new VocabularyMappingImpl(path);
+				}
 			}
 
-			if( fd.contains(iface, FD.vocabularyMappings) ){
-				final RDFNode path = fd.getRequiredProperty(iface, FD.vocabularyMappings).getObject();
-				addSPARQLEndpoint(addrStr, path.toString());
-			}
-			else
-				addSPARQLEndpoint(addrStr);
-		}
+			final Resource iface = fedMember.getProperty(FD.interface_).getResource();
+			// Check the type of interface
+			if ( fd.getRequiredProperty(iface, RDF.type).getObject().equals(FD.SPARQLEndpointInterface) ){
+				final RDFNode addr = fd.getRequiredProperty(iface, FD.endpointAddress).getObject();
 
-		final ResIterator itTPF = fd.listResourcesWithProperty(RDF.type, FD.TPFInterface);
-		while ( itTPF.hasNext() ) {
-			final Resource iface = itTPF.next();
-			final RDFNode addr = fd.getRequiredProperty(iface, FD.exampleFragmentAddress).getObject();
+				final String addrStr;
+				if ( addr.isLiteral() ) {
+					addrStr = addr.asLiteral().getLexicalForm();
+				}
+				else if ( addr.isURIResource() ) {
+					addrStr = addr.asResource().getURI();
+				}
+				else {
+					throw new IllegalArgumentException();
+				}
+				addSPARQLEndpoint(addrStr, vocabMap);
+			}
+			else if ( fd.getRequiredProperty(iface, RDF.type).getObject().equals(FD.TPFInterface) ){
+				final RDFNode addr = fd.getRequiredProperty(iface, FD.exampleFragmentAddress).getObject();
 
-			final String addrStr;
-			if ( addr.isLiteral() ) {
-				addrStr = addr.asLiteral().getLexicalForm();
+				final String addrStr;
+				if ( addr.isLiteral() ) {
+					addrStr = addr.asLiteral().getLexicalForm();
+				}
+				else if ( addr.isURIResource() ) {
+					addrStr = addr.asResource().getURI();
+				}
+				else {
+					throw new IllegalArgumentException();
+				}
+
+				addTPFServer(addrStr, vocabMap);
 			}
-			else if ( addr.isURIResource() ) {
-				addrStr = addr.asResource().getURI();
+			else if ( fd.getRequiredProperty(iface, RDF.type).getObject().equals(FD.brTPFInterface) ){
+				final RDFNode addr = fd.getRequiredProperty(iface, FD.exampleFragmentAddress).getObject();
+
+				final String addrStr;
+				if ( addr.isLiteral() ) {
+					addrStr = addr.asLiteral().getLexicalForm();
+				}
+				else if ( addr.isURIResource() ) {
+					addrStr = addr.asResource().getURI();
+				}
+				else {
+					throw new IllegalArgumentException();
+				}
+
+				addBRTPFServer(addrStr, vocabMap);
 			}
-			else {
-				throw new IllegalArgumentException();
+			else if ( fd.getRequiredProperty(iface, RDF.type).getObject().equals(FD.BoltInterface) ){
+				final RDFNode addr = fd.getRequiredProperty(iface, FD.endpointAddress).getObject();
+
+				final String addrStr;
+				if ( addr.isLiteral() ) {
+					addrStr = addr.asLiteral().getLexicalForm();
+				}
+				else if ( addr.isURIResource() ) {
+					addrStr = addr.asResource().getURI();
+				}
+				else {
+					throw new IllegalArgumentException();
+				}
+
+				addNeo4jServer(addrStr, vocabMap);
+			}
+			else if ( fd.getRequiredProperty(iface, RDF.type).getObject().equals(FD.GraphQLEndpointInterface) ){
+				final RDFNode addr = fd.getRequiredProperty(iface, FD.endpointAddress).getObject();
+
+				final String addrStr;
+				if ( addr.isLiteral() ) {
+					addrStr = addr.asLiteral().getLexicalForm();
+				}
+				else if ( addr.isURIResource() ) {
+					addrStr = addr.asResource().getURI();
+				}
+				else {
+					throw new IllegalArgumentException();
+				}
+
+				addGraphQLServer(addrStr);
 			}
 
-			addTPFServer(addrStr);
-		}
-
-		final ResIterator itBRTPF = fd.listResourcesWithProperty(RDF.type, FD.brTPFInterface);
-		while ( itBRTPF.hasNext() ) {
-			final Resource iface = itBRTPF.next();
-			final RDFNode addr = fd.getRequiredProperty(iface, FD.exampleFragmentAddress).getObject();
-
-			final String addrStr;
-			if ( addr.isLiteral() ) {
-				addrStr = addr.asLiteral().getLexicalForm();
-			}
-			else if ( addr.isURIResource() ) {
-				addrStr = addr.asResource().getURI();
-			}
-			else {
-				throw new IllegalArgumentException();
-			}
-
-			addBRTPFServer(addrStr);
-		}
-
-		final ResIterator itNeo4j = fd.listResourcesWithProperty(RDF.type, FD.BoltInterface);
-		while ( itNeo4j.hasNext() ) {
-			final Resource iface = itNeo4j.next();
-			final RDFNode addr = fd.getRequiredProperty(iface, FD.endpointAddress).getObject();
-
-			final String addrStr;
-			if ( addr.isLiteral() ) {
-				addrStr = addr.asLiteral().getLexicalForm();
-			}
-			else if ( addr.isURIResource() ) {
-				addrStr = addr.asResource().getURI();
-			}
-			else {
-				throw new IllegalArgumentException();
-			}
-
-			addNeo4jServer(addrStr);
-		}
-
-		final ResIterator itGraphQL = fd.listResourcesWithProperty(RDF.type, FD.GraphQLEndpointInterface);
-		while ( itGraphQL.hasNext() ) {
-			final Resource iface = itGraphQL.next();
-			final RDFNode addr = fd.getRequiredProperty(iface, FD.endpointAddress).getObject();
-
-			final String addrStr;
-			if ( addr.isLiteral() ) {
-				addrStr = addr.asLiteral().getLexicalForm();
-			}
-			else if ( addr.isURIResource() ) {
-				addrStr = addr.asResource().getURI();
-			}
-			else {
-				throw new IllegalArgumentException();
-			}
-
-			addGraphQLServer(addrStr);
 		}
 	}
 
 	protected void addSPARQLEndpoints( final List<String> sparqlEndpointValues ) {
 		for ( final String v : sparqlEndpointValues )
-			addSPARQLEndpoint(v);
+			// TODO: extend command line to support connect the endpoint to a file that describe the vocabulary mappings
+			addSPARQLEndpoint(v, null);
 	}
 
 	protected void addTPFServers( final List<String> uris ) {
 		for ( final String uri : uris )
-			addTPFServer(uri);
+			addTPFServer(uri, null);
 	}
 
 	protected void addBRTPFServers( final List<String> uris ) {
 		for ( final String uri : uris )
-			addBRTPFServer(uri);
+			addBRTPFServer(uri, null);
 	}
 
-	protected void addSPARQLEndpoint( final String sparqlEndpointValue, final String pathToVocabularyMappings ) {
-		verifyExpectedURI(sparqlEndpointValue);
-
-		final SPARQLEndpointInterface iface = new SPARQLEndpointInterfaceImpl(sparqlEndpointValue);
-		final VocabularyMapping vocabMap = new VocabularyMappingImpl( pathToVocabularyMappings );
-		final SPARQLEndpoint fm = new SPARQLEndpoint() {
-			@Override public SPARQLEndpointInterface getInterface() { return iface; }
-			@Override public VocabularyMapping getVocabularyMapping() { return vocabMap; }
-		};
-
-		membersByURI.put(sparqlEndpointValue, fm);
-	}
-
-	protected void addSPARQLEndpoint( final String sparqlEndpointValue ) {
+	protected void addSPARQLEndpoint( final String sparqlEndpointValue, final VocabularyMapping vocabMappings ) {
 		verifyExpectedURI(sparqlEndpointValue);
 
 		final SPARQLEndpointInterface iface = new SPARQLEndpointInterfaceImpl(sparqlEndpointValue);
 		final SPARQLEndpoint fm = new SPARQLEndpoint() {
 			@Override public SPARQLEndpointInterface getInterface() { return iface; }
-			@Override public VocabularyMapping getVocabularyMapping() { return null; }
+			@Override public VocabularyMapping getVocabularyMapping() { return vocabMappings; }
 		};
 
 		membersByURI.put(sparqlEndpointValue, fm);
 	}
 
-	protected void addTPFServer( final String uri ) {
+	protected void addTPFServer( final String uri, final VocabularyMapping vocabMappings ) {
 		verifyExpectedURI(uri);
 
 		final TPFInterface iface = TPFInterfaceUtils.createTPFInterface(uri);
 		final TPFServer fm = new TPFServer() {
-			@Override public VocabularyMapping getVocabularyMapping() { return null; }
+			@Override public VocabularyMapping getVocabularyMapping() { return vocabMappings; }
 			@Override public TPFInterface getInterface() { return iface; }
 		};
 
 		membersByURI.put(uri, fm);
 	}
 
-	protected void addBRTPFServer( final String uri ) {
+	protected void addBRTPFServer( final String uri, final VocabularyMapping vocabMappings ) {
 		verifyExpectedURI(uri);
 
 		final BRTPFInterface iface = BRTPFInterfaceUtils.createBRTPFInterface(uri);
 		final BRTPFServer fm = new BRTPFServer() {
-			@Override public VocabularyMapping getVocabularyMapping() { return null; }
+			@Override public VocabularyMapping getVocabularyMapping() { return vocabMappings; }
 			@Override public BRTPFInterface getInterface() { return iface; }
 		};
 
@@ -275,12 +262,12 @@ public class ModFederation extends ModBase
 		}
 	}
 
-	protected void addNeo4jServer( final String uri ) {
+	protected void addNeo4jServer( final String uri, final VocabularyMapping vocabMappings ) {
 		verifyExpectedURI(uri);
 
 		final Neo4jInterface iface = new Neo4jInterfaceImpl(uri);
 		final Neo4jServer fm = new Neo4jServer() {
-			@Override public VocabularyMapping getVocabularyMapping() { return null; }
+			@Override public VocabularyMapping getVocabularyMapping() { return vocabMappings; }
 			@Override public Neo4jInterface getInterface() { return iface; }
 		};
 
@@ -301,6 +288,16 @@ public class ModFederation extends ModBase
 		}
 
 		return uri;
+	}
+
+	protected boolean verifyValidVocabMappingFile(final String pathString ) {
+		File f = new File(pathString);
+		if ( f.exists() ){
+			// TODO: .nt file?
+			return f.isFile();
+		}
+		else
+			throw new IllegalArgumentException( "The following path to vocab.mapping does not exist:" + pathString );
 	}
 
 }

--- a/src/main/java/se/liu/ida/hefquin/vocabulary/FD.java
+++ b/src/main/java/se/liu/ida/hefquin/vocabulary/FD.java
@@ -30,4 +30,7 @@ public class FD
 	public static final Property interface_               = property("interface");
 	public static final Property endpointAddress          = property("endpointAddress");
 	public static final Property exampleFragmentAddress   = property("exampleFragmentAddress");
+
+	public static final Property vocabularyMappings     = property("vocabularyMappings");
+
 }

--- a/src/main/java/se/liu/ida/hefquin/vocabulary/FD.java
+++ b/src/main/java/se/liu/ida/hefquin/vocabulary/FD.java
@@ -31,6 +31,6 @@ public class FD
 	public static final Property endpointAddress          = property("endpointAddress");
 	public static final Property exampleFragmentAddress   = property("exampleFragmentAddress");
 
-	public static final Property vocabularyMappings     = property("vocabularyMappings");
+	public static final Property vocabularyMappingsFile     = property("vocabularyMappingsFile");
 
 }


### PR DESCRIPTION
- Extend the ExampleFederation with a property for specifying the path to vocabulary mappings
- Update the method parseFedDescr
- Add an example 'vocabularyMappings' file for testing

In the method 'parseFedDescr', only the federation members with a SPARQL endpoint are extended for considering vocabulary mappings when parsing federation descriptions, at the moment.
If it looks okay, I can use the same implementation for parsing all different types of federation members.