### PR TITLE
Merge of Path Patterns

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslator.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslator.java
@@ -7,6 +7,7 @@ import se.liu.ida.hefquin.engine.utils.Pair;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherMatchQuery;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherQuery;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherUnionQuery;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.MatchClause;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.CypherUnionQueryImpl;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression.CypherVar;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherVarGenerator;
@@ -66,4 +67,11 @@ public interface SPARQLStar2CypherTranslator {
         }
         return new CypherUnionQueryImpl(union);
     }
+
+    /**
+     * Receives a list of {@link MatchClause} and merges compatible clauses into longer paths.
+     * e.g., if receives (x)-[a]->(y) and (z)-[b]->(y) returns (z)-[b]->(y)<-[a]-(x).
+     */
+    List<MatchClause> mergePaths(final List<MatchClause> matchClauses);
+
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SPARQLStar2CypherTranslatorImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SPARQLStar2CypherTranslatorImpl.java
@@ -868,7 +868,7 @@ public class SPARQLStar2CypherTranslatorImpl implements SPARQLStar2CypherTransla
                 final EdgeMatchClause e = (EdgeMatchClause) m;
                 builder.addEdge(e.getSourceNode(), e.getEdge(), e.getTargetNode());
             } else {
-                throw new IllegalArgumentException("Only Node and Edge Match clauses are supported in pattern merging");
+                throw new IllegalArgumentException("Unsupported type of Match clause given to pattern merging: " + m.getClass().getName() );
             }
         }
         final LabeledGraph graph = builder.build();

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SPARQLStar2CypherTranslatorImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SPARQLStar2CypherTranslatorImpl.java
@@ -875,7 +875,10 @@ public class SPARQLStar2CypherTranslatorImpl implements SPARQLStar2CypherTransla
         final List<MatchClause> mergedPatterns = new ArrayList<>();
         while (!graph.isEmpty()) {
             final LabeledGraph.Path longest = graph.getLongestPath();
-            mergedPatterns.add(new PathMatchClause(longest));
+            if (longest.size()==0)
+                mergedPatterns.add(new NodeMatchClause(longest.getStart()));
+            else
+                mergedPatterns.add(new PathMatchClause(longest));
             graph.removePath(longest);
         }
         return mergedPatterns;

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SPARQLStar2CypherTranslatorImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SPARQLStar2CypherTranslatorImpl.java
@@ -860,7 +860,7 @@ public class SPARQLStar2CypherTranslatorImpl implements SPARQLStar2CypherTransla
 
     @Override
     public List<MatchClause> mergePaths(final List<MatchClause> matchClauses) {
-        final LabeledGraph.LabeledGraphBuilder builder = LabeledGraph.builder();
+        final LabeledGraphBuilder builder = new LabeledGraphBuilder();
         for (final MatchClause m : matchClauses) {
             if (m instanceof NodeMatchClause)
                 builder.addNode(((NodeMatchClause) m).getNode());

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/EdgeMatchClause.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/EdgeMatchClause.java
@@ -41,15 +41,13 @@ public class EdgeMatchClause implements MatchClause {
 
     @Override
     public String toString() {
-        final StringBuilder builder = new StringBuilder();
-        builder.append("MATCH (")
-                .append(sourceNode.getName())
-                .append(")-[");
-        builder.append(edge.getName());
-        builder.append("]->(")
-                .append(targetNode.getName())
-                .append(")");
-        return builder.toString();
+        return "MATCH (" +
+                sourceNode.getName() +
+                ")-[" +
+                edge.getName() +
+                "]->(" +
+                targetNode.getName() +
+                ")";
     }
 
     @Override

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/PathMatchClause.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/PathMatchClause.java
@@ -105,10 +105,6 @@ public class PathMatchClause implements MatchClause {
             this.direction = direction;
         }
 
-        public LabeledGraph.Direction getDirection() {
-            return direction;
-        }
-
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/PathMatchClause.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/PathMatchClause.java
@@ -1,0 +1,84 @@
+package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.match;
+
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.MatchClause;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression.CypherVar;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
+
+import java.util.List;
+import java.util.Set;
+
+public class PathMatchClause implements MatchClause {
+
+    protected final List<PathMatchClause.Edge> edges;
+
+    //assumes that edges[i].right==edges[i+1].left
+    public PathMatchClause(List<Edge> edges) {
+        this.edges = edges;
+    }
+
+    @Override
+    public void visit(final CypherExpressionVisitor visitor) {
+        for (final Edge e : edges) {
+            e.left.visit(visitor);
+            e.edge.visit(visitor);
+            e.right.visit(visitor);
+        }
+        visitor.visitPathMatch(this);
+    }
+
+    @Override
+    public boolean isRedundantWith(final MatchClause match) {
+        return false;
+    }
+
+    @Override
+    public Set<CypherVar> getVars() {
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder builder = new StringBuilder();
+        builder.append("MATCH ");
+        boolean first = true;
+        for (final Edge e : edges) {
+            if (first) {
+                builder.append("(").append(e.left).append(")");
+                first = false;
+            }
+            if (e.direction.equals(Direction.RIGHT2LEFT)) {
+                builder.append("<");
+            }
+            builder.append("-").append("[").append(e.edge).append("]").append("-");
+            if (e.direction.equals(Direction.LEFT2RIGHT)) {
+                builder.append(">");
+            }
+            builder.append("(").append(e.right).append(")");
+        }
+        return builder.toString();
+    }
+
+    public List<Edge> getEdges() {
+        return edges;
+    }
+
+    public enum Direction {LEFT2RIGHT, RIGHT2LEFT, UNDIRECTED}
+
+    public static class Edge {
+        protected final CypherVar left;
+        protected final CypherVar edge;
+        protected final CypherVar right;
+        protected final PathMatchClause.Direction direction;
+
+        public Edge(final CypherVar left, final CypherVar edge, final CypherVar right, final Direction direction) {
+            this.left = left;
+            this.edge = edge;
+            this.right = right;
+            this.direction = direction;
+        }
+
+        public Direction getDirection() {
+            return direction;
+        }
+    }
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/PathMatchClause.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/PathMatchClause.java
@@ -88,10 +88,10 @@ public class PathMatchClause implements MatchClause {
     }
 
     public static class EdgePattern {
-        protected final CypherVar left;
-        protected final CypherVar edge;
-        protected final CypherVar right;
-        protected final LabeledGraph.Direction direction;
+        public final CypherVar left;
+        public final CypherVar edge;
+        public final CypherVar right;
+        public final LabeledGraph.Direction direction;
 
         public EdgePattern(final CypherVar left, final CypherVar edge, final CypherVar right, final LabeledGraph.Direction direction) {
             assert left != null;

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/PathMatchClause.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/query/impl/match/PathMatchClause.java
@@ -3,22 +3,34 @@ package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.match;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.MatchClause;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression.CypherVar;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherExpressionVisitor;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.LabeledGraph;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 public class PathMatchClause implements MatchClause {
 
-    protected final List<PathMatchClause.Edge> edges;
+    protected final List<EdgePattern> edges;
 
     //assumes that edges[i].right==edges[i+1].left
-    public PathMatchClause(List<Edge> edges) {
+    public PathMatchClause(final List<EdgePattern> edges) {
         this.edges = edges;
+    }
+
+    public PathMatchClause(final LabeledGraph.Path path) {
+        edges = new ArrayList<>();
+        CypherVar start = path.getStart();
+        for (final LabeledGraph.Edge e : path.getEdges()) {
+            edges.add(new EdgePattern(start, e.getEdge(), e.getTarget(), e.getDirection()));
+            start = e.getTarget();
+        }
     }
 
     @Override
     public void visit(final CypherExpressionVisitor visitor) {
-        for (final Edge e : edges) {
+        for (final EdgePattern e : edges) {
             e.left.visit(visitor);
             e.edge.visit(visitor);
             e.right.visit(visitor);
@@ -41,16 +53,16 @@ public class PathMatchClause implements MatchClause {
         final StringBuilder builder = new StringBuilder();
         builder.append("MATCH ");
         boolean first = true;
-        for (final Edge e : edges) {
+        for (final EdgePattern e : edges) {
             if (first) {
                 builder.append("(").append(e.left).append(")");
                 first = false;
             }
-            if (e.direction.equals(Direction.RIGHT2LEFT)) {
+            if (e.direction.equals(LabeledGraph.Direction.RIGHT2LEFT)) {
                 builder.append("<");
             }
             builder.append("-").append("[").append(e.edge).append("]").append("-");
-            if (e.direction.equals(Direction.LEFT2RIGHT)) {
+            if (e.direction.equals(LabeledGraph.Direction.LEFT2RIGHT)) {
                 builder.append(">");
             }
             builder.append("(").append(e.right).append(")");
@@ -58,27 +70,56 @@ public class PathMatchClause implements MatchClause {
         return builder.toString();
     }
 
-    public List<Edge> getEdges() {
+    public List<EdgePattern> getEdges() {
         return edges;
     }
 
-    public enum Direction {LEFT2RIGHT, RIGHT2LEFT, UNDIRECTED}
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        PathMatchClause that = (PathMatchClause) o;
+        return edges.equals(that.edges);
+    }
 
-    public static class Edge {
+    @Override
+    public int hashCode() {
+        return Objects.hash(edges);
+    }
+
+    public static class EdgePattern {
         protected final CypherVar left;
         protected final CypherVar edge;
         protected final CypherVar right;
-        protected final PathMatchClause.Direction direction;
+        protected final LabeledGraph.Direction direction;
 
-        public Edge(final CypherVar left, final CypherVar edge, final CypherVar right, final Direction direction) {
+        public EdgePattern(final CypherVar left, final CypherVar edge, final CypherVar right, final LabeledGraph.Direction direction) {
+            assert left != null;
+            assert edge != null;
+            assert right != null;
+            assert direction != null;
+
             this.left = left;
             this.edge = edge;
             this.right = right;
             this.direction = direction;
         }
 
-        public Direction getDirection() {
+        public LabeledGraph.Direction getDirection() {
             return direction;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            EdgePattern that = (EdgePattern) o;
+            return left.equals(that.left) && edge.equals(that.edge) && right.equals(that.right) && direction == that.direction;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(left, edge, right, direction);
         }
     }
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherExpressionVisitor.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/CypherExpressionVisitor.java
@@ -4,6 +4,7 @@ import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherExpression;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression.*;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.match.EdgeMatchClause;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.match.NodeMatchClause;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.match.PathMatchClause;
 
 /**
  * This class is made to provide generic visitor functionalities to traverse expression trees.
@@ -37,4 +38,5 @@ public interface CypherExpressionVisitor {
     void visitVariableLabel (final VariableLabelExpression ex);
     void visitEdgeMatch(final EdgeMatchClause ex);
     void visitNodeMatch(final NodeMatchClause ex);
+    void visitPathMatch(final PathMatchClause ex);
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
@@ -169,8 +169,8 @@ public class LabeledGraph {
      * Represents a path in a graph, starting from a given node and following a sequence of edges.
      */
     public static class Path {
-        protected CypherVar start;
-        protected List<Edge> path;
+        protected final CypherVar start;
+        protected final List<Edge> path;
 
         public Path(final CypherVar start, final Edge e) {
             this.start = start;

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
@@ -256,11 +256,9 @@ public class LabeledGraph {
             list = adjacencyList.get(tgt);
             if (list == null) {
                 list = new LinkedList<>();
-                list.add(new Edge(currentId, edge, src, Direction.RIGHT2LEFT));
                 adjacencyList.put(tgt, list);
-            } else {
-                list.add(new Edge(currentId, edge, src, Direction.RIGHT2LEFT));
             }
+            list.add( new Edge(currentId, edge, src, Direction.RIGHT2LEFT) );
         }
 
         public void addNode(final CypherVar node) {

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
@@ -62,6 +62,10 @@ public class LabeledGraph {
      * removes the edges contained in path
      */
     public void removePath(final Path path) {
+        if (adjacencyLists.get(path.start).isEmpty()) {
+            adjacencyLists.remove(path.start);
+            return;
+        }
         CypherVar current = path.start;
         for (final Edge e : path.path) {
             //removes LEFT2RIGHT
@@ -88,16 +92,16 @@ public class LabeledGraph {
     public Path getLongestPath() {
         Path longest = null;
         for (final CypherVar start : adjacencyLists.keySet()) {
-           final Path candidate = longestStartingFrom(start);
-           if (longest == null || candidate.size() > longest.size()) {
-               longest = candidate;
-           }
+            final Path candidate = longestStartingFrom(start);
+            if (longest == null || candidate.size() > longest.size()) {
+                longest = candidate;
+            }
         }
         return longest;
     }
 
     private Path longestStartingFrom(final CypherVar start) {
-        //System.out.println("start: "+start);
+        if (adjacencyLists.get(start).isEmpty()) return new Path(start, new ArrayList<>());
         final Set<Integer> visitedEdges = new HashSet<>();
         final Deque<Edge> toVisit = new ArrayDeque<>();
         for (final Edge e : adjacencyLists.get(start)) {
@@ -107,7 +111,6 @@ public class LabeledGraph {
         Path longest = null;
         while (!toVisit.isEmpty()) {
             final Edge currentEdge = toVisit.pop();
-            //System.out.println("current edge: " + currentEdge);
             if (candidate == null) {
                 candidate = new Path(start, currentEdge);
             }
@@ -115,11 +118,7 @@ public class LabeledGraph {
                 candidate.addEdge(currentEdge);
             }
             visitedEdges.add(currentEdge.id);
-            //System.out.println("current path: " + candidate);
             if (!allVisited(adjacencyLists.get(currentEdge.target), visitedEdges)) {
-                //System.out.println("going through: " + currentEdge.target);
-                //System.out.println(visitedEdges);
-                //System.out.println(adjacencyLists.get(currentEdge.target));
                 for (final Edge e : adjacencyLists.get(currentEdge.target)) {
                     if (!visitedEdges.contains(e.id)) {
                         toVisit.push(e);
@@ -129,7 +128,6 @@ public class LabeledGraph {
                 if ( longest == null || candidate.size() > longest.size() ) {
                     longest = candidate.copy();
                 }
-                //System.out.println("end of path");
                 candidate.removeLast();
             }
         }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
@@ -250,11 +250,9 @@ public class LabeledGraph {
             List<Edge> list = adjacencyList.get(src);
             if (list == null) {
                 list = new LinkedList<>();
-                list.add(new Edge(currentId, edge, tgt, Direction.LEFT2RIGHT));
                 adjacencyList.put(src, list);
-            } else {
-                list.add(new Edge(currentId, edge, tgt, Direction.LEFT2RIGHT));
             }
+            list.add( new Edge(currentId, edge, tgt, Direction.LEFT2RIGHT) );
             list = adjacencyList.get(tgt);
             if (list == null) {
                 list = new LinkedList<>();

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
@@ -176,10 +176,7 @@ public class LabeledGraph {
     private Path longestStartingFrom(final CypherVar start) {
         if (adjacencyLists.get(start).isEmpty()) return new Path(start, new ArrayList<>());
         final Set<Integer> visitedEdges = new HashSet<>();
-        final Deque<Edge> toVisit = new ArrayDeque<>();
-        for (final Edge e : adjacencyLists.get(start)) {
-            toVisit.push(e);
-        }
+        final Deque<Edge> toVisit = new ArrayDeque<>( adjacencyLists.get(start) );
         Path candidate = null;
         Path longest = null;
         while (!toVisit.isEmpty()) {

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
@@ -5,10 +5,21 @@ import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression.Cyphe
 import java.util.*;
 import java.util.stream.Collectors;
 
+/**
+ * This class models graphs with labeled edges. Nodes and edge labels are modeled as {@link CypherVar} objects.
+ * Edges can be directed or not. A pair of nodes can have an arbitrary number of edges between them. Nodes can
+ * have edges that start and end on themselves.
+ */
 public class LabeledGraph {
 
+    /**
+     * Enum for the possible edge directions
+     */
     public enum Direction {LEFT2RIGHT, RIGHT2LEFT, UNDIRECTED}
 
+    /**
+     * An edge of a labeled graph has an id, an edge label, a target node and a direction
+     */
     public static class Edge {
         protected final int id;
         protected final CypherVar edge;
@@ -24,11 +35,7 @@ public class LabeledGraph {
 
         @Override
         public String toString() {
-            return "(" + id +
-                    ", " + edge +
-                    ", " + target +
-                    ", " + direction +
-                    ')';
+            return "(" + id + ", " + edge + ", " + target + ", " + direction + ')';
         }
     }
 
@@ -62,6 +69,10 @@ public class LabeledGraph {
         }
     }
 
+    /**
+     * Enumerates all possible paths and returns the longest found. In case of ties, it returns the first
+     * longest path found.
+     */
     public Path getLongestPath() {
         Path longest = null;
         for (final CypherVar start : adjacencyLists.keySet()) {
@@ -135,6 +146,9 @@ public class LabeledGraph {
         return Objects.hash(adjacencyLists);
     }
 
+    /**
+     * Represents a path in a graph, starting from a given node and following a sequence of edges.
+     */
     public static class Path {
         protected CypherVar start;
         protected List<Edge> path;

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
@@ -51,6 +51,79 @@ public class LabeledGraph {
         }
     }
 
+    /**
+     * Represents a path in a graph, starting from a given node and following a sequence of edges.
+     */
+    public static class Path {
+        protected final CypherVar start;
+        protected final List<Edge> path;
+
+        public Path(final CypherVar start, final Edge e) {
+            this.start = start;
+            this.path = new LinkedList<>();
+            this.path.add(e);
+        }
+
+        public Path(final CypherVar start, final List<Edge> path) {
+            this.start = start;
+            this.path = path;
+        }
+
+        public void addEdge(final Edge e) {
+            this.path.add(e);
+        }
+
+        public int size() {
+            return path.size();
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder builder = new StringBuilder();
+            builder.append("(").append(start).append(")");
+            for (final LabeledGraph.Edge e : path) {
+                if (e.direction.equals(LabeledGraph.Direction.RIGHT2LEFT)) {
+                    builder.append("<");
+                }
+                builder.append("-").append("[").append(e.edge).append("]").append("-");
+                if (e.direction.equals(LabeledGraph.Direction.LEFT2RIGHT)) {
+                    builder.append(">");
+                }
+                builder.append("(").append(e.target).append(")");
+            }
+            return builder.toString();
+        }
+
+        public void removeLast() {
+            this.path.remove(size()-1);
+        }
+
+        public Path copy() {
+            return new Path(start, new LinkedList<>(path));
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Path path1 = (Path) o;
+            return start.equals(path1.start) && path.equals(path1.path);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(start, path);
+        }
+
+        public CypherVar getStart() {
+            return start;
+        }
+
+        public List<Edge> getEdges() {
+            return path;
+        }
+    }
+
     protected final Map<CypherVar, List<Edge>> adjacencyLists;
 
     public LabeledGraph(final Map<CypherVar, List<Edge>> adjacencyLists) {
@@ -138,10 +211,6 @@ public class LabeledGraph {
         return edges == null || visitedEdges.containsAll(edges.stream().map(x->x.id).collect(Collectors.toSet()));
     }
 
-    public static LabeledGraphBuilder builder() {
-        return new LabeledGraphBuilder();
-    }
-
     //checks if there's any nodes or edges in the graph
     public boolean isEmpty() {
         return adjacencyLists.isEmpty();
@@ -163,111 +232,5 @@ public class LabeledGraph {
     @Override
     public int hashCode() {
         return Objects.hash(adjacencyLists);
-    }
-
-    /**
-     * Represents a path in a graph, starting from a given node and following a sequence of edges.
-     */
-    public static class Path {
-        protected final CypherVar start;
-        protected final List<Edge> path;
-
-        public Path(final CypherVar start, final Edge e) {
-            this.start = start;
-            this.path = new LinkedList<>();
-            this.path.add(e);
-        }
-
-        public Path(final CypherVar start, final List<Edge> path) {
-            this.start = start;
-            this.path = path;
-        }
-
-        public void addEdge(final Edge e) {
-            this.path.add(e);
-        }
-
-        public int size() {
-            return path.size();
-        }
-
-        @Override
-        public String toString() {
-            final StringBuilder builder = new StringBuilder();
-            builder.append("(").append(start).append(")");
-            for (final LabeledGraph.Edge e : path) {
-                if (e.direction.equals(LabeledGraph.Direction.RIGHT2LEFT)) {
-                    builder.append("<");
-                }
-                builder.append("-").append("[").append(e.edge).append("]").append("-");
-                if (e.direction.equals(LabeledGraph.Direction.LEFT2RIGHT)) {
-                    builder.append(">");
-                }
-                builder.append("(").append(e.target).append(")");
-            }
-            return builder.toString();
-        }
-
-        public void removeLast() {
-            this.path.remove(size()-1);
-        }
-
-        public Path copy() {
-            return new Path(start, new LinkedList<>(path));
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            Path path1 = (Path) o;
-            return start.equals(path1.start) && path.equals(path1.path);
-        }
-
-        @Override
-        public int hashCode() {
-            return Objects.hash(start, path);
-        }
-
-        public CypherVar getStart() {
-            return start;
-        }
-
-        public List<Edge> getEdges() {
-            return path;
-        }
-    }
-
-    public static class LabeledGraphBuilder {
-        protected final Map<CypherVar, List<Edge>> adjacencyList = new HashMap<>();
-        protected int currentId = 0;
-
-        private LabeledGraphBuilder() {
-        }
-
-        public void addEdge(final CypherVar src, final CypherVar edge, final CypherVar tgt) {
-            ++currentId;
-            List<Edge> list = adjacencyList.get(src);
-            if (list == null) {
-                list = new LinkedList<>();
-                adjacencyList.put(src, list);
-            }
-            list.add( new Edge(currentId, edge, tgt, Direction.LEFT2RIGHT) );
-            list = adjacencyList.get(tgt);
-            if (list == null) {
-                list = new LinkedList<>();
-                adjacencyList.put(tgt, list);
-            }
-            list.add( new Edge(currentId, edge, src, Direction.RIGHT2LEFT) );
-        }
-
-        public void addNode(final CypherVar node) {
-            if (!adjacencyList.containsKey(node))
-                adjacencyList.put(node, new ArrayList<>());
-        }
-
-        public LabeledGraph build() {
-            return new LabeledGraph(adjacencyList);
-        }
     }
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
@@ -1,0 +1,200 @@
+package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils;
+
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression.CypherVar;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class LabeledGraph {
+
+    public enum Direction {LEFT2RIGHT, RIGHT2LEFT, UNDIRECTED}
+
+    public static class Edge {
+        protected final int id;
+        protected final CypherVar edge;
+        protected final CypherVar target;
+        protected final Direction direction;
+
+        public Edge(final int id, final CypherVar edge, final CypherVar target, final Direction direction) {
+            this.id = id;
+            this.edge = edge;
+            this.target = target;
+            this.direction = direction;
+        }
+
+        @Override
+        public String toString() {
+            return "(" + id +
+                    ", " + edge +
+                    ", " + target +
+                    ", " + direction +
+                    ')';
+        }
+    }
+
+    protected final Map<CypherVar, List<Edge>> adjacencyLists;
+
+    public LabeledGraph(final Map<CypherVar, List<Edge>> adjacencyLists) {
+        assert adjacencyLists != null;
+        this.adjacencyLists = adjacencyLists;
+    }
+
+    /**
+     * removes the edges contained in path
+     */
+    public void removePath(final Path path) {
+        CypherVar current = path.start;
+        for (final Edge e : path.path) {
+            //removes LEFT2RIGHT
+            List<Edge> toRemove = adjacencyLists.get(current).stream().filter(x->x.edge.equals(e.edge)).collect(Collectors.toList());
+            adjacencyLists.get(current).removeAll(toRemove);
+            if (adjacencyLists.get(current).isEmpty()) {
+                adjacencyLists.remove(current);
+            }
+            //removes RIGHT2LEFT
+            if (!adjacencyLists.containsKey(e.target)) continue;;
+            toRemove = adjacencyLists.get(e.target).stream().filter(x->x.id==e.id).collect(Collectors.toList());
+            adjacencyLists.get(e.target).removeAll(toRemove);
+            if (adjacencyLists.get(e.target).isEmpty()) {
+                adjacencyLists.remove(e.target);
+            }
+            current = e.target;
+        }
+    }
+
+    public Path getLongestPath() {
+        Path longest = null;
+        for (final CypherVar start : adjacencyLists.keySet()) {
+           final Path candidate = longestStartingFrom(start);
+           if (longest == null || candidate.size() > longest.size()) {
+               longest = candidate;
+           }
+        }
+        return longest;
+    }
+
+    private Path longestStartingFrom(final CypherVar start) {
+        System.out.println("start: "+start);
+        final Set<Integer> visitedEdges = new HashSet<>();
+        final Deque<Edge> toVisit = new ArrayDeque<>();
+        for (final Edge e : adjacencyLists.get(start)) {
+            toVisit.push(e);
+        }
+        Path candidate = null;
+        Path longest = null;
+        while (!toVisit.isEmpty()) {
+            final Edge currentEdge = toVisit.pop();
+            System.out.println("current edge: " + currentEdge);
+            if (candidate == null) {
+                candidate = new Path(start, currentEdge);
+            }
+            else if (! visitedEdges.contains(currentEdge.id)) {
+                candidate.addEdge(currentEdge);
+            }
+            visitedEdges.add(currentEdge.id);
+            System.out.println("current path: " + candidate);
+            if (!allVisited(adjacencyLists.get(currentEdge.target), visitedEdges)) {
+                System.out.println("going through: " + currentEdge.target);
+                System.out.println(visitedEdges);
+                System.out.println(adjacencyLists.get(currentEdge.target));
+                for (final Edge e : adjacencyLists.get(currentEdge.target)) {
+                    if (!visitedEdges.contains(e.id)) {
+                        toVisit.push(e);
+                    }
+                }
+            } else {
+                if ( longest == null || candidate.size() > longest.size() ) {
+                    longest = candidate.copy();
+                }
+                System.out.println("end of path");
+                candidate.removeLast();
+            }
+        }
+        return longest;
+    }
+
+    private boolean allVisited(final List<Edge> edges, Set<Integer> visitedEdges) {
+        return edges == null || visitedEdges.containsAll(edges.stream().map(x->x.id).collect(Collectors.toSet()));
+    }
+
+    @Override
+    public String toString() {
+        return adjacencyLists.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        LabeledGraph graph = (LabeledGraph) o;
+        return adjacencyLists.equals(graph.adjacencyLists);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(adjacencyLists);
+    }
+
+    public static class Path {
+        protected CypherVar start;
+        protected List<Edge> path;
+
+        public Path(final CypherVar start, final Edge e) {
+            this.start = start;
+            this.path = new LinkedList<>();
+            this.path.add(e);
+        }
+
+        public Path(final CypherVar start, final List<Edge> path) {
+            this.start = start;
+            this.path = path;
+        }
+
+        public void addEdge(final Edge e) {
+            this.path.add(e);
+        }
+
+        public int size() {
+            return path.size();
+        }
+
+        @Override
+        public String toString() {
+            final StringBuilder builder = new StringBuilder();
+            builder.append("(").append(start).append(")");
+            for (final LabeledGraph.Edge e : path) {
+                if (e.direction.equals(LabeledGraph.Direction.RIGHT2LEFT)) {
+                    builder.append("<");
+                }
+                builder.append("-").append("[").append(e.edge).append("]").append("-");
+                if (e.direction.equals(LabeledGraph.Direction.LEFT2RIGHT)) {
+                    builder.append(">");
+                }
+                builder.append("(").append(e.target).append(")");
+            }
+            return builder.toString();
+        }
+
+        public void removeLast() {
+            this.path.remove(size()-1);
+        }
+
+        public Path copy() {
+            return new Path(start, new LinkedList<>(path));
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Path path1 = (Path) o;
+            return start.equals(path1.start) && path.equals(path1.path);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(start, path);
+        }
+    }
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
@@ -239,11 +239,10 @@ public class LabeledGraph {
     }
 
     public static class LabeledGraphBuilder {
-        protected final Map<CypherVar, List<Edge>> adjacencyList;
+        protected final Map<CypherVar, List<Edge>> adjacencyList = new HashMap<>();
         protected int currentId = 0;
 
         private LabeledGraphBuilder() {
-            adjacencyList = new HashMap<>();
         }
 
         public void addEdge(final CypherVar src, final CypherVar edge, final CypherVar tgt) {

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraphBuilder.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraphBuilder.java
@@ -1,0 +1,35 @@
+package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils;
+
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression.CypherVar;
+
+import java.util.*;
+
+public class LabeledGraphBuilder {
+    protected final Map<CypherVar, List<LabeledGraph.Edge>> adjacencyList = new HashMap<>();
+    protected int currentId = 0;
+
+    public void addEdge(final CypherVar src, final CypherVar edge, final CypherVar tgt) {
+        ++currentId;
+        List<LabeledGraph.Edge> list = adjacencyList.get(src);
+        if (list == null) {
+            list = new LinkedList<>();
+            adjacencyList.put(src, list);
+        }
+        list.add( new LabeledGraph.Edge(currentId, edge, tgt, LabeledGraph.Direction.LEFT2RIGHT) );
+        list = adjacencyList.get(tgt);
+        if (list == null) {
+            list = new LinkedList<>();
+            adjacencyList.put(tgt, list);
+        }
+        list.add( new LabeledGraph.Edge(currentId, edge, src, LabeledGraph.Direction.RIGHT2LEFT) );
+    }
+
+    public void addNode(final CypherVar node) {
+        if (!adjacencyList.containsKey(node))
+            adjacencyList.put(node, new ArrayList<>());
+    }
+
+    public LabeledGraph build() {
+        return new LabeledGraph(adjacencyList);
+    }
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/VariableReplacementVisitor.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/VariableReplacementVisitor.java
@@ -177,7 +177,7 @@ public class VariableReplacementVisitor implements CypherExpressionVisitor {
             final CypherVar edge = (CypherVar) stack.pop();
             assert stack.peek() instanceof CypherVar;
             final CypherVar left = (CypherVar) stack.pop();
-            edges.push(new PathMatchClause.EdgePattern(left, edge, right, ex.getEdges().get(i).getDirection()));
+            edges.push( new PathMatchClause.EdgePattern(left, edge, right, ex.getEdges().get(i).direction) );
         }
         stack.push(new PathMatchClause(new ArrayList<>(edges)));
     }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/VariableReplacementVisitor.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/VariableReplacementVisitor.java
@@ -169,7 +169,7 @@ public class VariableReplacementVisitor implements CypherExpressionVisitor {
 
     @Override
     public void visitPathMatch(PathMatchClause ex) {
-        final Deque<PathMatchClause.Edge> edges = new ArrayDeque<>();
+        final Deque<PathMatchClause.EdgePattern> edges = new ArrayDeque<>();
         for (int i = ex.getEdges().size(); i > 0; i--) {
             assert stack.peek() instanceof CypherVar;
             final CypherVar right = (CypherVar) stack.pop();
@@ -177,7 +177,7 @@ public class VariableReplacementVisitor implements CypherExpressionVisitor {
             final CypherVar edge = (CypherVar) stack.pop();
             assert stack.peek() instanceof CypherVar;
             final CypherVar left = (CypherVar) stack.pop();
-            edges.push(new PathMatchClause.Edge(left, edge, right, ex.getEdges().get(i).getDirection()));
+            edges.push(new PathMatchClause.EdgePattern(left, edge, right, ex.getEdges().get(i).getDirection()));
         }
         stack.push(new PathMatchClause(new ArrayList<>(edges)));
     }

--- a/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/LabeledGraphTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/LabeledGraphTest.java
@@ -48,16 +48,16 @@ public class LabeledGraphTest {
     @Test
     public void longestPathWithCyclesTest() {
         final Map<CypherVar, List<LabeledGraph.Edge>> adjacencyList = new HashMap<>();
-        final LabeledGraph.Edge wczr2l = new LabeledGraph.Edge(4, c, z, LabeledGraph.Direction.RIGHT2LEFT);
-        final LabeledGraph.Edge zdyl2r = new LabeledGraph.Edge(3, d, y, LabeledGraph.Direction.LEFT2RIGHT);
-        final LabeledGraph.Edge ybxl2r = new LabeledGraph.Edge(2, b, x, LabeledGraph.Direction.LEFT2RIGHT);
-        final LabeledGraph.Edge xawr2l = new LabeledGraph.Edge(1, a, w, LabeledGraph.Direction.RIGHT2LEFT);
-        adjacencyList.put(x, List.of(xawr2l, new LabeledGraph.Edge(2, b, y, LabeledGraph.Direction.RIGHT2LEFT)));
-        adjacencyList.put(y, List.of(ybxl2r, new LabeledGraph.Edge(3, d, z, LabeledGraph.Direction.RIGHT2LEFT)));
-        adjacencyList.put(z, List.of(zdyl2r, new LabeledGraph.Edge(4, c, w, LabeledGraph.Direction.LEFT2RIGHT)));
-        adjacencyList.put(w, List.of(new LabeledGraph.Edge(1, a, x, LabeledGraph.Direction.LEFT2RIGHT), wczr2l));
+        final LabeledGraph.Edge waxl2r = new LabeledGraph.Edge(1, a, x, LabeledGraph.Direction.LEFT2RIGHT);
+        final LabeledGraph.Edge xbdr2l = new LabeledGraph.Edge(2, b, y, LabeledGraph.Direction.RIGHT2LEFT);
+        final LabeledGraph.Edge ydzr2l = new LabeledGraph.Edge(3, d, z, LabeledGraph.Direction.RIGHT2LEFT);
+        final LabeledGraph.Edge zcwl2r = new LabeledGraph.Edge(4, c, w, LabeledGraph.Direction.LEFT2RIGHT);
+        adjacencyList.put(x, List.of(new LabeledGraph.Edge(1, a, w, LabeledGraph.Direction.RIGHT2LEFT), xbdr2l));
+        adjacencyList.put(y, List.of(new LabeledGraph.Edge(2, b, x, LabeledGraph.Direction.LEFT2RIGHT), ydzr2l));
+        adjacencyList.put(z, List.of(new LabeledGraph.Edge(3, d, y, LabeledGraph.Direction.LEFT2RIGHT), zcwl2r));
+        adjacencyList.put(w, List.of(waxl2r, new LabeledGraph.Edge(4, c, z, LabeledGraph.Direction.RIGHT2LEFT)));
         final LabeledGraph graph = new LabeledGraph(adjacencyList);
-        assertEquals(new LabeledGraph.Path(w, List.of(wczr2l, zdyl2r, ybxl2r, xawr2l)), graph.getLongestPath());
+        assertEquals(new LabeledGraph.Path(w, List.of(waxl2r, xbdr2l, ydzr2l, zcwl2r)), graph.getLongestPath());
     }
 
     @Test

--- a/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/LabeledGraphTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/LabeledGraphTest.java
@@ -1,0 +1,89 @@
+package se.liu.ida.hefquin.engine.wrappers.lpgwrapper;
+
+import org.junit.Test;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression.CypherVar;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.LabeledGraph;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class LabeledGraphTest {
+
+    final CypherVar a = new CypherVar("a");
+    final CypherVar b = new CypherVar("b");
+    final CypherVar c = new CypherVar("c");
+    final CypherVar d = new CypherVar("d");
+    final CypherVar e = new CypherVar("e");
+    final CypherVar x = new CypherVar("x");
+    final CypherVar y = new CypherVar("y");
+    final CypherVar z = new CypherVar("z");
+    final CypherVar u = new CypherVar("u");
+    final CypherVar w = new CypherVar("w");
+    final CypherVar t = new CypherVar("t");
+
+    @Test
+    public void longestPathTest() {
+        final Map<CypherVar, List<LabeledGraph.Edge>> adjacencyList = new HashMap<>();
+        final LabeledGraph.Edge tewr2l = new LabeledGraph.Edge(5, e, w, LabeledGraph.Direction.RIGHT2LEFT);
+        final LabeledGraph.Edge wczl2r = new LabeledGraph.Edge(3, c, z, LabeledGraph.Direction.LEFT2RIGHT);
+        final LabeledGraph.Edge zbyr2l = new LabeledGraph.Edge(2, b, y, LabeledGraph.Direction.RIGHT2LEFT);
+        final LabeledGraph.Edge yaxr2l = new LabeledGraph.Edge(1, a, x, LabeledGraph.Direction.RIGHT2LEFT);
+
+        adjacencyList.put(x, List.of(new LabeledGraph.Edge(1, a, y, LabeledGraph.Direction.LEFT2RIGHT)));
+        adjacencyList.put(y, List.of(yaxr2l, new LabeledGraph.Edge(2, b, z, LabeledGraph.Direction.LEFT2RIGHT)));
+        adjacencyList.put(z, List.of(zbyr2l, new LabeledGraph.Edge(3, c, w, LabeledGraph.Direction.RIGHT2LEFT)));
+        adjacencyList.put(w, List.of(wczl2r, new LabeledGraph.Edge(4, d, u, LabeledGraph.Direction.LEFT2RIGHT),
+                new LabeledGraph.Edge(5, e, t, LabeledGraph.Direction.LEFT2RIGHT)));
+        adjacencyList.put(u, List.of(new LabeledGraph.Edge(4, d, w, LabeledGraph.Direction.RIGHT2LEFT)));
+        adjacencyList.put(t, List.of(tewr2l));
+        final LabeledGraph graph = new LabeledGraph(adjacencyList);
+        assertEquals(new LabeledGraph.Path(t, List.of(tewr2l, wczl2r, zbyr2l, yaxr2l)),
+                graph.getLongestPath());
+    }
+
+    @Test
+    public void longestPathWithCyclesTest() {
+        final Map<CypherVar, List<LabeledGraph.Edge>> adjacencyList = new HashMap<>();
+        final LabeledGraph.Edge wczr2l = new LabeledGraph.Edge(4, c, z, LabeledGraph.Direction.RIGHT2LEFT);
+        final LabeledGraph.Edge zdyl2r = new LabeledGraph.Edge(3, d, y, LabeledGraph.Direction.LEFT2RIGHT);
+        final LabeledGraph.Edge ybxl2r = new LabeledGraph.Edge(2, b, x, LabeledGraph.Direction.LEFT2RIGHT);
+        final LabeledGraph.Edge xawr2l = new LabeledGraph.Edge(1, a, w, LabeledGraph.Direction.RIGHT2LEFT);
+        adjacencyList.put(x, List.of(xawr2l, new LabeledGraph.Edge(2, b, y, LabeledGraph.Direction.RIGHT2LEFT)));
+        adjacencyList.put(y, List.of(ybxl2r, new LabeledGraph.Edge(3, d, z, LabeledGraph.Direction.RIGHT2LEFT)));
+        adjacencyList.put(z, List.of(zdyl2r, new LabeledGraph.Edge(4, c, w, LabeledGraph.Direction.LEFT2RIGHT)));
+        adjacencyList.put(w, List.of(new LabeledGraph.Edge(1, a, x, LabeledGraph.Direction.LEFT2RIGHT), wczr2l));
+        final LabeledGraph graph = new LabeledGraph(adjacencyList);
+        assertEquals(new LabeledGraph.Path(w, List.of(wczr2l, zdyl2r, ybxl2r, xawr2l)), graph.getLongestPath());
+    }
+
+    @Test
+    public void removePathTest() {
+        final Map<CypherVar, List<LabeledGraph.Edge>> adjacencyList = new HashMap<>();
+        final LabeledGraph.Edge wdxl2r = new LabeledGraph.Edge(3, d, x, LabeledGraph.Direction.LEFT2RIGHT);
+        final LabeledGraph.Edge xbyl2r = new LabeledGraph.Edge(1, b, y, LabeledGraph.Direction.LEFT2RIGHT);
+        final LabeledGraph.Edge xczl2r = new LabeledGraph.Edge(2, c, z, LabeledGraph.Direction.LEFT2RIGHT);
+        final LabeledGraph.Edge xaur2l = new LabeledGraph.Edge(4, a, u, LabeledGraph.Direction.RIGHT2LEFT);
+        final LabeledGraph.Edge uaxl2r = new LabeledGraph.Edge(4, a, x, LabeledGraph.Direction.LEFT2RIGHT);
+        final LabeledGraph.Edge zcxr2l = new LabeledGraph.Edge(2, c, x, LabeledGraph.Direction.RIGHT2LEFT);
+        adjacencyList.put(x, new ArrayList<>(List.of(xbyl2r, xczl2r, new LabeledGraph.Edge(3, d, w, LabeledGraph.Direction.RIGHT2LEFT), xaur2l)));
+        adjacencyList.put(y, new ArrayList<>(List.of(new LabeledGraph.Edge(1, b, x, LabeledGraph.Direction.RIGHT2LEFT))));
+        adjacencyList.put(z, new ArrayList<>(List.of(zcxr2l)));
+        adjacencyList.put(w, new ArrayList<>(List.of(wdxl2r)));
+        adjacencyList.put(u, new ArrayList<>(List.of(uaxl2r)));
+        final LabeledGraph graph = new LabeledGraph(adjacencyList);
+        final LabeledGraph.Path toRemove = new LabeledGraph.Path(w, List.of(wdxl2r, xbyl2r));
+        graph.removePath(toRemove);
+
+        final Map<CypherVar, List<LabeledGraph.Edge>> updatedAdjacencyList = new HashMap<>();
+        updatedAdjacencyList.put(u, List.of(uaxl2r));
+        updatedAdjacencyList.put(x, List.of(xczl2r, xaur2l));
+        updatedAdjacencyList.put(z, List.of(zcxr2l));
+
+        assertEquals(new LabeledGraph(updatedAdjacencyList), graph);
+    }
+
+}

--- a/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslatorTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslatorTest.java
@@ -1194,10 +1194,10 @@ public class SPARQLStar2CypherTranslatorTest {
         matchClauses.add(new EdgeMatchClause(a7, a8, a1));
         final List<MatchClause> merged = new SPARQLStar2CypherTranslatorImpl().mergePaths(matchClauses);
         assertEquals(1, merged.size());
-        assertEquals(new PathMatchClause(List.of(new PathMatchClause.EdgePattern(a3, a4, a5, LabeledGraph.Direction.LEFT2RIGHT),
-                        new PathMatchClause.EdgePattern(a5, a6, a7, LabeledGraph.Direction.LEFT2RIGHT),
-                        new PathMatchClause.EdgePattern(a7, a8, a1, LabeledGraph.Direction.LEFT2RIGHT),
-                        new PathMatchClause.EdgePattern(a1, a2, a3, LabeledGraph.Direction.LEFT2RIGHT))),
+        assertEquals(new PathMatchClause(List.of(new PathMatchClause.EdgePattern(a3, a2, a1, LabeledGraph.Direction.RIGHT2LEFT),
+                        new PathMatchClause.EdgePattern(a1, a8, a7, LabeledGraph.Direction.RIGHT2LEFT),
+                        new PathMatchClause.EdgePattern(a7, a6, a5, LabeledGraph.Direction.RIGHT2LEFT),
+                        new PathMatchClause.EdgePattern(a5, a4, a3, LabeledGraph.Direction.RIGHT2LEFT))),
                 merged.get(0));
     }
 

--- a/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslatorTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslatorTest.java
@@ -16,13 +16,17 @@ import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl.DefaultConfiguration;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl.SPARQLStar2CypherTranslatorImpl;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherMatchQuery;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.CypherQuery;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.MatchClause;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.CypherUnionQueryImpl;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.expression.*;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.match.EdgeMatchClause;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.match.NodeMatchClause;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.query.impl.match.PathMatchClause;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherQueryBuilder;
 import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.CypherVarGenerator;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.utils.LabeledGraph;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -1144,6 +1148,26 @@ public class SPARQLStar2CypherTranslatorTest {
                         .add(new AliasedExpression(new GetItemExpression(a4, 0), ret2))
                         .build(),
                 translation);
+    }
+
+    @Test
+    public void mergePatternsTest() {
+        final CypherVar a11 = new CypherVar("a11");
+        final List<MatchClause> matchClauses = new ArrayList<>();
+        matchClauses.add(new EdgeMatchClause(a1, a2, a3));
+        matchClauses.add(new EdgeMatchClause(a3, a4, a5));
+        matchClauses.add(new EdgeMatchClause(a7, a6, a5));
+        matchClauses.add(new EdgeMatchClause(a7, a8, a9));
+        matchClauses.add(new EdgeMatchClause(a7, a10, a11));
+        final List<MatchClause> merged = new SPARQLStar2CypherTranslatorImpl().mergePaths(matchClauses);
+        assertEquals(2, merged.size());
+        assertEquals(new PathMatchClause(List.of(new PathMatchClause.EdgePattern(a11, a10, a7, LabeledGraph.Direction.RIGHT2LEFT),
+                        new PathMatchClause.EdgePattern(a7, a6, a5, LabeledGraph.Direction.LEFT2RIGHT),
+                        new PathMatchClause.EdgePattern(a5, a4, a3, LabeledGraph.Direction.RIGHT2LEFT),
+                        new PathMatchClause.EdgePattern(a3, a2, a1, LabeledGraph.Direction.RIGHT2LEFT))),
+                merged.get(0));
+        assertEquals(new PathMatchClause(List.of(new PathMatchClause.EdgePattern(a7, a8, a9, LabeledGraph.Direction.LEFT2RIGHT))),
+                merged.get(1));
     }
 
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslatorTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/SPARQLStar2CypherTranslatorTest.java
@@ -1170,4 +1170,51 @@ public class SPARQLStar2CypherTranslatorTest {
                 merged.get(1));
     }
 
+    @Test
+    public void mergeStarPatternTest() {
+        final List<MatchClause> matchClauses = new ArrayList<>();
+        matchClauses.add(new EdgeMatchClause(a1, a2, a3));
+        matchClauses.add(new EdgeMatchClause(a1, a4, a5));
+        matchClauses.add(new EdgeMatchClause(a1, a6, a7));
+        matchClauses.add(new EdgeMatchClause(a1, a8, a9));
+        final List<MatchClause> merged = new SPARQLStar2CypherTranslatorImpl().mergePaths(matchClauses);
+        assertEquals(2, merged.size());
+        assertEquals(new PathMatchClause(List.of(new PathMatchClause.EdgePattern(a3, a2, a1, LabeledGraph.Direction.RIGHT2LEFT),
+                new PathMatchClause.EdgePattern(a1, a8, a9, LabeledGraph.Direction.LEFT2RIGHT))), merged.get(0));
+        assertEquals(new PathMatchClause(List.of(new PathMatchClause.EdgePattern(a5, a4, a1, LabeledGraph.Direction.RIGHT2LEFT),
+                new PathMatchClause.EdgePattern(a1, a6, a7, LabeledGraph.Direction.LEFT2RIGHT))), merged.get(1));
+    }
+
+    @Test
+    public void mergeCyclePatternTest() {
+        final List<MatchClause> matchClauses = new ArrayList<>();
+        matchClauses.add(new EdgeMatchClause(a1, a2, a3));
+        matchClauses.add(new EdgeMatchClause(a3, a4, a5));
+        matchClauses.add(new EdgeMatchClause(a5, a6, a7));
+        matchClauses.add(new EdgeMatchClause(a7, a8, a1));
+        final List<MatchClause> merged = new SPARQLStar2CypherTranslatorImpl().mergePaths(matchClauses);
+        assertEquals(1, merged.size());
+        assertEquals(new PathMatchClause(List.of(new PathMatchClause.EdgePattern(a3, a4, a5, LabeledGraph.Direction.LEFT2RIGHT),
+                        new PathMatchClause.EdgePattern(a5, a6, a7, LabeledGraph.Direction.LEFT2RIGHT),
+                        new PathMatchClause.EdgePattern(a7, a8, a1, LabeledGraph.Direction.LEFT2RIGHT),
+                        new PathMatchClause.EdgePattern(a1, a2, a3, LabeledGraph.Direction.LEFT2RIGHT))),
+                merged.get(0));
+    }
+
+    @Test
+    public void mergeWithNodePatternsTest() {
+        final List<MatchClause> matchClauses = new ArrayList<>();
+        matchClauses.add(new EdgeMatchClause(a1, a2, a3));
+        matchClauses.add(new EdgeMatchClause(a3, a4, a5));
+        matchClauses.add(new EdgeMatchClause(a3, a6, a7));
+        matchClauses.add(new NodeMatchClause(a8));
+        final List<MatchClause> merged = new SPARQLStar2CypherTranslatorImpl().mergePaths(matchClauses);
+        assertEquals(3, merged.size());
+        assertEquals(new PathMatchClause(List.of(new PathMatchClause.EdgePattern(a5, a4, a3, LabeledGraph.Direction.RIGHT2LEFT),
+                new PathMatchClause.EdgePattern(a3, a6, a7, LabeledGraph.Direction.LEFT2RIGHT))), merged.get(0));
+        assertEquals(new PathMatchClause(List.of(new PathMatchClause.EdgePattern(a3, a2, a1, LabeledGraph.Direction.RIGHT2LEFT))),
+                merged.get(1));
+        assertEquals(new NodeMatchClause(a8), merged.get(2));
+    }
+
 }


### PR DESCRIPTION
This PR introduces a method for the translator object, which takes a set of `NodeMatchClause` and `EdgeMatchClause` and merges them into longer path patterns (`PathMatchPattern`).

To implement this method, all Match clauses are added into a "graph pattern", which is in class `LabeledGraph`. This class provides methods for finding the longest (simple undirected) path in the graph, and removing paths from the graph.

This PR also fixes a bug in the visitor pattern, where objects in lists need to be extracted in the reverse order they were put in the stack.
