### PR TITLE
ExecOpBindJoinSPARQLwithVALUES

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithVALUES.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithVALUES.java
@@ -43,8 +43,16 @@ public class ExecOpBindJoinSPARQLwithVALUES extends BaseForExecOpBindJoinSPARQL
 	protected NullaryExecutableOp createExecutableRequestOperator( final Iterable<SolutionMapping> solMaps ) {
 		final Set<Binding> bindings = new HashSet<>();
 		final Set<Var> joinVars = new HashSet<>();
+
+		boolean noJoinVars = false;
 		for ( final SolutionMapping s : solMaps ) {
 			final Binding b = SolutionMappingUtils.restrict( s.asJenaBinding(), varsInSubQuery );
+			// If there exists a solution mapping that does not have any variables in common with the triple pattern of this operator
+			// retrieve all matching triples of the given query
+			if ( b.isEmpty() ) {
+				noJoinVars = true;
+				break;
+			}
 			if ( ! SolutionMappingUtils.containsBlankNodes(b) ) {
 				bindings.add(b);
 
@@ -55,6 +63,9 @@ public class ExecOpBindJoinSPARQLwithVALUES extends BaseForExecOpBindJoinSPARQL
 			}
 		}
 
+		if (noJoinVars) {
+			return new ExecOpRequestSPARQL( new SPARQLRequestImpl(query), fm, false );
+		}
 		if ( bindings.isEmpty() ) {
 			return null;
 		}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithVALUES.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithVALUES.java
@@ -66,6 +66,7 @@ public class ExecOpBindJoinSPARQLwithVALUES extends BaseForExecOpBindJoinSPARQL
 		if (noJoinVars) {
 			return new ExecOpRequestSPARQL( new SPARQLRequestImpl(query), fm, false );
 		}
+
 		if ( bindings.isEmpty() ) {
 			return null;
 		}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithVALUES.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithVALUES.java
@@ -47,12 +47,14 @@ public class ExecOpBindJoinSPARQLwithVALUES extends BaseForExecOpBindJoinSPARQL
 		boolean noJoinVars = false;
 		for ( final SolutionMapping s : solMaps ) {
 			final Binding b = SolutionMappingUtils.restrict( s.asJenaBinding(), varsInSubQuery );
+
 			// If there exists a solution mapping that does not have any variables in common with the triple pattern of this operator
 			// retrieve all matching triples of the given query
 			if ( b.isEmpty() ) {
 				noJoinVars = true;
 				break;
 			}
+
 			if ( ! SolutionMappingUtils.containsBlankNodes(b) ) {
 				bindings.add(b);
 


### PR DESCRIPTION
Consider the case where the given solution mapping does not have any join variables with the triple pattern