### PR TITLE
Adds code for join rewriting of Cypher Queries

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslator.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslator.java
@@ -4,10 +4,15 @@ import org.apache.jena.graph.Node;
 import se.liu.ida.hefquin.engine.query.BGP;
 import se.liu.ida.hefquin.engine.query.TriplePattern;
 import se.liu.ida.hefquin.engine.utils.Pair;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherMatchQuery;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherQuery;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherUnionQuery;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.CypherUnionQueryImpl;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression.CypherVar;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherVarGenerator;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -43,4 +48,14 @@ public interface SPARQLStar2CypherTranslator {
      */
     Pair<CypherQuery, Map<CypherVar, Node>> translateBGP(final BGP bgp, final LPG2RDFConfiguration conf);
 
+
+    CypherMatchQuery rewriteJoins(CypherMatchQuery query);
+
+    default CypherUnionQuery rewriteJoins(CypherUnionQuery query) {
+        List<CypherMatchQuery> union = new ArrayList<>();
+        for (final CypherMatchQuery q : query.getSubqueries()) {
+            union.add(rewriteJoins(q));
+        }
+        return new CypherUnionQueryImpl(union);
+    }
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslator.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslator.java
@@ -49,9 +49,9 @@ public interface SPARQLStar2CypherTranslator {
     Pair<CypherQuery, Map<CypherVar, Node>> translateBGP(final BGP bgp, final LPG2RDFConfiguration conf);
 
 
-    CypherMatchQuery rewriteJoins(CypherMatchQuery query);
+    CypherMatchQuery rewriteJoins(final CypherMatchQuery query);
 
-    default CypherUnionQuery rewriteJoins(CypherUnionQuery query) {
+    default CypherUnionQuery rewriteJoins(final CypherUnionQuery query) {
         List<CypherMatchQuery> union = new ArrayList<>();
         for (final CypherMatchQuery q : query.getSubqueries()) {
             union.add(rewriteJoins(q));

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslator.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslator.java
@@ -49,8 +49,16 @@ public interface SPARQLStar2CypherTranslator {
     Pair<CypherQuery, Map<CypherVar, Node>> translateBGP(final BGP bgp, final LPG2RDFConfiguration conf);
 
 
+    /**
+     * Receives a {@link CypherMatchQuery} and rewrites explicit variable joins in the WHERE clause
+     * as implicit joins in the MATCH clauses. Then, it removes redundant MATCH clauses.
+     * e.g. query MATCH (a)-[b]->(c) MATCH (x) WHERE a=x RETURN x is rewritten as MATCH (a)-[b]->(c) RETURN a
+     */
     CypherMatchQuery rewriteJoins(final CypherMatchQuery query);
 
+    /**
+     * Applies the join rewriting method to each subquery of a {@link CypherUnionQuery}
+     */
     default CypherUnionQuery rewriteJoins(final CypherUnionQuery query) {
         List<CypherMatchQuery> union = new ArrayList<>();
         for (final CypherMatchQuery q : query.getSubqueries()) {

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SPARQLStar2CypherTranslatorImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SPARQLStar2CypherTranslatorImpl.java
@@ -13,18 +13,19 @@ import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.SPARQLStar2CypherTranslator
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.data.impl.LPGNode;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherMatchQuery;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherQuery;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.MatchClause;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.UnwindIterator;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.CypherUnionQueryImpl;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression.*;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.match.EdgeMatchClause;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.match.NodeMatchClause;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherQueryBuilder;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherQueryCombinator;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherUtils;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherVarGenerator;
 
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
+import java.util.stream.Collectors;
 
 public class SPARQLStar2CypherTranslatorImpl implements SPARQLStar2CypherTranslator {
 
@@ -806,4 +807,85 @@ public class SPARQLStar2CypherTranslatorImpl implements SPARQLStar2CypherTransla
                         .add(new AliasedExpression(new GetItemExpression(a10, 1), gen.getRetVar(o)))
                         .build());
     }
+
+    @Override
+    public CypherMatchQuery rewriteJoins(CypherMatchQuery query) {
+        final CypherQueryBuilder builder = new CypherQueryBuilder();
+        final List<BooleanCypherExpression> variableJoins = query.getConditions().stream()
+                .filter(x -> x instanceof EqualityExpression
+                        && ((EqualityExpression) x).getLeftExpression() instanceof CypherVar
+                        && ((EqualityExpression) x).getRightExpression() instanceof CypherVar
+                        && query.getMatchVars().contains((CypherVar) ((EqualityExpression) x).getLeftExpression())
+                        && query.getMatchVars().contains((CypherVar) ((EqualityExpression) x).getRightExpression()))
+                .collect(Collectors.toList());
+        final Map<CypherVar, CypherVar> equivalences = getEquivalenceMap(variableJoins);
+        final List<MatchClause> matches = new ArrayList<>();
+        for (final MatchClause m : query.getMatches()){
+            final MatchClause newM = (MatchClause) CypherUtils.replaceVariable(equivalences, m);
+            if (!matches.contains(newM))
+                matches.add(newM);
+        }
+        for (final BooleanCypherExpression c : query.getConditions()) {
+            if (variableJoins.contains(c)) continue;
+            builder.add(CypherUtils.replaceVariable(equivalences, c));
+        }
+        for (final UnwindIterator i : query.getIterators()) {
+            builder.add(CypherUtils.replaceVariable(equivalences, i));
+        }
+        for (final AliasedExpression r : query.getReturnExprs()) {
+            builder.add(CypherUtils.replaceVariable(equivalences, r));
+        }
+        final List<NodeMatchClause> nodes = matches.stream().filter(x->x instanceof NodeMatchClause)
+                .map(x->(NodeMatchClause)x).collect(Collectors.toList());
+        final List<MatchClause> toRemove = new ArrayList<>();
+        for (final MatchClause m : matches) {
+            if (m instanceof EdgeMatchClause) {
+                for (final NodeMatchClause node : nodes) {
+                    if (m.isRedundantWith(node))
+                        toRemove.add(node);
+                }
+            }
+        }
+        matches.removeAll(toRemove);
+        for (final MatchClause m : matches)
+            builder.add(m);
+        return builder.build();
+    }
+
+    private Map<CypherVar, CypherVar> getEquivalenceMap(final List<BooleanCypherExpression> variableJoins) {
+        final Set<Set<CypherVar>> equivalenceClasses = new HashSet<>();
+        for (final BooleanCypherExpression join : variableJoins) {
+            final EqualityExpression eq = (EqualityExpression) join;
+            final CypherVar v1 = (CypherVar) eq.getLeftExpression();
+            final CypherVar v2 = (CypherVar) eq.getRightExpression();
+            boolean found = false;
+            for (final Set<CypherVar> eqClass : equivalenceClasses) {
+                if (eqClass.contains(v1) || eqClass.contains(v2)) {
+                    eqClass.add(v1); eqClass.add(v2);
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                final Set<CypherVar> eqClass = new HashSet<>();
+                eqClass.add(v1); eqClass.add(v2);
+                equivalenceClasses.add(eqClass);
+            }
+        }
+        final Map<CypherVar, CypherVar> equivalenceMap = new HashMap<>();
+        for (final Set<CypherVar> eqClass : equivalenceClasses) {
+            CypherVar id = null;
+            boolean first = true;
+            for (final CypherVar v : eqClass) {
+                if (first) {
+                    id = v;
+                    first = false;
+                    continue;
+                }
+                equivalenceMap.put(v, id);
+            }
+        }
+        return equivalenceMap;
+    }
+
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SPARQLStar2CypherTranslatorImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SPARQLStar2CypherTranslatorImpl.java
@@ -809,7 +809,7 @@ public class SPARQLStar2CypherTranslatorImpl implements SPARQLStar2CypherTransla
     }
 
     @Override
-    public CypherMatchQuery rewriteJoins(CypherMatchQuery query) {
+    public CypherMatchQuery rewriteJoins(final CypherMatchQuery query) {
         final CypherQueryBuilder builder = new CypherQueryBuilder();
         final List<BooleanCypherExpression> variableJoins = query.getConditions().stream()
                 .filter(x -> x instanceof EqualityExpression

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/CypherExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/CypherExpression.java
@@ -1,6 +1,8 @@
 package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query;
 
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression.CypherVar;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.VariableReplacementVisitor;
 
 import java.util.Set;
 
@@ -16,4 +18,8 @@ public interface CypherExpression {
      */
     Set<CypherVar> getVars();
 
+    /**
+     * accepts a {@link CypherExpressionVisitor} and propagates the visit recursively when required.
+     */
+    void acceptVisitor(CypherExpressionVisitor visitor);
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/CypherExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/CypherExpression.java
@@ -2,7 +2,6 @@ package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query;
 
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression.CypherVar;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
-import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.VariableReplacementVisitor;
 
 import java.util.Set;
 
@@ -21,5 +20,5 @@ public interface CypherExpression {
     /**
      * accepts a {@link CypherExpressionVisitor} and propagates the visit recursively when required.
      */
-    void acceptVisitor(final CypherExpressionVisitor visitor);
+    void visit(final CypherExpressionVisitor visitor);
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/CypherExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/CypherExpression.java
@@ -21,5 +21,5 @@ public interface CypherExpression {
     /**
      * accepts a {@link CypherExpressionVisitor} and propagates the visit recursively when required.
      */
-    void acceptVisitor(CypherExpressionVisitor visitor);
+    void acceptVisitor(final CypherExpressionVisitor visitor);
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/AliasedExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/AliasedExpression.java
@@ -1,6 +1,7 @@
 package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression;
 
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherExpression;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -25,6 +26,13 @@ public class AliasedExpression implements CypherExpression {
         final Set<CypherVar> res = new HashSet<>(expression.getVars());
         res.add(alias);
         return res;
+    }
+
+    @Override
+    public void acceptVisitor(final CypherExpressionVisitor visitor) {
+        expression.acceptVisitor(visitor);
+        alias.acceptVisitor(visitor);
+        visitor.visitAliasedExpression(this);
     }
 
     public CypherVar getAlias() {

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/AliasedExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/AliasedExpression.java
@@ -3,7 +3,6 @@ package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherExpression;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -29,9 +28,9 @@ public class AliasedExpression implements CypherExpression {
     }
 
     @Override
-    public void acceptVisitor(final CypherExpressionVisitor visitor) {
-        expression.acceptVisitor(visitor);
-        alias.acceptVisitor(visitor);
+    public void visit(final CypherExpressionVisitor visitor) {
+        expression.visit(visitor);
+        alias.visit(visitor);
         visitor.visitAliasedExpression(this);
     }
 

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/CountLargerThanZeroExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/CountLargerThanZeroExpression.java
@@ -1,5 +1,7 @@
 package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression;
 
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
+
 import java.util.Collections;
 import java.util.Set;
 
@@ -7,6 +9,11 @@ public class CountLargerThanZeroExpression implements BooleanCypherExpression{
     @Override
     public Set<CypherVar> getVars() {
         return Collections.emptySet();
+    }
+
+    @Override
+    public void acceptVisitor(final CypherExpressionVisitor visitor) {
+        visitor.visitCountLargerThanZero(this);
     }
 
     @Override

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/CountLargerThanZeroExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/CountLargerThanZeroExpression.java
@@ -12,7 +12,7 @@ public class CountLargerThanZeroExpression implements BooleanCypherExpression{
     }
 
     @Override
-    public void acceptVisitor(final CypherExpressionVisitor visitor) {
+    public void visit(final CypherExpressionVisitor visitor) {
         visitor.visitCountLargerThanZero(this);
     }
 

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/CypherVar.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/CypherVar.java
@@ -1,6 +1,7 @@
 package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression;
 
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherExpression;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
 
 import java.util.Objects;
 import java.util.Set;
@@ -38,5 +39,10 @@ public class CypherVar implements CypherExpression {
     @Override
     public Set<CypherVar> getVars() {
         return Set.of(this);
+    }
+
+    @Override
+    public void acceptVisitor(final CypherExpressionVisitor visitor) {
+        visitor.visitVar(this);
     }
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/CypherVar.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/CypherVar.java
@@ -42,7 +42,7 @@ public class CypherVar implements CypherExpression {
     }
 
     @Override
-    public void acceptVisitor(final CypherExpressionVisitor visitor) {
+    public void visit(final CypherExpressionVisitor visitor) {
         visitor.visitVar(this);
     }
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/EXISTSExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/EXISTSExpression.java
@@ -1,6 +1,7 @@
 package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression;
 
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherExpression;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
 
 import java.util.Objects;
 import java.util.Set;
@@ -17,6 +18,12 @@ public class EXISTSExpression implements BooleanCypherExpression{
     @Override
     public Set<CypherVar> getVars() {
         return expression.getVars();
+    }
+
+    @Override
+    public void acceptVisitor(final CypherExpressionVisitor visitor) {
+        expression.acceptVisitor(visitor);
+        visitor.visitEXISTS(this);
     }
 
     @Override

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/EXISTSExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/EXISTSExpression.java
@@ -21,8 +21,8 @@ public class EXISTSExpression implements BooleanCypherExpression{
     }
 
     @Override
-    public void acceptVisitor(final CypherExpressionVisitor visitor) {
-        expression.acceptVisitor(visitor);
+    public void visit(final CypherExpressionVisitor visitor) {
+        expression.visit(visitor);
         visitor.visitEXISTS(this);
     }
 

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/EqualityExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/EqualityExpression.java
@@ -1,6 +1,7 @@
 package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression;
 
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherExpression;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
 
 import java.util.HashSet;
 import java.util.Objects;
@@ -24,6 +25,21 @@ public class EqualityExpression implements BooleanCypherExpression{
         final Set<CypherVar> res = new HashSet<>(leftExpression.getVars());
         res.addAll(rightExpression.getVars());
         return res;
+    }
+
+    @Override
+    public void acceptVisitor(final CypherExpressionVisitor visitor) {
+        leftExpression.acceptVisitor(visitor);
+        rightExpression.acceptVisitor(visitor);
+        visitor.visitEquality(this);
+    }
+
+    public CypherExpression getLeftExpression() {
+        return leftExpression;
+    }
+
+    public CypherExpression getRightExpression() {
+        return rightExpression;
     }
 
     @Override

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/EqualityExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/EqualityExpression.java
@@ -28,9 +28,9 @@ public class EqualityExpression implements BooleanCypherExpression{
     }
 
     @Override
-    public void acceptVisitor(final CypherExpressionVisitor visitor) {
-        leftExpression.acceptVisitor(visitor);
-        rightExpression.acceptVisitor(visitor);
+    public void visit(final CypherExpressionVisitor visitor) {
+        leftExpression.visit(visitor);
+        rightExpression.visit(visitor);
         visitor.visitEquality(this);
     }
 

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/GetItemExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/GetItemExpression.java
@@ -1,6 +1,7 @@
 package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression;
 
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherExpression;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
 
 import java.util.Objects;
 import java.util.Set;
@@ -20,6 +21,12 @@ public class GetItemExpression implements CypherExpression {
     @Override
     public Set<CypherVar> getVars() {
         return expression.getVars();
+    }
+
+    @Override
+    public void acceptVisitor(final CypherExpressionVisitor visitor) {
+        expression.acceptVisitor(visitor);
+        visitor.visitGetItem(this);
     }
 
     @Override

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/GetItemExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/GetItemExpression.java
@@ -24,8 +24,8 @@ public class GetItemExpression implements CypherExpression {
     }
 
     @Override
-    public void acceptVisitor(final CypherExpressionVisitor visitor) {
-        expression.acceptVisitor(visitor);
+    public void visit(final CypherExpressionVisitor visitor) {
+        expression.visit(visitor);
         visitor.visitGetItem(this);
     }
 

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/KeysExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/KeysExpression.java
@@ -1,5 +1,7 @@
 package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression;
 
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
+
 import java.util.Objects;
 import java.util.Set;
 
@@ -15,6 +17,12 @@ public class KeysExpression implements ListCypherExpression{
     @Override
     public Set<CypherVar> getVars() {
         return Set.of(var);
+    }
+
+    @Override
+    public void acceptVisitor(final CypherExpressionVisitor visitor) {
+        var.acceptVisitor(visitor);
+        visitor.visitKeys(this);
     }
 
     @Override

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/KeysExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/KeysExpression.java
@@ -20,8 +20,8 @@ public class KeysExpression implements ListCypherExpression{
     }
 
     @Override
-    public void acceptVisitor(final CypherExpressionVisitor visitor) {
-        var.acceptVisitor(visitor);
+    public void visit(final CypherExpressionVisitor visitor) {
+        var.visit(visitor);
         visitor.visitKeys(this);
     }
 

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/LabelsExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/LabelsExpression.java
@@ -21,8 +21,8 @@ public class LabelsExpression implements CypherExpression {
     }
 
     @Override
-    public void acceptVisitor(final CypherExpressionVisitor visitor) {
-        var.acceptVisitor(visitor);
+    public void visit(final CypherExpressionVisitor visitor) {
+        var.visit(visitor);
         visitor.visitLabels(this);
     }
 

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/LabelsExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/LabelsExpression.java
@@ -1,6 +1,7 @@
 package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression;
 
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherExpression;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
 
 import java.util.Objects;
 import java.util.Set;
@@ -17,6 +18,12 @@ public class LabelsExpression implements CypherExpression {
     @Override
     public Set<CypherVar> getVars() {
         return Set.of(var);
+    }
+
+    @Override
+    public void acceptVisitor(final CypherExpressionVisitor visitor) {
+        var.acceptVisitor(visitor);
+        visitor.visitLabels(this);
     }
 
     @Override

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/LiteralExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/LiteralExpression.java
@@ -31,7 +31,7 @@ public class LiteralExpression implements CypherExpression {
     }
 
     @Override
-    public void acceptVisitor(final CypherExpressionVisitor visitor) {
+    public void visit(final CypherExpressionVisitor visitor) {
         visitor.visitLiteral(this);
     }
 

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/LiteralExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/LiteralExpression.java
@@ -2,6 +2,7 @@ package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression;
 
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherExpression;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
 
 import java.util.Collections;
 import java.util.Objects;
@@ -27,6 +28,11 @@ public class LiteralExpression implements CypherExpression {
     @Override
     public Set<CypherVar> getVars() {
         return Collections.emptySet();
+    }
+
+    @Override
+    public void acceptVisitor(final CypherExpressionVisitor visitor) {
+        visitor.visitLiteral(this);
     }
 
     @Override

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/MembershipExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/MembershipExpression.java
@@ -27,9 +27,9 @@ public class MembershipExpression implements BooleanCypherExpression {
     }
 
     @Override
-    public void acceptVisitor(final CypherExpressionVisitor visitor) {
-        var.acceptVisitor(visitor);
-        listExpression.acceptVisitor(visitor);
+    public void visit(final CypherExpressionVisitor visitor) {
+        var.visit(visitor);
+        listExpression.visit(visitor);
         visitor.visitMembership(this);
     }
 

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/MembershipExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/MembershipExpression.java
@@ -1,5 +1,7 @@
 package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression;
 
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
+
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
@@ -22,6 +24,13 @@ public class MembershipExpression implements BooleanCypherExpression {
         final Set<CypherVar> res = new HashSet<>(listExpression.getVars());
         res.add(var);
         return res;
+    }
+
+    @Override
+    public void acceptVisitor(final CypherExpressionVisitor visitor) {
+        var.acceptVisitor(visitor);
+        listExpression.acceptVisitor(visitor);
+        visitor.visitMembership(this);
     }
 
     @Override

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/PropertyAccessExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/PropertyAccessExpression.java
@@ -1,6 +1,7 @@
 package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression;
 
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherExpression;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
 
 import java.util.Objects;
 import java.util.Set;
@@ -24,6 +25,12 @@ public class PropertyAccessExpression implements CypherExpression {
     }
 
     @Override
+    public void acceptVisitor(final CypherExpressionVisitor visitor) {
+        var.acceptVisitor(visitor);
+        visitor.visitPropertyAccess(this);
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
@@ -39,5 +46,9 @@ public class PropertyAccessExpression implements CypherExpression {
     @Override
     public String toString() {
         return var + "." + property;
+    }
+
+    public String getProperty() {
+        return property;
     }
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/PropertyAccessExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/PropertyAccessExpression.java
@@ -25,8 +25,8 @@ public class PropertyAccessExpression implements CypherExpression {
     }
 
     @Override
-    public void acceptVisitor(final CypherExpressionVisitor visitor) {
-        var.acceptVisitor(visitor);
+    public void visit(final CypherExpressionVisitor visitor) {
+        var.visit(visitor);
         visitor.visitPropertyAccess(this);
     }
 

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/PropertyAccessWithVarExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/PropertyAccessWithVarExpression.java
@@ -25,9 +25,9 @@ public class PropertyAccessWithVarExpression implements CypherExpression {
     }
 
     @Override
-    public void acceptVisitor(final CypherExpressionVisitor visitor) {
-        var.acceptVisitor(visitor);
-        innerVar.acceptVisitor(visitor);
+    public void visit(final CypherExpressionVisitor visitor) {
+        var.visit(visitor);
+        innerVar.visit(visitor);
         visitor.visitPropertyAccessWithVar(this);
     }
 

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/PropertyAccessWithVarExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/PropertyAccessWithVarExpression.java
@@ -1,6 +1,7 @@
 package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression;
 
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherExpression;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
 
 import java.util.Objects;
 import java.util.Set;
@@ -21,6 +22,13 @@ public class PropertyAccessWithVarExpression implements CypherExpression {
     @Override
     public Set<CypherVar> getVars() {
         return Set.of(var, innerVar);
+    }
+
+    @Override
+    public void acceptVisitor(final CypherExpressionVisitor visitor) {
+        var.acceptVisitor(visitor);
+        innerVar.acceptVisitor(visitor);
+        visitor.visitPropertyAccessWithVar(this);
     }
 
     @Override

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/TripleMapExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/TripleMapExpression.java
@@ -1,6 +1,7 @@
 package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression;
 
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherExpression;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
 
 import java.util.Objects;
 import java.util.Set;
@@ -24,6 +25,14 @@ public class TripleMapExpression implements CypherExpression {
     @Override
     public Set<CypherVar> getVars() {
         return Set.of(source, edge, target);
+    }
+
+    @Override
+    public void acceptVisitor(final CypherExpressionVisitor visitor) {
+        source.acceptVisitor(visitor);
+        edge.acceptVisitor(visitor);
+        target.acceptVisitor(visitor);
+        visitor.visitTripleMap(this);
     }
 
     @Override

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/TripleMapExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/TripleMapExpression.java
@@ -28,10 +28,10 @@ public class TripleMapExpression implements CypherExpression {
     }
 
     @Override
-    public void acceptVisitor(final CypherExpressionVisitor visitor) {
-        source.acceptVisitor(visitor);
-        edge.acceptVisitor(visitor);
-        target.acceptVisitor(visitor);
+    public void visit(final CypherExpressionVisitor visitor) {
+        source.visit(visitor);
+        edge.visit(visitor);
+        target.visit(visitor);
         visitor.visitTripleMap(this);
     }
 

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/TypeExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/TypeExpression.java
@@ -1,6 +1,7 @@
 package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression;
 
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherExpression;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
 
 import java.util.Objects;
 import java.util.Set;
@@ -17,6 +18,12 @@ public class TypeExpression implements CypherExpression {
     @Override
     public Set<CypherVar> getVars() {
         return Set.of(var);
+    }
+
+    @Override
+    public void acceptVisitor(final CypherExpressionVisitor visitor) {
+        var.acceptVisitor(visitor);
+        visitor.visitType(this);
     }
 
     @Override

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/TypeExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/TypeExpression.java
@@ -21,8 +21,8 @@ public class TypeExpression implements CypherExpression {
     }
 
     @Override
-    public void acceptVisitor(final CypherExpressionVisitor visitor) {
-        var.acceptVisitor(visitor);
+    public void visit(final CypherExpressionVisitor visitor) {
+        var.visit(visitor);
         visitor.visitType(this);
     }
 

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/UnwindIteratorImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/UnwindIteratorImpl.java
@@ -100,14 +100,14 @@ public class UnwindIteratorImpl implements UnwindIterator {
     }
 
     @Override
-    public void acceptVisitor(final CypherExpressionVisitor visitor) {
-        innerVar.acceptVisitor(visitor);
-        listExpression.acceptVisitor(visitor);
+    public void visit(final CypherExpressionVisitor visitor) {
+        innerVar.visit(visitor);
+        listExpression.visit(visitor);
         for (final CypherExpression e : filters)
-            e.acceptVisitor(visitor);
+            e.visit(visitor);
         for (final CypherExpression e : returnExpressions)
-            e.acceptVisitor(visitor);
-        alias.acceptVisitor(visitor);
+            e.visit(visitor);
+        alias.visit(visitor);
         visitor.visitUnwind(this);
     }
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/UnwindIteratorImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/UnwindIteratorImpl.java
@@ -2,6 +2,7 @@ package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression;
 
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherExpression;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.UnwindIterator;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -96,5 +97,17 @@ public class UnwindIteratorImpl implements UnwindIterator {
             res.addAll(c.getVars());
         res.add(alias);
         return res;
+    }
+
+    @Override
+    public void acceptVisitor(final CypherExpressionVisitor visitor) {
+        innerVar.acceptVisitor(visitor);
+        listExpression.acceptVisitor(visitor);
+        for (final CypherExpression e : filters)
+            e.acceptVisitor(visitor);
+        for (final CypherExpression e : returnExpressions)
+            e.acceptVisitor(visitor);
+        alias.acceptVisitor(visitor);
+        visitor.visitUnwind(this);
     }
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/VariableIDExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/VariableIDExpression.java
@@ -1,6 +1,7 @@
 package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression;
 
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherExpression;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
 
 import java.util.Objects;
 import java.util.Set;
@@ -17,6 +18,12 @@ public class VariableIDExpression implements CypherExpression {
     @Override
     public Set<CypherVar> getVars() {
         return Set.of(var);
+    }
+
+    @Override
+    public void acceptVisitor(final CypherExpressionVisitor visitor) {
+        var.acceptVisitor(visitor);
+        visitor.visitID(this);
     }
 
     @Override

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/VariableIDExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/VariableIDExpression.java
@@ -21,8 +21,8 @@ public class VariableIDExpression implements CypherExpression {
     }
 
     @Override
-    public void acceptVisitor(final CypherExpressionVisitor visitor) {
-        var.acceptVisitor(visitor);
+    public void visit(final CypherExpressionVisitor visitor) {
+        var.visit(visitor);
         visitor.visitID(this);
     }
 

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/VariableLabelExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/VariableLabelExpression.java
@@ -24,8 +24,8 @@ public class VariableLabelExpression implements BooleanCypherExpression {
     }
 
     @Override
-    public void acceptVisitor(final CypherExpressionVisitor visitor) {
-        variable.acceptVisitor(visitor);
+    public void visit(final CypherExpressionVisitor visitor) {
+        variable.visit(visitor);
         visitor.visitVariableLabel(this);
     }
 

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/VariableLabelExpression.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/expression/VariableLabelExpression.java
@@ -1,5 +1,7 @@
 package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression;
 
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
+
 import java.util.Objects;
 import java.util.Set;
 
@@ -22,6 +24,12 @@ public class VariableLabelExpression implements BooleanCypherExpression {
     }
 
     @Override
+    public void acceptVisitor(final CypherExpressionVisitor visitor) {
+        variable.acceptVisitor(visitor);
+        visitor.visitVariableLabel(this);
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
@@ -37,5 +45,9 @@ public class VariableLabelExpression implements BooleanCypherExpression {
     @Override
     public String toString() {
         return variable + ":" + label;
+    }
+
+    public String getLabel() {
+        return label;
     }
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/EdgeMatchClause.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/EdgeMatchClause.java
@@ -86,10 +86,10 @@ public class EdgeMatchClause implements MatchClause {
     }
 
     @Override
-    public void acceptVisitor(final CypherExpressionVisitor visitor) {
-        sourceNode.acceptVisitor(visitor);
-        edge.acceptVisitor(visitor);
-        targetNode.acceptVisitor(visitor);
+    public void visit(final CypherExpressionVisitor visitor) {
+        sourceNode.visit(visitor);
+        edge.visit(visitor);
+        targetNode.visit(visitor);
         visitor.visitEdgeMatch(this);
     }
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/EdgeMatchClause.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/EdgeMatchClause.java
@@ -86,7 +86,7 @@ public class EdgeMatchClause implements MatchClause {
     }
 
     @Override
-    public void acceptVisitor(CypherExpressionVisitor visitor) {
+    public void acceptVisitor(final CypherExpressionVisitor visitor) {
         sourceNode.acceptVisitor(visitor);
         edge.acceptVisitor(visitor);
         targetNode.acceptVisitor(visitor);

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/EdgeMatchClause.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/EdgeMatchClause.java
@@ -2,6 +2,7 @@ package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.match;
 
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression.CypherVar;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.MatchClause;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
 
 import java.util.HashSet;
 import java.util.Objects;
@@ -82,5 +83,13 @@ public class EdgeMatchClause implements MatchClause {
         vars.add(targetNode);
         vars.add(edge);
         return vars;
+    }
+
+    @Override
+    public void acceptVisitor(CypherExpressionVisitor visitor) {
+        sourceNode.acceptVisitor(visitor);
+        edge.acceptVisitor(visitor);
+        targetNode.acceptVisitor(visitor);
+        visitor.visitEdgeMatch(this);
     }
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/NodeMatchClause.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/NodeMatchClause.java
@@ -2,6 +2,7 @@ package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.match;
 
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression.CypherVar;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.MatchClause;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
 
 import java.util.Collections;
 import java.util.Objects;
@@ -37,6 +38,12 @@ public class NodeMatchClause implements MatchClause {
     @Override
     public Set<CypherVar> getVars() {
         return Collections.singleton(node);
+    }
+
+    @Override
+    public void acceptVisitor(CypherExpressionVisitor visitor) {
+        node.acceptVisitor(visitor);
+        visitor.visitNodeMatch(this);
     }
 
     @Override

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/NodeMatchClause.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/NodeMatchClause.java
@@ -41,7 +41,7 @@ public class NodeMatchClause implements MatchClause {
     }
 
     @Override
-    public void acceptVisitor(CypherExpressionVisitor visitor) {
+    public void acceptVisitor(final CypherExpressionVisitor visitor) {
         node.acceptVisitor(visitor);
         visitor.visitNodeMatch(this);
     }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/NodeMatchClause.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/NodeMatchClause.java
@@ -41,8 +41,8 @@ public class NodeMatchClause implements MatchClause {
     }
 
     @Override
-    public void acceptVisitor(final CypherExpressionVisitor visitor) {
-        node.acceptVisitor(visitor);
+    public void visit(final CypherExpressionVisitor visitor) {
+        node.visit(visitor);
         visitor.visitNodeMatch(this);
     }
 

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherExpressionVisitor.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherExpressionVisitor.java
@@ -1,0 +1,40 @@
+package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils;
+
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherExpression;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression.*;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.match.EdgeMatchClause;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.match.NodeMatchClause;
+
+/**
+ * This class is made to provide generic visitor functionalities to traverse expression trees.
+ * The visit call is made recursive through the accept method in {@link CypherExpression}
+ */
+public interface CypherExpressionVisitor {
+    /**
+     * Recursive initial call
+     */
+    void visit(final CypherExpression ex);
+
+    /**
+     * Specific calls for each type of expression
+     */
+    void visitAliasedExpression(final AliasedExpression ex);
+    void visitCountLargerThanZero(final CountLargerThanZeroExpression ex);
+    void visitVar(final CypherVar var);
+    void visitEquality(final EqualityExpression ex);
+    void visitEXISTS(final EXISTSExpression ex);
+    void visitGetItem(final GetItemExpression ex);
+    void visitKeys(final KeysExpression ex);
+    void visitLabels(final LabelsExpression ex);
+    void visitLiteral(final LiteralExpression ex);
+    void visitMembership(final MembershipExpression ex);
+    void visitPropertyAccess(final PropertyAccessExpression ex);
+    void visitPropertyAccessWithVar(final PropertyAccessWithVarExpression ex);
+    void visitTripleMap(final TripleMapExpression ex);
+    void visitType(final TypeExpression ex);
+    void visitUnwind(final UnwindIteratorImpl iterator);
+    void visitID(final VariableIDExpression ex);
+    void visitVariableLabel (final VariableLabelExpression ex);
+    void visitEdgeMatch(final EdgeMatchClause ex);
+    void visitNodeMatch(final NodeMatchClause ex);
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherQueryBuilder.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherQueryBuilder.java
@@ -23,22 +23,26 @@ public class CypherQueryBuilder {
     }
 
     public CypherQueryBuilder addMatch(final MatchClause match) {
-        this.matches.add(match);
+        if (!matches.contains(match))
+            matches.add(match);
         return this;
     }
 
     public CypherQueryBuilder addCondition(final BooleanCypherExpression condition) {
-        this.conditions.add(condition);
+        if (!conditions.contains(condition))
+            conditions.add(condition);
         return this;
     }
 
     public CypherQueryBuilder addIterator(final UnwindIterator iterator) {
-        this.iterators.add(iterator);
+        if (!iterators.contains(iterator))
+            iterators.add(iterator);
         return this;
     }
 
     public CypherQueryBuilder addReturn(final AliasedExpression ret) {
-        this.returns.add(ret);
+        if (!returns.contains(ret))
+            returns.add(ret);
         return this;
     }
 
@@ -52,7 +56,7 @@ public class CypherQueryBuilder {
         } else if (clause instanceof AliasedExpression) {
             this.addReturn((AliasedExpression) clause);
         } else {
-            throw new IllegalArgumentException("Provided object is not a CypherQuery Clause");
+            throw new IllegalArgumentException("Provided object is not a CypherQuery Clause: " + clause.getClass());
         }
         return this;
     }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherUtils.java
@@ -10,10 +10,7 @@ import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.data.impl.TableRecordImpl;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.*;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression.*;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 public class CypherUtils {
 
@@ -55,91 +52,10 @@ public class CypherUtils {
         return records;
     }
 
-    /**
-     * This method checks if a given cypher query has a given column name, and if said column is from type
-     * PropertyListReturnStatement. If the query is a {@link CypherUnionQuery}, the method just checks if
-     * any of the {@link CypherMatchQuery} of the union satisfies the condition.
-     * This class will be deprecated.
-     */
-    public static boolean isPropertyColumn(final CypherQuery query, final CypherVar colName) {
-        if (query instanceof CypherMatchQuery) {
-            return isPropertyColumn( (CypherMatchQuery) query, colName );
-        }
-        else if (query instanceof CypherUnionQuery) {
-            for (final CypherMatchQuery q : ((CypherUnionQuery) query).getSubqueries()) {
-                if (isPropertyColumn(q, colName)) {
-                    return true;
-                }
-            }
-        }
-        else {
-            throw new IllegalArgumentException("Unsupported implementation of Cypher Query (" + query.getClass().getName() +")");
-        }
-        return false;
-    }
-
-    public static boolean isPropertyColumn( final CypherMatchQuery query, final CypherVar colName ) {
-        final List<AliasedExpression> returns = query.getReturnExprs();
-        for (final AliasedExpression r : returns) {
-            if (colName.equals(r.getAlias()) && (r.getExpression() instanceof PropertyAccessExpression
-                                             || r.getExpression() instanceof PropertyAccessWithVarExpression)) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    public static boolean isLabelColumn(final CypherQuery query, final CypherVar colName) {
-        if (query instanceof CypherMatchQuery) {
-            return isLabelColumn( (CypherMatchQuery) query, colName );
-        }
-        else if (query instanceof CypherUnionQuery) {
-            for (final CypherMatchQuery q : ((CypherUnionQuery) query).getSubqueries()) {
-                if (isLabelColumn(q, colName)) {
-                    return true;
-                }
-            }
-        }
-        else {
-            throw new IllegalArgumentException("Unsupported implementation of Cypher Query (" + query.getClass().getName() +")");
-        }
-        return false;
-    }
-
-    public static boolean isLabelColumn(final CypherMatchQuery query, final CypherVar colName) {
-        final List<AliasedExpression> returns = query.getReturnExprs();
-        for (final AliasedExpression r : returns) {
-            if (colName.equals(r.getAlias()) && r.getExpression() instanceof LabelsExpression) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    public static boolean isRelationshipTypeColumn(final CypherQuery query, final CypherVar colName) {
-        if (query instanceof CypherMatchQuery) {
-            return isRelationshipTypeColumn( (CypherMatchQuery) query, colName );
-        }
-        else if (query instanceof CypherUnionQuery) {
-            for (final CypherMatchQuery q : ((CypherUnionQuery) query).getSubqueries()) {
-                if (isRelationshipTypeColumn(q, colName)) {
-                    return true;
-                }
-            }
-        }
-        else {
-            throw new IllegalArgumentException("Unsupported implementation of Cypher Query (" + query.getClass().getName() +")");
-        }
-        return false;
-    }
-
-    public static boolean isRelationshipTypeColumn(final CypherMatchQuery query, final CypherVar colName) {
-        final List<AliasedExpression> returns = query.getReturnExprs();
-        for (final AliasedExpression r : returns) {
-            if (colName.equals(r.getAlias()) && r.getExpression() instanceof TypeExpression) {
-                return true;
-            }
-        }
-        return false;
+    public static Object replaceVariable(Map<CypherVar, CypherVar> equivalences, final CypherExpression ex) {
+        if (Collections.disjoint(equivalences.keySet(), ex.getVars())) return ex;
+        final VariableReplacementVisitor visitor = new VariableReplacementVisitor(equivalences);
+        visitor.visit(ex);
+        return visitor.getResult();
     }
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherUtils.java
@@ -52,7 +52,7 @@ public class CypherUtils {
         return records;
     }
 
-    public static Object replaceVariable(Map<CypherVar, CypherVar> equivalences, final CypherExpression ex) {
+    public static Object replaceVariable(final Map<CypherVar, CypherVar> equivalences, final CypherExpression ex) {
         if (Collections.disjoint(equivalences.keySet(), ex.getVars())) return ex;
         final VariableReplacementVisitor visitor = new VariableReplacementVisitor(equivalences);
         visitor.visit(ex);

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/VariableReplacementVisitor.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/VariableReplacementVisitor.java
@@ -21,12 +21,12 @@ public class VariableReplacementVisitor implements CypherExpressionVisitor {
 
 
     @Override
-    public void visit(CypherExpression ex) {
+    public void visit(final CypherExpression ex) {
         ex.acceptVisitor(this);
     }
 
     @Override
-    public void visitAliasedExpression(AliasedExpression ex) {
+    public void visitAliasedExpression(final AliasedExpression ex) {
         //we need to get the elements from the stack in reverse order
         assert stack.peek() instanceof CypherVar;
         final CypherVar alias = (CypherVar) stack.pop();
@@ -35,51 +35,51 @@ public class VariableReplacementVisitor implements CypherExpressionVisitor {
     }
 
     @Override
-    public void visitCountLargerThanZero(CountLargerThanZeroExpression ex) {
+    public void visitCountLargerThanZero(final CountLargerThanZeroExpression ex) {
         stack.push(ex);
     }
 
     @Override
-    public void visitVar(CypherVar var) {
+    public void visitVar(final CypherVar var) {
         stack.push(equivalences.getOrDefault(var, var));
     }
 
     @Override
-    public void visitEquality(EqualityExpression ex) {
+    public void visitEquality(final EqualityExpression ex) {
         final CypherExpression rhs = stack.pop();
         final CypherExpression lhs = stack.pop();
         stack.push(new EqualityExpression(lhs, rhs));
     }
 
     @Override
-    public void visitEXISTS(EXISTSExpression ex) {
+    public void visitEXISTS(final EXISTSExpression ex) {
         stack.push(new EXISTSExpression(stack.pop()));
     }
 
     @Override
-    public void visitGetItem(GetItemExpression ex) {
+    public void visitGetItem(final GetItemExpression ex) {
         stack.push(new GetItemExpression(stack.pop(), ex.getIndex()));
     }
 
     @Override
-    public void visitKeys(KeysExpression ex) {
+    public void visitKeys(final KeysExpression ex) {
         assert stack.peek() instanceof CypherVar;
         stack.push(new KeysExpression((CypherVar) stack.pop()));
     }
 
     @Override
-    public void visitLabels(LabelsExpression ex) {
+    public void visitLabels(final LabelsExpression ex) {
         assert stack.peek() instanceof CypherVar;
         stack.push(new LabelsExpression((CypherVar) stack.pop()));
     }
 
     @Override
-    public void visitLiteral(LiteralExpression ex) {
+    public void visitLiteral(final LiteralExpression ex) {
         stack.push(ex);
     }
 
     @Override
-    public void visitMembership(MembershipExpression ex) {
+    public void visitMembership(final MembershipExpression ex) {
         assert stack.peek() instanceof ListCypherExpression;
         final ListCypherExpression list = (ListCypherExpression) stack.pop();
         assert stack.peek() instanceof CypherVar;
@@ -88,13 +88,13 @@ public class VariableReplacementVisitor implements CypherExpressionVisitor {
     }
 
     @Override
-    public void visitPropertyAccess(PropertyAccessExpression ex) {
+    public void visitPropertyAccess(final PropertyAccessExpression ex) {
         assert stack.peek() instanceof CypherVar;
         stack.push(new PropertyAccessExpression((CypherVar) stack.pop(), ex.getProperty()));
     }
 
     @Override
-    public void visitPropertyAccessWithVar(PropertyAccessWithVarExpression ex) {
+    public void visitPropertyAccessWithVar(final PropertyAccessWithVarExpression ex) {
         assert stack.peek() instanceof CypherVar;
         final CypherVar innerVar = (CypherVar) stack.pop();
         assert stack.peek() instanceof CypherVar;
@@ -103,7 +103,7 @@ public class VariableReplacementVisitor implements CypherExpressionVisitor {
     }
 
     @Override
-    public void visitTripleMap(TripleMapExpression ex) {
+    public void visitTripleMap(final TripleMapExpression ex) {
         assert stack.peek() instanceof CypherVar;
         final CypherVar target = (CypherVar) stack.pop();
         assert stack.peek() instanceof CypherVar;
@@ -114,13 +114,13 @@ public class VariableReplacementVisitor implements CypherExpressionVisitor {
     }
 
     @Override
-    public void visitType(TypeExpression ex) {
+    public void visitType(final TypeExpression ex) {
         assert stack.peek() instanceof CypherVar;
         stack.push(new TypeExpression((CypherVar) stack.pop()));
     }
 
     @Override
-    public void visitUnwind(UnwindIteratorImpl iterator) {
+    public void visitUnwind(final UnwindIteratorImpl iterator) {
         assert stack.peek() instanceof CypherVar;
         final CypherVar alias = (CypherVar) stack.pop();
         final List<CypherExpression> returnExps = new ArrayList<>();
@@ -140,19 +140,19 @@ public class VariableReplacementVisitor implements CypherExpressionVisitor {
     }
 
     @Override
-    public void visitID(VariableIDExpression ex) {
+    public void visitID(final VariableIDExpression ex) {
         assert stack.peek() instanceof CypherVar;
         stack.push(new VariableIDExpression((CypherVar) stack.pop()));
     }
 
     @Override
-    public void visitVariableLabel(VariableLabelExpression ex) {
+    public void visitVariableLabel(final VariableLabelExpression ex) {
         assert stack.peek() instanceof CypherVar;
         stack.push(new VariableLabelExpression((CypherVar) stack.pop(), ex.getLabel()));
     }
 
     @Override
-    public void visitEdgeMatch(EdgeMatchClause ex) {
+    public void visitEdgeMatch(final EdgeMatchClause ex) {
         assert stack.peek() instanceof CypherVar;
         final CypherVar target = (CypherVar) stack.pop();
         assert stack.peek() instanceof CypherVar;
@@ -163,7 +163,7 @@ public class VariableReplacementVisitor implements CypherExpressionVisitor {
     }
 
     @Override
-    public void visitNodeMatch(NodeMatchClause ex) {
+    public void visitNodeMatch(final NodeMatchClause ex) {
         assert stack.peek() instanceof CypherVar;
         stack.push(new NodeMatchClause((CypherVar) stack.pop()));
     }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/VariableReplacementVisitor.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/VariableReplacementVisitor.java
@@ -1,0 +1,175 @@
+package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils;
+
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherExpression;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression.*;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.match.EdgeMatchClause;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.match.NodeMatchClause;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+
+public class VariableReplacementVisitor implements CypherExpressionVisitor {
+    protected final Map<CypherVar, CypherVar> equivalences;
+
+    protected final Stack<CypherExpression> stack = new Stack<>();
+
+    public VariableReplacementVisitor(final Map<CypherVar, CypherVar> equivalences) {
+        this.equivalences = equivalences;
+    }
+
+
+    @Override
+    public void visit(CypherExpression ex) {
+        ex.acceptVisitor(this);
+    }
+
+    @Override
+    public void visitAliasedExpression(AliasedExpression ex) {
+        //we need to get the elements from the stack in reverse order
+        assert stack.peek() instanceof CypherVar;
+        final CypherVar alias = (CypherVar) stack.pop();
+        final CypherExpression exp = stack.pop();
+        stack.push(new AliasedExpression(exp, alias));
+    }
+
+    @Override
+    public void visitCountLargerThanZero(CountLargerThanZeroExpression ex) {
+        stack.push(ex);
+    }
+
+    @Override
+    public void visitVar(CypherVar var) {
+        stack.push(equivalences.getOrDefault(var, var));
+    }
+
+    @Override
+    public void visitEquality(EqualityExpression ex) {
+        final CypherExpression rhs = stack.pop();
+        final CypherExpression lhs = stack.pop();
+        stack.push(new EqualityExpression(lhs, rhs));
+    }
+
+    @Override
+    public void visitEXISTS(EXISTSExpression ex) {
+        stack.push(new EXISTSExpression(stack.pop()));
+    }
+
+    @Override
+    public void visitGetItem(GetItemExpression ex) {
+        stack.push(new GetItemExpression(stack.pop(), ex.getIndex()));
+    }
+
+    @Override
+    public void visitKeys(KeysExpression ex) {
+        assert stack.peek() instanceof CypherVar;
+        stack.push(new KeysExpression((CypherVar) stack.pop()));
+    }
+
+    @Override
+    public void visitLabels(LabelsExpression ex) {
+        assert stack.peek() instanceof CypherVar;
+        stack.push(new LabelsExpression((CypherVar) stack.pop()));
+    }
+
+    @Override
+    public void visitLiteral(LiteralExpression ex) {
+        stack.push(ex);
+    }
+
+    @Override
+    public void visitMembership(MembershipExpression ex) {
+        assert stack.peek() instanceof ListCypherExpression;
+        final ListCypherExpression list = (ListCypherExpression) stack.pop();
+        assert stack.peek() instanceof CypherVar;
+        final CypherVar var = (CypherVar) stack.pop();
+        stack.push(new MembershipExpression(var, list));
+    }
+
+    @Override
+    public void visitPropertyAccess(PropertyAccessExpression ex) {
+        assert stack.peek() instanceof CypherVar;
+        stack.push(new PropertyAccessExpression((CypherVar) stack.pop(), ex.getProperty()));
+    }
+
+    @Override
+    public void visitPropertyAccessWithVar(PropertyAccessWithVarExpression ex) {
+        assert stack.peek() instanceof CypherVar;
+        final CypherVar innerVar = (CypherVar) stack.pop();
+        assert stack.peek() instanceof CypherVar;
+        final CypherVar var = (CypherVar) stack.pop();
+        stack.push(new PropertyAccessWithVarExpression(var, innerVar));
+    }
+
+    @Override
+    public void visitTripleMap(TripleMapExpression ex) {
+        assert stack.peek() instanceof CypherVar;
+        final CypherVar target = (CypherVar) stack.pop();
+        assert stack.peek() instanceof CypherVar;
+        final CypherVar edge = (CypherVar) stack.pop();
+        assert stack.peek() instanceof CypherVar;
+        final CypherVar source = (CypherVar) stack.pop();
+        stack.push(new TripleMapExpression(source, edge, target));
+    }
+
+    @Override
+    public void visitType(TypeExpression ex) {
+        assert stack.peek() instanceof CypherVar;
+        stack.push(new TypeExpression((CypherVar) stack.pop()));
+    }
+
+    @Override
+    public void visitUnwind(UnwindIteratorImpl iterator) {
+        assert stack.peek() instanceof CypherVar;
+        final CypherVar alias = (CypherVar) stack.pop();
+        final List<CypherExpression> returnExps = new ArrayList<>();
+        for (int i = iterator.getReturnExpressions().size(); i > 0; i--) {
+            returnExps.add(stack.pop());
+        }
+        final List<BooleanCypherExpression> filters = new ArrayList<>();
+        for (int i = iterator.getFilters().size(); i > 0; i--) {
+            assert stack.peek() instanceof BooleanCypherExpression;
+            filters.add((BooleanCypherExpression) stack.pop());
+        }
+        assert stack.peek() instanceof ListCypherExpression;
+        final ListCypherExpression list = (ListCypherExpression) stack.pop();
+        assert stack.peek() instanceof CypherVar;
+        final CypherVar innerVar = (CypherVar) stack.pop();
+        stack.push(new UnwindIteratorImpl(innerVar, list, filters, returnExps, alias));
+    }
+
+    @Override
+    public void visitID(VariableIDExpression ex) {
+        assert stack.peek() instanceof CypherVar;
+        stack.push(new VariableIDExpression((CypherVar) stack.pop()));
+    }
+
+    @Override
+    public void visitVariableLabel(VariableLabelExpression ex) {
+        assert stack.peek() instanceof CypherVar;
+        stack.push(new VariableLabelExpression((CypherVar) stack.pop(), ex.getLabel()));
+    }
+
+    @Override
+    public void visitEdgeMatch(EdgeMatchClause ex) {
+        assert stack.peek() instanceof CypherVar;
+        final CypherVar target = (CypherVar) stack.pop();
+        assert stack.peek() instanceof CypherVar;
+        final CypherVar edge = (CypherVar) stack.pop();
+        assert stack.peek() instanceof CypherVar;
+        final CypherVar source = (CypherVar) stack.pop();
+        stack.push(new EdgeMatchClause(source, edge, target));
+    }
+
+    @Override
+    public void visitNodeMatch(NodeMatchClause ex) {
+        assert stack.peek() instanceof CypherVar;
+        stack.push(new NodeMatchClause((CypherVar) stack.pop()));
+    }
+
+    public CypherExpression getResult() {
+        return stack.pop();
+    }
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/VariableReplacementVisitor.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/VariableReplacementVisitor.java
@@ -22,7 +22,7 @@ public class VariableReplacementVisitor implements CypherExpressionVisitor {
 
     @Override
     public void visit(final CypherExpression ex) {
-        ex.acceptVisitor(this);
+        ex.visit(this);
     }
 
     @Override

--- a/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslatorTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslatorTest.java
@@ -918,6 +918,45 @@ public class SPARQLStar2CypherTranslatorTest {
     }
 
     @Test
+    public void rewriteJoinsTest() {
+        final CypherVar a11 = new CypherVar("a11");
+        final CypherVar a12 = new CypherVar("a12");
+        final CypherVar a13 = new CypherVar("a13");
+        final CypherVar a14 = new CypherVar("a14");
+        final CypherMatchQuery query = new CypherQueryBuilder()
+                .add(new EdgeMatchClause(a1, a2, a3))
+                .add(new EdgeMatchClause(a4, a5, a6))
+                .add(new EdgeMatchClause(a7, a8, a9))
+                .add(new EdgeMatchClause(a10, a11, a12))
+                .add(new NodeMatchClause(a13))
+                .add(new NodeMatchClause(a14))
+                .add(new EqualityExpression(a1, a6))
+                .add(new EqualityExpression(a14, a1))
+                .add(new EqualityExpression(a4, a13))
+                .add(new EqualityExpression(a7, a4))
+                .add(new EqualityExpression(a13, a10))
+                .add(new EqualityExpression(new PropertyAccessExpression(a13, "name"),
+                        new LiteralExpression("Uma Thurman")))
+                .add(new AliasedExpression(a13, ret1))
+                .add(new AliasedExpression(a14, ret2))
+                .add(new AliasedExpression(new TypeExpression(a5), ret3))
+                .build();
+        final CypherMatchQuery rewrittenQuery = new SPARQLStar2CypherTranslatorImpl().rewriteJoins(query);
+        assertEquals(new CypherQueryBuilder()
+                        .add(new EdgeMatchClause(a14, a2, a3))
+                        .add(new EdgeMatchClause(a4, a5, a14))
+                        .add(new EdgeMatchClause(a4, a8, a9))
+                        .add(new EdgeMatchClause(a4, a11, a12))
+                        .add(new EqualityExpression(new PropertyAccessExpression(a4, "name"),
+                                new LiteralExpression("Uma Thurman")))
+                        .add(new AliasedExpression(a4, ret1))
+                        .add(new AliasedExpression(a14, ret2))
+                        .add(new AliasedExpression(new TypeExpression(a5), ret3))
+                        .build(),
+                rewrittenQuery);
+    }
+
+    @Test
     public void joinOnLiteralsTest() {
         final LPG2RDFConfiguration conf = new DefaultConfiguration();
         final Var l = Var.alloc("l");


### PR DESCRIPTION
Hi, I wanted to have a PR with both the join rewriting and the path merging, but I had to add a Visitor for the first one since most `CypherExpression`s are recursive, so this PR is all about making explicit joins implicit.