### PR TITLE
Fix an issue in result rewriting

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/data/impl/VocabularyMappingImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/impl/VocabularyMappingImpl.java
@@ -347,36 +347,37 @@ public class VocabularyMappingImpl implements VocabularyMapping
 		while(i.hasNext()) {
 			final Var v = i.next();
 			final Node n = sm.asJenaBinding().get(v);
-			
+
 			if(!n.isURI()) {
 				for (final BindingBuilder j : bbs) {
 					j.add(v, n);
 				}
 			}
-			
-			final Set<Node> bindingTranslation = translateBinding(n);
-			if (bindingTranslation.size() > 1) {
-				final Set<BindingBuilder> bbsCopy = new HashSet<>();
-				
-				for(final Node j : bindingTranslation) {
-					for (final BindingBuilder k : bbs) {
-						BindingBuilder translationCopy = BindingBuilder.create();
-						if(!k.isEmpty()) {
-							translationCopy.addAll(k.snapshot());
+			else {
+				final Set<Node> bindingTranslation = translateBinding(n);
+				if (bindingTranslation.size() > 1) {
+					final Set<BindingBuilder> bbsCopy = new HashSet<>();
+
+					for (final Node j : bindingTranslation) {
+						for (final BindingBuilder k : bbs) {
+							BindingBuilder translationCopy = BindingBuilder.create();
+							if (!k.isEmpty()) {
+								translationCopy.addAll(k.snapshot());
+							}
+							translationCopy.add(v, j);
+							bbsCopy.add(translationCopy);
 						}
-						translationCopy.add(v, j);
-						bbsCopy.add(translationCopy);
 					}
-				}
-				
-				bbs = bbsCopy;
-			} else if (bindingTranslation.size() == 0) {
-				for (final BindingBuilder j : bbs) {
-					j.add(v, n);
-				}
-			} else {
-				for (final BindingBuilder j : bbs) {
-					j.add(v, bindingTranslation.iterator().next());
+
+					bbs = bbsCopy;
+				} else if (bindingTranslation.size() == 0) {
+					for (final BindingBuilder j : bbs) {
+						j.add(v, n);
+					}
+				} else {
+					for (final BindingBuilder j : bbs) {
+						j.add(v, bindingTranslation.iterator().next());
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fix an issue in result rewriting, specifically for variables that are bound to RDF literals.

Here is an example query for reproducing the issue:
the execution of this query does not terminate if '[ApplyVocabularyMappings](https://github.com/LiUSemWeb/HeFQUIN/blob/b5ee241745cad089cb4a8e91ee8e6baef73ddf5c/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/LogicalOptimizerImpl.java#L23)' is enabled.
```
SELECT * WHERE {
    SERVICE <http://dbpedia.org/sparql> { 
         <http://data.europa.eu/euodp/jrc-names/Adam_Maher> <http://www.w3.org/2000/01/rdf-schema#label> ?name 
    }
}
```
