### PR TITLE
Support for gpAdd and gpOptAdd

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/federation/access/DataRetrievalInterface.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/federation/access/DataRetrievalInterface.java
@@ -6,5 +6,7 @@ public interface DataRetrievalInterface
 
 	boolean supportsBGPRequests();
 
+	boolean supportsSPARQLPatternRequests();
+
 	boolean supportsRequest( final DataRetrievalRequest req );
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/iface/GraphQLInterfaceImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/iface/GraphQLInterfaceImpl.java
@@ -24,6 +24,11 @@ public class GraphQLInterfaceImpl implements GraphQLInterface
 	}
 
 	@Override
+	public boolean supportsSPARQLPatternRequests() {
+		return false;
+	}
+
+	@Override
 	public boolean supportsRequest( final DataRetrievalRequest req ) {
 		return req instanceof GraphQLRequest;
 	}

--- a/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/iface/Neo4jInterfaceImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/iface/Neo4jInterfaceImpl.java
@@ -28,6 +28,11 @@ public class Neo4jInterfaceImpl implements Neo4jInterface
         return false;
     }
 
+	@Override
+	public boolean supportsSPARQLPatternRequests() {
+		return false;
+	}
+
     @Override
     public boolean supportsRequest( final DataRetrievalRequest req ) {
         return req instanceof Neo4jRequest;

--- a/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/iface/SPARQLEndpointInterfaceImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/iface/SPARQLEndpointInterfaceImpl.java
@@ -26,6 +26,11 @@ public class SPARQLEndpointInterfaceImpl implements SPARQLEndpointInterface
 	}
 
 	@Override
+	public boolean supportsSPARQLPatternRequests() {
+		return true;
+	}
+
+	@Override
 	public boolean supportsRequest( final DataRetrievalRequest req ) {
 		return req instanceof SPARQLRequest;
 	}

--- a/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/iface/TPFInterfaceImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/iface/TPFInterfaceImpl.java
@@ -53,6 +53,11 @@ public class TPFInterfaceImpl implements TPFInterface
 	}
 
 	@Override
+	public boolean supportsSPARQLPatternRequests() {
+		return false;
+	}
+
+	@Override
 	public boolean supportsRequest( final DataRetrievalRequest req ) {
 		return req instanceof TriplePatternRequest;
 	}

--- a/src/main/java/se/liu/ida/hefquin/engine/federation/access/utils/SPARQLRequestUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/federation/access/utils/SPARQLRequestUtils.java
@@ -11,32 +11,13 @@ import se.liu.ida.hefquin.engine.query.impl.QueryPatternUtils;
 public class SPARQLRequestUtils
 {
 	/**
-	 * Merges the given triple pattern into the given request. If the given
-	 * request is a {@link TriplePatternRequest} or a {@link BGPRequest}, then
-	 * the resulting request is a {@link BGPRequest} with a BGP to which the
-	 * triple pattern was added. Otherwise, the resulting request contains a
-	 * {@link SPARQLGraphPattern} with the triple pattern joined to the pattern
-	 * of the given request.
+	 * Merges the given graph pattern into the given request. Returns a
+	 * {@link BGPRequest} if possible (namely, if the given request is a
+	 * {@link TriplePatternRequest} or a {@link BGPRequest} and the given
+	 * pattern is a {@link BGP} or a {@link TriplePattern}).
 	 */
-	public static SPARQLRequest merge( final SPARQLRequest req, final TriplePattern tp ) {
-		final SPARQLGraphPattern mergedPattern = QueryPatternUtils.merge( tp, req.getQueryPattern() );
-		if ( req instanceof BGP ) {
-			return new BGPRequestImpl( (BGP) mergedPattern );
-		}
-		else {
-			return new SPARQLRequestImpl(mergedPattern);
-		}
-	}
-
-	/**
-	 * Merges the given BGP into the given request. If the given request is a
-	 * {@link TriplePatternRequest} or a {@link BGPRequest}, then the resulting
-	 * request is a {@link BGPRequest} with a BGP to which the given BGP was
-	 * added. Otherwise, the resulting request contains a {@link SPARQLGraphPattern}
-	 * with the BGP joined to the pattern of the given request.
-	 */
-	public static SPARQLRequest merge( final SPARQLRequest req, final BGP bgp ) {
-		final SPARQLGraphPattern mergedPattern = QueryPatternUtils.merge( bgp, req.getQueryPattern() );
+	public static SPARQLRequest merge( final SPARQLRequest req, final SPARQLGraphPattern pattern ) {
+		final SPARQLGraphPattern mergedPattern = QueryPatternUtils.merge( pattern, req.getQueryPattern() );
 		if ( req instanceof BGP ) {
 			return new BGPRequestImpl( (BGP) mergedPattern );
 		}

--- a/src/main/java/se/liu/ida/hefquin/engine/query/impl/QueryPatternUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/query/impl/QueryPatternUtils.java
@@ -88,6 +88,30 @@ public class QueryPatternUtils
 			}
 			return new OpBGP(bgp);
 		}
+		else if ( pattern instanceof SPARQLUnionPattern ) {
+			final SPARQLUnionPattern up = (SPARQLUnionPattern) pattern;
+
+			final Iterator<SPARQLGraphPattern> it = up.getSubPatterns().iterator();
+			Op unionOp = convertToJenaOp( it.next() );
+			while ( it.hasNext() ) {
+				final Op nextOp = convertToJenaOp( it.next() );
+				unionOp = OpUnion.create( unionOp, nextOp );
+			}
+
+			return unionOp;
+		}
+		else if ( pattern instanceof SPARQLGroupPattern ) {
+			final SPARQLGroupPattern gp = (SPARQLGroupPattern) pattern;
+
+			final Iterator<SPARQLGraphPattern> it = gp.getSubPatterns().iterator();
+			Op joinOp = convertToJenaOp( it.next() );
+			while ( it.hasNext() ) {
+				final Op nextOp = convertToJenaOp( it.next() );
+				joinOp = OpJoin.create( joinOp, nextOp );
+			}
+
+			return joinOp;
+		}
 		else if ( pattern instanceof GenericSPARQLGraphPatternImpl1 ) {
 			@SuppressWarnings("deprecation")
 			final Op jenaOp = ( (GenericSPARQLGraphPatternImpl1) pattern ).asJenaOp();

--- a/src/main/java/se/liu/ida/hefquin/engine/query/impl/QueryPatternUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/query/impl/QueryPatternUtils.java
@@ -768,6 +768,26 @@ public class QueryPatternUtils
 	}
 
 	/**
+	 * Merges the two graph patterns into a single one, using join semantics.
+	 * Returns a {@link BGP} if possible (for instance, if both of the given
+	 * patterns are BGPs or one of them is a BGP and the other one a triple
+	 * pattern).
+	 */
+	public static SPARQLGraphPattern merge( final SPARQLGraphPattern p1,
+	                                        final SPARQLGraphPattern p2 )
+	{
+		if ( p1 instanceof TriplePattern ) return merge( (TriplePattern) p1, p2 );
+
+		if ( p2 instanceof TriplePattern ) return merge( (TriplePattern) p2, p1 );
+
+		if ( p1 instanceof BGP ) return merge( (BGP) p1, p2 );
+
+		if ( p2 instanceof BGP ) return merge( (BGP) p2, p1 );
+
+		return new SPARQLGroupPatternImpl(p1, p2);
+	}
+
+	/**
 	 * Merges the given triple pattern into the given graph pattern. If the
 	 * given graph pattern is also a triple pattern or a BGP, then the resulting
 	 * graph pattern is a BGP to which the triple pattern was added. Otherwise,

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanUtils.java
@@ -9,6 +9,8 @@ import se.liu.ida.hefquin.engine.federation.access.TriplePatternRequest;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFilter;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGlobalToLocal;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRightJoin;
@@ -129,10 +131,16 @@ public class LogicalPlanUtils
 		public void visit( final LogicalOpBGPAdd op )        { subplanCount++; }
 
 		@Override
+		public void visit( final LogicalOpGPAdd op )         { subplanCount++; }
+
+		@Override
 		public void visit( final LogicalOpTPOptAdd op )      { subplanCount++; }
 
 		@Override
 		public void visit( final LogicalOpBGPOptAdd op )     { subplanCount++; }
+
+		@Override
+		public void visit( final LogicalOpGPOptAdd op )      { subplanCount++; }
 
 		@Override
 		public void visit( final LogicalOpJoin op )          { subplanCount++; }
@@ -186,12 +194,22 @@ public class LogicalPlanUtils
 		}
 
 		@Override
+		public void visit( final LogicalOpGPAdd op ) {
+			isSourceAssignment = false;
+		}
+
+		@Override
 		public void visit( final LogicalOpTPOptAdd op ) {
 			isSourceAssignment = false;
 		}
 
 		@Override
 		public void visit( final LogicalOpBGPOptAdd op ) {
+			isSourceAssignment = false;
+		}
+
+		@Override
+		public void visit( final LogicalOpGPOptAdd op ) {
 			isSourceAssignment = false;
 		}
 

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanVisitor.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanVisitor.java
@@ -3,6 +3,8 @@ package se.liu.ida.hefquin.engine.queryplan.logical;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFilter;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGlobalToLocal;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRightJoin;
@@ -21,9 +23,11 @@ public interface LogicalPlanVisitor
 
 	void visit( final LogicalOpTPAdd op );
 	void visit( final LogicalOpBGPAdd op );
+	void visit( final LogicalOpGPAdd op );
 
 	void visit( final LogicalOpTPOptAdd op );
 	void visit( final LogicalOpBGPOptAdd op );
+	void visit( final LogicalOpGPOptAdd op );
 
 	void visit( final LogicalOpJoin op );
 	void visit( final LogicalOpRightJoin op );

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanVisitorBase.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanVisitorBase.java
@@ -3,6 +3,8 @@ package se.liu.ida.hefquin.engine.queryplan.logical;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFilter;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGlobalToLocal;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRightJoin;
@@ -27,10 +29,16 @@ public class LogicalPlanVisitorBase implements LogicalPlanVisitor
 	public void visit( final LogicalOpBGPAdd op )            {}
 
 	@Override
+	public void visit( final LogicalOpGPAdd op )             {}
+
+	@Override
 	public void visit( final LogicalOpTPOptAdd op )          {}
 
 	@Override
 	public void visit( final LogicalOpBGPOptAdd op )         {}
+
+	@Override
+	public void visit( final LogicalOpGPOptAdd op )          {}
 
 	@Override
 	public void visit( final LogicalOpJoin op )              {}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalOpGPAdd.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalOpGPAdd.java
@@ -1,0 +1,66 @@
+package se.liu.ida.hefquin.engine.queryplan.logical.impl;
+
+import se.liu.ida.hefquin.engine.federation.FederationMember;
+import se.liu.ida.hefquin.engine.query.SPARQLGraphPattern;
+import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanVisitor;
+import se.liu.ida.hefquin.engine.queryplan.logical.UnaryLogicalOp;
+
+public class LogicalOpGPAdd implements UnaryLogicalOp
+{
+	protected final FederationMember fm;
+	protected final SPARQLGraphPattern pattern;
+
+	public LogicalOpGPAdd( final FederationMember fm, final SPARQLGraphPattern pattern ) {
+		assert fm != null;
+		assert pattern != null;
+		assert fm.getInterface().supportsSPARQLPatternRequests();
+
+		this.fm = fm;
+		this.pattern = pattern;
+	}
+
+	public FederationMember getFederationMember() {
+		return fm;
+	} 
+
+	public SPARQLGraphPattern getPattern() {
+		return pattern;
+	}
+
+	@Override
+	public boolean equals( final Object o ) {
+		if ( o == this )
+			return true;
+
+		if ( ! (o instanceof LogicalOpGPAdd) )
+			return false;
+
+		final LogicalOpGPAdd oo = (LogicalOpGPAdd) o;
+		return oo.fm.equals(fm) && oo.pattern.equals(pattern); 
+	}
+
+	@Override
+	public int hashCode(){
+		return fm.hashCode() ^ pattern.hashCode();
+	}
+
+	@Override
+	public void visit( final LogicalPlanVisitor visitor ) {
+		visitor.visit(this);
+	}
+
+	@Override
+	public String toString(){
+		final int codeOfPattern = pattern.toString().hashCode();
+		final int codeOfFm = fm.getInterface().toString().hashCode();
+
+		return "> gpAdd" +
+				"[" + codeOfPattern + ", "+ codeOfFm + "]"+
+				" ( "
+				+ pattern.toString()
+				+ ", "
+				+ fm.getInterface().toString()
+				+ " )";
+	}
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalOpGPOptAdd.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalOpGPOptAdd.java
@@ -1,0 +1,66 @@
+package se.liu.ida.hefquin.engine.queryplan.logical.impl;
+
+import se.liu.ida.hefquin.engine.federation.FederationMember;
+import se.liu.ida.hefquin.engine.query.SPARQLGraphPattern;
+import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanVisitor;
+import se.liu.ida.hefquin.engine.queryplan.logical.UnaryLogicalOp;
+
+public class LogicalOpGPOptAdd implements UnaryLogicalOp
+{
+	protected final FederationMember fm;
+	protected final SPARQLGraphPattern pattern;
+
+	public LogicalOpGPOptAdd( final FederationMember fm, final SPARQLGraphPattern pattern ) {
+		assert fm != null;
+		assert pattern != null;
+		assert fm.getInterface().supportsSPARQLPatternRequests();
+
+		this.fm = fm;
+		this.pattern = pattern;
+	}
+
+	public FederationMember getFederationMember() {
+		return fm;
+	} 
+
+	public SPARQLGraphPattern getPattern() {
+		return pattern;
+	}
+
+	@Override
+	public boolean equals( final Object o ) {
+		if ( o == this )
+			return true;
+
+		if ( ! (o instanceof LogicalOpGPOptAdd) )
+			return false;
+
+		final LogicalOpGPOptAdd oo = (LogicalOpGPOptAdd) o;
+		return oo.fm.equals(fm) && oo.pattern.equals(pattern); 
+	}
+
+	@Override
+	public int hashCode(){
+		return fm.hashCode() ^ pattern.hashCode();
+	}
+
+	@Override
+	public void visit( final LogicalPlanVisitor visitor ) {
+		visitor.visit(this);
+	}
+
+	@Override
+	public String toString(){
+		final int codeOfPattern = pattern.toString().hashCode();
+		final int codeOfFm = fm.getInterface().toString().hashCode();
+
+		return "> gpOptAdd" +
+				"[" + codeOfPattern + ", "+ codeOfFm + "]"+
+				" ( "
+				+ pattern.toString()
+				+ ", "
+				+ fm.getInterface().toString()
+				+ " )";
+	}
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/BasePhysicalOpSingleInputJoin.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/BasePhysicalOpSingleInputJoin.java
@@ -1,16 +1,15 @@
 package se.liu.ida.hefquin.engine.queryplan.physical.impl;
 
-import java.util.HashSet;
 import java.util.Objects;
-import java.util.Set;
 
-import org.apache.jena.sparql.core.Var;
-
+import se.liu.ida.hefquin.engine.query.SPARQLGraphPattern;
 import se.liu.ida.hefquin.engine.query.impl.QueryPatternUtils;
 import se.liu.ida.hefquin.engine.queryplan.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.logical.UnaryLogicalOp;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPOptAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.physical.UnaryPhysicalOpForLogicalOp;
@@ -21,11 +20,16 @@ public abstract class BasePhysicalOpSingleInputJoin implements UnaryPhysicalOpFo
 
     /**
      * The given logical operator is expected to be of one of the following
-     * two types: {@link LogicalOpTPAdd} or {@link LogicalOpBGPAdd}.
+     * six types:
+     * {@link LogicalOpTPAdd}, {@link LogicalOpTPOptAdd},
+     * {@link LogicalOpBGPAdd}, {@link LogicalOpBGPOptAdd},
+     * {@link LogicalOpGPAdd}, or {@link LogicalOpGPOptAdd}.
      */
     protected BasePhysicalOpSingleInputJoin( final UnaryLogicalOp lop ) {
         assert lop != null;
-        assert (lop instanceof LogicalOpBGPAdd) || (lop instanceof LogicalOpTPAdd);
+        assert (lop instanceof LogicalOpBGPAdd) || (lop instanceof LogicalOpBGPOptAdd) ||
+               (lop instanceof LogicalOpTPAdd) || (lop instanceof LogicalOpTPOptAdd) ||
+               (lop instanceof LogicalOpGPAdd) || (lop instanceof LogicalOpGPOptAdd);
         this.lop = lop;
     }
 
@@ -47,32 +51,30 @@ public abstract class BasePhysicalOpSingleInputJoin implements UnaryPhysicalOpFo
 	public ExpectedVariables getExpectedVariables( final ExpectedVariables... inputVars ) {
 		assert inputVars.length == 1;
 
-		final Set<Var> certainVars = new HashSet<>( inputVars[0].getCertainVariables() );
-		final Set<Var> possibleVars = new HashSet<>( inputVars[0].getPossibleVariables() );
+		final SPARQLGraphPattern p;
 
 		if ( lop instanceof LogicalOpTPAdd ) {
-			final LogicalOpTPAdd tpAdd = (LogicalOpTPAdd) lop;
-			certainVars.addAll( QueryPatternUtils.getVariablesInPattern(tpAdd.getTP()) );
+			p = ( (LogicalOpTPAdd) lop ).getTP();
 		}
 		else if ( lop instanceof LogicalOpTPOptAdd ) {
-			final LogicalOpTPOptAdd tpAdd = (LogicalOpTPOptAdd) lop;
-			certainVars.addAll( QueryPatternUtils.getVariablesInPattern(tpAdd.getTP()) );
+			p = ( (LogicalOpTPOptAdd) lop ).getTP();
 		}
 		else if ( lop instanceof LogicalOpBGPAdd ) {
-			final LogicalOpBGPAdd bgpAdd = (LogicalOpBGPAdd) lop;
-			certainVars.addAll( QueryPatternUtils.getVariablesInPattern(bgpAdd.getBGP()) );
+			p = ( (LogicalOpBGPAdd) lop ).getBGP();
 		}
 		else if ( lop instanceof LogicalOpBGPOptAdd ) {
-			final LogicalOpBGPOptAdd bgpAdd = (LogicalOpBGPOptAdd) lop;
-			certainVars.addAll( QueryPatternUtils.getVariablesInPattern(bgpAdd.getBGP()) );
+			p = ( (LogicalOpBGPOptAdd) lop ).getBGP();
+		}
+		else if ( lop instanceof LogicalOpGPAdd ) {
+			p = ( (LogicalOpGPAdd) lop ).getPattern();
+		}
+		else if ( lop instanceof LogicalOpGPOptAdd ) {
+			p = ( (LogicalOpGPOptAdd) lop ).getPattern();
 		}
 		else
 			throw new IllegalArgumentException("Unsupported type of operator: " + lop.getClass().getName() );
 
-		return new ExpectedVariables() {
-			@Override public Set<Var> getCertainVariables() { return certainVars; }
-			@Override public Set<Var> getPossibleVariables() { return possibleVars; }
-		};
+		return QueryPatternUtils.getExpectedVariablesInPattern(p);
 	}
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithFILTER.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithFILTER.java
@@ -8,6 +8,8 @@ import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithFILTER;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPOptAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
@@ -33,6 +35,18 @@ public class PhysicalOpBindJoinWithFILTER extends BasePhysicalOpSingleInputJoin
 	}
 
 	public PhysicalOpBindJoinWithFILTER( final LogicalOpBGPOptAdd lop ) {
+		super(lop);
+
+		assert lop.getFederationMember() instanceof SPARQLEndpoint;
+	}
+
+	public PhysicalOpBindJoinWithFILTER( final LogicalOpGPAdd lop ) {
+		super(lop);
+
+		assert lop.getFederationMember() instanceof SPARQLEndpoint;
+	}
+
+	public PhysicalOpBindJoinWithFILTER( final LogicalOpGPOptAdd lop ) {
 		super(lop);
 
 		assert lop.getFederationMember() instanceof SPARQLEndpoint;
@@ -69,6 +83,16 @@ public class PhysicalOpBindJoinWithFILTER extends BasePhysicalOpSingleInputJoin
 		else if ( lop instanceof LogicalOpBGPOptAdd ) {
 			pt = ( (LogicalOpBGPOptAdd) lop ).getBGP();
 			fm = ( (LogicalOpBGPOptAdd) lop ).getFederationMember();
+			useOuterJoinSemantics = true;
+		}
+		else if ( lop instanceof LogicalOpGPAdd ) {
+			pt = ( (LogicalOpGPAdd) lop ).getPattern();
+			fm = ( (LogicalOpGPAdd) lop ).getFederationMember();
+			useOuterJoinSemantics = false;
+		}
+		else if ( lop instanceof LogicalOpGPOptAdd ) {
+			pt = ( (LogicalOpGPOptAdd) lop ).getPattern();
+			fm = ( (LogicalOpGPOptAdd) lop ).getFederationMember();
 			useOuterJoinSemantics = true;
 		}
 		else {

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithFILTERandTranslation.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithFILTERandTranslation.java
@@ -7,6 +7,8 @@ import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithFILTERandTranslation;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPOptAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
@@ -32,6 +34,18 @@ public class PhysicalOpBindJoinWithFILTERandTranslation extends PhysicalOpBindJo
 	}
 
 	public PhysicalOpBindJoinWithFILTERandTranslation( final LogicalOpBGPOptAdd lop ) {
+		super(lop);
+
+		assert lop.getFederationMember().getVocabularyMapping() != null;
+	}
+
+	public PhysicalOpBindJoinWithFILTERandTranslation( final LogicalOpGPAdd lop ) {
+		super(lop);
+
+		assert lop.getFederationMember().getVocabularyMapping() != null;
+	}
+
+	public PhysicalOpBindJoinWithFILTERandTranslation( final LogicalOpGPOptAdd lop ) {
 		super(lop);
 
 		assert lop.getFederationMember().getVocabularyMapping() != null;

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithUNION.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithUNION.java
@@ -6,6 +6,7 @@ import se.liu.ida.hefquin.engine.queryplan.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithUNION;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPAdd;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
 
@@ -18,6 +19,12 @@ public class PhysicalOpBindJoinWithUNION extends BasePhysicalOpSingleInputJoin
 	}
 
 	public PhysicalOpBindJoinWithUNION( final LogicalOpBGPAdd lop) {
+		super(lop);
+
+		assert lop.getFederationMember() instanceof SPARQLEndpoint;
+	}
+
+	public PhysicalOpBindJoinWithUNION( final LogicalOpGPAdd lop) {
 		super(lop);
 
 		assert lop.getFederationMember() instanceof SPARQLEndpoint;
@@ -55,6 +62,15 @@ public class PhysicalOpBindJoinWithUNION extends BasePhysicalOpSingleInputJoin
 
 			if ( fm instanceof SPARQLEndpoint )
 				return new ExecOpBindJoinSPARQLwithUNION( bgpAdd.getBGP(), (SPARQLEndpoint) fm, collectExceptions );
+			else
+				throw new IllegalArgumentException("Unsupported type of federation member: " + fm.getClass().getName() );
+		}
+		else if ( lop instanceof LogicalOpGPAdd ) {
+			final LogicalOpGPAdd gpAdd = (LogicalOpGPAdd) lop;
+			final FederationMember fm = gpAdd.getFederationMember();
+
+			if ( fm instanceof SPARQLEndpoint )
+				return new ExecOpBindJoinSPARQLwithUNION( gpAdd.getPattern(), (SPARQLEndpoint) fm, collectExceptions );
 			else
 				throw new IllegalArgumentException("Unsupported type of federation member: " + fm.getClass().getName() );
 		}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithVALUES.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithVALUES.java
@@ -6,11 +6,12 @@ import se.liu.ida.hefquin.engine.queryplan.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithVALUES;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPAdd;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
 
-public class PhysicalOpBindJoinWithVALUES extends BasePhysicalOpSingleInputJoin {
-
+public class PhysicalOpBindJoinWithVALUES extends BasePhysicalOpSingleInputJoin
+{
 	public PhysicalOpBindJoinWithVALUES( final LogicalOpTPAdd lop ) {
 		super(lop);
 
@@ -18,6 +19,12 @@ public class PhysicalOpBindJoinWithVALUES extends BasePhysicalOpSingleInputJoin 
 	}
 
 	public PhysicalOpBindJoinWithVALUES( final LogicalOpBGPAdd lop ) {
+		super(lop);
+
+		assert lop.getFederationMember() instanceof SPARQLEndpoint;
+	}
+
+	public PhysicalOpBindJoinWithVALUES( final LogicalOpGPAdd lop ) {
 		super(lop);
 
 		assert lop.getFederationMember() instanceof SPARQLEndpoint;
@@ -55,6 +62,15 @@ public class PhysicalOpBindJoinWithVALUES extends BasePhysicalOpSingleInputJoin 
 
 			if ( fm instanceof SPARQLEndpoint )
 				return new ExecOpBindJoinSPARQLwithVALUES( bgpAdd.getBGP(), (SPARQLEndpoint) fm, collectExceptions );
+			else
+				throw new IllegalArgumentException("Unsupported type of federation member: " + fm.getClass().getName() );
+		}
+		else if ( lop instanceof LogicalOpGPAdd ) {
+			final LogicalOpGPAdd gpAdd = (LogicalOpGPAdd) lop;
+			final FederationMember fm = gpAdd.getFederationMember();
+
+			if ( fm instanceof SPARQLEndpoint )
+				return new ExecOpBindJoinSPARQLwithVALUES( gpAdd.getPattern(), (SPARQLEndpoint) fm, collectExceptions );
 			else
 				throw new IllegalArgumentException("Unsupported type of federation member: " + fm.getClass().getName() );
 		}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpIndexNestedLoopsJoin.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpIndexNestedLoopsJoin.java
@@ -11,6 +11,8 @@ import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpIndexNested
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpIndexNestedLoopsJoinTPF;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPOptAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
@@ -30,6 +32,14 @@ public class PhysicalOpIndexNestedLoopsJoin extends BasePhysicalOpSingleInputJoi
 	}
 
 	public PhysicalOpIndexNestedLoopsJoin( final LogicalOpBGPOptAdd lop ) {
+		super(lop);
+	}
+
+	public PhysicalOpIndexNestedLoopsJoin( final LogicalOpGPAdd lop ) {
+		super(lop);
+	}
+
+	public PhysicalOpIndexNestedLoopsJoin( final LogicalOpGPOptAdd lop ) {
 		super(lop);
 	}
 
@@ -88,6 +98,26 @@ public class PhysicalOpIndexNestedLoopsJoin extends BasePhysicalOpSingleInputJoi
 
 			if ( fm instanceof SPARQLEndpoint )
 				return new ExecOpIndexNestedLoopsJoinSPARQL( bgpAdd.getBGP(), (SPARQLEndpoint) fm, useOuterJoinSemantics, collectExceptions );
+			else
+				throw new IllegalArgumentException("Unsupported type of federation member: " + fm.getClass().getName() );
+		}
+		else if ( lop instanceof LogicalOpGPAdd ) {
+			final LogicalOpGPAdd gpAdd = (LogicalOpGPAdd) lop;
+			final FederationMember fm = gpAdd.getFederationMember();
+			final boolean useOuterJoinSemantics = false;
+
+			if ( fm instanceof SPARQLEndpoint )
+				return new ExecOpIndexNestedLoopsJoinSPARQL( gpAdd.getPattern(), (SPARQLEndpoint) fm, useOuterJoinSemantics, collectExceptions );
+			else
+				throw new IllegalArgumentException("Unsupported type of federation member: " + fm.getClass().getName() );
+		}
+		else if ( lop instanceof LogicalOpGPOptAdd ) {
+			final LogicalOpGPOptAdd gpAdd = (LogicalOpGPOptAdd) lop;
+			final FederationMember fm = gpAdd.getFederationMember();
+			final boolean useOuterJoinSemantics = true;
+
+			if ( fm instanceof SPARQLEndpoint )
+				return new ExecOpIndexNestedLoopsJoinSPARQL( gpAdd.getPattern(), (SPARQLEndpoint) fm, useOuterJoinSemantics, collectExceptions );
 			else
 				throw new IllegalArgumentException("Unsupported type of federation member: " + fm.getClass().getName() );
 		}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalOpUtils.java
@@ -24,6 +24,8 @@ import se.liu.ida.hefquin.engine.queryplan.logical.LogicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.logical.UnaryLogicalOp;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPOptAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPOptAdd;
@@ -209,6 +211,9 @@ public class LogicalOpUtils
         else if( req instanceof TriplePatternRequest ) {
             return createTPAddLopFromRequest( (TriplePatternRequest) req, fm );
         }
+        else if( req instanceof SPARQLRequest ) {
+            return createGPAddLopFromRequest( (SPARQLRequest) req, fm );
+        }
         else {
             throw new IllegalArgumentException( "unsupported type of request: " + req.getClass().getName() );
         }
@@ -231,6 +236,9 @@ public class LogicalOpUtils
         else if( req instanceof TriplePatternRequest ) {
             return createTPOptAddLopFromRequest( (TriplePatternRequest) req, fm );
         }
+        else if( req instanceof SPARQLRequest ) {
+            return createGPOptAddLopFromRequest( (SPARQLRequest) req, fm );
+        }
         else {
             throw new IllegalArgumentException( "unsupported type of request: " + req.getClass().getName() );
         }
@@ -247,7 +255,7 @@ public class LogicalOpUtils
     }
 
     /**
-     * Creates a logical bgpAdd operator that uses the BGP of the
+     * Creates a logical bgpOptAdd operator that uses the BGP of the
      * given request, together with the given federation member.
      */
     public static LogicalOpBGPOptAdd createBGPOptAddLopFromRequest( final BGPRequest req,
@@ -267,13 +275,33 @@ public class LogicalOpUtils
     }
 
     /**
-     * Creates a logical tpAdd operator that uses the triple pattern of
-     * the given request, together with the given federation member.
+     * Creates a logical tpOptAdd operator that uses the triple pattern
+     * of the given request, together with the given federation member.
      */
     public static LogicalOpTPOptAdd createTPOptAddLopFromRequest( final TriplePatternRequest req,
                                                                   final FederationMember fm ) {
         final TriplePattern tp = req.getQueryPattern();
         return new LogicalOpTPOptAdd( fm, tp );
+    }
+
+    /**
+     * Creates a logical gpAdd operator that uses the graph pattern of
+     * the given request, together with the given federation member.
+     */
+    public static LogicalOpGPAdd createGPAddLopFromRequest( final SPARQLRequest req,
+                                                            final FederationMember fm ) {
+        final SPARQLGraphPattern pattern = req.getQueryPattern();
+        return new LogicalOpGPAdd( fm, pattern );
+    }
+
+    /**
+     * Creates a logical gpOptAdd operator that uses the graph pattern
+     * of the given request, together with the given federation member.
+     */
+    public static LogicalOpGPOptAdd createGPOptAddLopFromRequest( final SPARQLRequest req,
+                                                                  final FederationMember fm ) {
+        final SPARQLGraphPattern pattern = req.getQueryPattern();
+        return new LogicalOpGPOptAdd( fm, pattern );
     }
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalPlanPrinter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalPlanPrinter.java
@@ -6,6 +6,8 @@ import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanWalker;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFilter;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGlobalToLocal;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRightJoin;
@@ -55,6 +57,14 @@ public class LogicalPlanPrinter extends PlanPrinter{
 		}
 
 		@Override
+		public void visit(final LogicalOpGPAdd op) {
+			addTabs();
+			builder.append( op.toString() );
+			builder.append(System.lineSeparator());
+			indentLevel--;
+		}
+
+		@Override
 		public void visit(final LogicalOpTPOptAdd op) {
 			addTabs();
 			builder.append( op.toString() );
@@ -64,6 +74,14 @@ public class LogicalPlanPrinter extends PlanPrinter{
 
 		@Override
 		public void visit(final LogicalOpBGPOptAdd op) {
+			addTabs();
+			builder.append( op.toString() );
+			builder.append(System.lineSeparator());
+			indentLevel--;
+		}
+
+		@Override
+		public void visit(final LogicalOpGPOptAdd op) {
 			addTabs();
 			builder.append( op.toString() );
 			builder.append(System.lineSeparator());
@@ -161,12 +179,22 @@ public class LogicalPlanPrinter extends PlanPrinter{
 		}
 
 		@Override
+		public void visit(final LogicalOpGPAdd op) {
+			indentLevel--;
+		}
+
+		@Override
 		public void visit(final LogicalOpTPOptAdd op) {
 			indentLevel--;
 		}
 
 		@Override
 		public void visit(final LogicalOpBGPOptAdd op) {
+			indentLevel--;
+		}
+
+		@Override
+		public void visit(final LogicalOpGPOptAdd op) {
 			indentLevel--;
 		}
 

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalToPhysicalOpConverter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalToPhysicalOpConverter.java
@@ -55,6 +55,8 @@ public class LogicalToPhysicalOpConverter
 		else if ( lop instanceof LogicalOpTPOptAdd )  return convert( (LogicalOpTPOptAdd) lop );
 		else if ( lop instanceof LogicalOpBGPAdd )    return convert( (LogicalOpBGPAdd) lop );
 		else if ( lop instanceof LogicalOpBGPOptAdd ) return convert( (LogicalOpBGPOptAdd) lop );
+		else if ( lop instanceof LogicalOpGPAdd )    return convert( (LogicalOpGPAdd) lop );
+		else if ( lop instanceof LogicalOpGPOptAdd ) return convert( (LogicalOpGPOptAdd) lop );
 		else if ( lop instanceof LogicalOpFilter )    return convert( (LogicalOpFilter) lop );
 		else if ( lop instanceof LogicalOpLocalToGlobal ) return convert ( (LogicalOpLocalToGlobal) lop);
 		else if ( lop instanceof LogicalOpGlobalToLocal ) return convert ( (LogicalOpGlobalToLocal) lop);
@@ -125,10 +127,6 @@ public class LogicalToPhysicalOpConverter
 
 		if (      fm instanceof SPARQLEndpoint ) return new PhysicalOpBindJoinWithFILTER(lop);
 
-		else if ( fm instanceof TPFServer )      throw new IllegalArgumentException();
-
-		else if ( fm instanceof BRTPFServer )    throw new IllegalArgumentException();
-
 		else throw new UnsupportedOperationException("Unsupported type of federation member: " + fm.getClass().getName() + ".");
 	}
 
@@ -148,9 +146,43 @@ public class LogicalToPhysicalOpConverter
 
 		if (      fm instanceof SPARQLEndpoint ) return new PhysicalOpBindJoinWithFILTER(lop);
 
-		else if ( fm instanceof TPFServer )      throw new IllegalArgumentException();
+		else throw new UnsupportedOperationException("Unsupported type of federation member: " + fm.getClass().getName() + ".");
+	}
 
-		else if ( fm instanceof BRTPFServer )    throw new IllegalArgumentException();
+	public static UnaryPhysicalOp convert( final LogicalOpGPAdd lop ) {
+		final FederationMember fm = lop.getFederationMember();
+
+		// first, consider the possibility that vocabulary mappings should be
+		// handled implicitly (i.e., within the physical operators), which is
+		// not the default behavior of the engine
+
+		if ( ! handleVocabMappingsExplicitly && fm.getVocabularyMapping() != null ) {
+			throw new UnsupportedOperationException("No suitable operator for the given type of federation member: " + fm.getClass().getName() + ".");
+		}
+
+		// now, consider the default behavior in which vocabulary mappings
+		// are handled explicitly during query planning
+
+		if (      fm instanceof SPARQLEndpoint ) return new PhysicalOpBindJoinWithFILTER(lop);
+
+		else throw new UnsupportedOperationException("Unsupported type of federation member: " + fm.getClass().getName() + ".");
+	}
+
+	public static UnaryPhysicalOp convert( final LogicalOpGPOptAdd lop ) {
+		final FederationMember fm = lop.getFederationMember();
+
+		// first, consider the possibility that vocabulary mappings should be
+		// handled implicitly (i.e., within the physical operators), which is
+		// not the default behavior of the engine
+
+		if ( ! handleVocabMappingsExplicitly && fm.getVocabularyMapping() != null ) {
+			throw new UnsupportedOperationException("No suitable operator for the given type of federation member: " + fm.getClass().getName() + ".");
+		}
+
+		// now, consider the default behavior in which vocabulary mappings
+		// are handled explicitly during query planning
+
+		if (      fm instanceof SPARQLEndpoint ) return new PhysicalOpBindJoinWithFILTER(lop);
 
 		else throw new UnsupportedOperationException("Unsupported type of federation member: " + fm.getClass().getName() + ".");
 	}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/PhysicalPlanFactory.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/PhysicalPlanFactory.java
@@ -8,6 +8,7 @@ import se.liu.ida.hefquin.engine.federation.SPARQLEndpoint;
 import se.liu.ida.hefquin.engine.federation.TPFServer;
 import se.liu.ida.hefquin.engine.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.engine.federation.access.impl.req.BGPRequestImpl;
+import se.liu.ida.hefquin.engine.federation.access.impl.req.SPARQLRequestImpl;
 import se.liu.ida.hefquin.engine.federation.access.impl.req.TPFRequestImpl;
 import se.liu.ida.hefquin.engine.federation.access.impl.req.TriplePatternRequestImpl;
 import se.liu.ida.hefquin.engine.query.TriplePattern;
@@ -498,6 +499,20 @@ public class PhysicalPlanFactory
 		final DataRetrievalRequest req;
 		if ( fm.getInterface().supportsBGPRequests() ) {
 			req = new BGPRequestImpl( lop.getBGP() );
+		}
+		else {
+			throw new IllegalArgumentException("Unsupported type of federation member (type: " + fm.getClass().getName() + ").");
+		}
+
+		return createPlanWithRequest( new LogicalOpRequest<>(fm,req) );
+	}
+
+	public static PhysicalPlan extractRequestAsPlan( final LogicalOpGPAdd lop ) {
+		final FederationMember fm = lop.getFederationMember();
+
+		final DataRetrievalRequest req;
+		if ( fm.getInterface().supportsSPARQLPatternRequests() ) {
+			req = new SPARQLRequestImpl( lop.getPattern() );
 		}
 		else {
 			throw new IllegalArgumentException("Unsupported type of federation member (type: " + fm.getClass().getName() + ").");

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/PhysicalPlanFactory.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/PhysicalPlanFactory.java
@@ -541,12 +541,15 @@ public class PhysicalPlanFactory
 		return extractRequestAsPlan( pop.getLogicalOperator() );
 	}
 
-	protected static PhysicalPlan extractRequestAsPlan( final LogicalOperator lop ) {
+	public static PhysicalPlan extractRequestAsPlan(final UnaryLogicalOp lop) {
 		if ( lop instanceof LogicalOpTPAdd ) {
 			return extractRequestAsPlan( (LogicalOpTPAdd) lop );
 		}
 		else if ( lop instanceof LogicalOpBGPAdd ) {
 			return extractRequestAsPlan( (LogicalOpBGPAdd) lop );
+		}
+		else if ( lop instanceof LogicalOpGPAdd ) {
+			return extractRequestAsPlan( (LogicalOpGPAdd) lop );
 		}
 		else {
 			throw new IllegalArgumentException("Unsupported type of logical operator (type: " + lop.getClass().getName() + ").");

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/PhysicalPlanFactory.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/PhysicalPlanFactory.java
@@ -21,10 +21,10 @@ import se.liu.ida.hefquin.engine.queryplan.physical.BinaryPhysicalOp;
 import se.liu.ida.hefquin.engine.queryplan.physical.NaryPhysicalOp;
 import se.liu.ida.hefquin.engine.queryplan.physical.NullaryPhysicalOp;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalOperator;
+import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalOperatorForLogicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.physical.UnaryPhysicalOp;
 import se.liu.ida.hefquin.engine.queryplan.physical.impl.*;
-import se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.rewriting.rules.IdentifyTypeOfRequestUsedForReq;
 
 public class PhysicalPlanFactory
 {
@@ -213,6 +213,62 @@ public class PhysicalPlanFactory
 	 * Creates a plan with a bind join as root operator.
 	 */
 	public static PhysicalPlan createPlanWithBindJoinVALUES( final LogicalOpBGPAdd lop,
+	                                                         final PhysicalPlan subplan ) {
+		final UnaryPhysicalOp pop;
+		if ( ! handleVocabMappingsExplicitly && lop.getFederationMember().getVocabularyMapping() != null )
+			throw new UnsupportedOperationException("There is no such bind join operator that takes care of vocab.mappings.");
+		else
+			pop = new PhysicalOpBindJoinWithVALUES(lop);
+
+		return createPlan(pop, subplan);
+	}
+
+	/**
+	 * Creates a plan with an index nested loops join as root operator.
+	 */
+	public static PhysicalPlan createPlanWithIndexNLJ( final LogicalOpGPAdd lop,
+	                                                   final PhysicalPlan subplan ) {
+		final UnaryPhysicalOp pop;
+		if ( ! handleVocabMappingsExplicitly && lop.getFederationMember().getVocabularyMapping() != null )
+			throw new UnsupportedOperationException("There is no such join operator that takes care of vocab.mappings.");
+		else
+			pop = new PhysicalOpIndexNestedLoopsJoin(lop);
+
+		return createPlan(pop, subplan);
+	}
+
+	/**
+	 * Creates a plan with a FILTER-based bind join as root operator.
+	 */
+	public static PhysicalPlan createPlanWithBindJoinFILTER( final LogicalOpGPAdd lop,
+	                                                         final PhysicalPlan subplan ) {
+		final UnaryPhysicalOp pop;
+		if ( ! handleVocabMappingsExplicitly && lop.getFederationMember().getVocabularyMapping() != null )
+			pop = new PhysicalOpBindJoinWithFILTERandTranslation(lop);
+		else
+			pop = new PhysicalOpBindJoinWithFILTER(lop);
+
+		return createPlan(pop, subplan);
+	}
+
+	/**
+	 * Creates a plan with a UNION-based bind join as root operator.
+	 */
+	public static PhysicalPlan createPlanWithBindJoinUNION( final LogicalOpGPAdd lop,
+	                                                        final PhysicalPlan subplan ) {
+		final UnaryPhysicalOp pop;
+		if ( ! handleVocabMappingsExplicitly && lop.getFederationMember().getVocabularyMapping() != null )
+			throw new UnsupportedOperationException("There is no such bind join operator that takes care of vocab.mappings.");
+		else
+			pop = new PhysicalOpBindJoinWithUNION(lop);
+
+		return createPlan(pop, subplan);
+	}
+
+	/**
+	 * Creates a plan with a VALUES-based bind join as root operator.
+	 */
+	public static PhysicalPlan createPlanWithBindJoinVALUES( final LogicalOpGPAdd lop,
 	                                                         final PhysicalPlan subplan ) {
 		final UnaryPhysicalOp pop;
 		if ( ! handleVocabMappingsExplicitly && lop.getFederationMember().getVocabularyMapping() != null )
@@ -485,52 +541,101 @@ public class PhysicalPlanFactory
 	public static List<PhysicalPlan> enumeratePlansWithUnaryOpFromReq( final PhysicalOpRequest<?, ?> req,
 	                                                                   final PhysicalPlan subplan,
 	                                                                   final List<PhysicalPlan> plans ) {
-		if (IdentifyTypeOfRequestUsedForReq.isBGPRequestOverSPARQLEndpoint(req)) {
-			final LogicalOpBGPAdd newRoot = (LogicalOpBGPAdd) LogicalOpUtils.createLogicalAddOpFromPhysicalReqOp(req);
+		final LogicalOperator lop = ((PhysicalOperatorForLogicalOperator) req).getLogicalOperator();
+		final UnaryLogicalOp newRoot = LogicalOpUtils.createLogicalAddOpFromLogicalReqOp( (LogicalOpRequest<?,?>) lop );
 
-			plans.add( createPlanWithIndexNLJ(newRoot, subplan) );
-			plans.add( createPlanWithBindJoinFILTER(newRoot, subplan) );
-			plans.add( createPlanWithBindJoinUNION(newRoot, subplan) );
-			plans.add( createPlanWithBindJoinVALUES(newRoot, subplan) );
+		if ( newRoot instanceof LogicalOpTPAdd ) {
+			final LogicalOpTPAdd tpAdd = (LogicalOpTPAdd) newRoot;
 
-		}
-		else if (IdentifyTypeOfRequestUsedForReq.isTriplePatternRequest(req)) {
-			final LogicalOpTPAdd newRoot = (LogicalOpTPAdd) LogicalOpUtils.createLogicalAddOpFromPhysicalReqOp(req);
-			plans.add( createPlanWithIndexNLJ(newRoot, subplan) );
+			plans.add( createPlanWithIndexNLJ( tpAdd, subplan) );
 
-			final FederationMember fm = ((LogicalOpRequest<?, ?>) req.getLogicalOperator()).getFederationMember();
-			if (fm instanceof SPARQLEndpoint) {
-				plans.add( createPlanWithBindJoinFILTER(newRoot, subplan) );
-				plans.add( createPlanWithBindJoinUNION(newRoot, subplan) );
-				plans.add( createPlanWithBindJoinVALUES(newRoot, subplan) );
+			if ( tpAdd.getFederationMember().getInterface().supportsSPARQLPatternRequests() ) {
+				plans.add( createPlanWithBindJoinFILTER(tpAdd, subplan) );
+				plans.add( createPlanWithBindJoinUNION( tpAdd, subplan) );
+				plans.add( createPlanWithBindJoinVALUES(tpAdd, subplan) );
+			}
+
+			if ( tpAdd.getFederationMember() instanceof BRTPFServer ) {
+				plans.add( createPlanWithBindJoin(tpAdd, subplan) );
 			}
 		}
+		else if ( newRoot instanceof LogicalOpBGPAdd ) {
+			final LogicalOpBGPAdd bgpAdd = (LogicalOpBGPAdd) newRoot;
+
+			plans.add( createPlanWithIndexNLJ( bgpAdd, subplan) );
+
+			if ( bgpAdd.getFederationMember().getInterface().supportsSPARQLPatternRequests() ) {
+				plans.add( createPlanWithBindJoinFILTER(bgpAdd, subplan) );
+				plans.add( createPlanWithBindJoinUNION( bgpAdd, subplan) );
+				plans.add( createPlanWithBindJoinVALUES(bgpAdd, subplan) );
+			}
+		}
+		else if ( newRoot instanceof LogicalOpGPAdd ) {
+			final LogicalOpGPAdd gpAdd = (LogicalOpGPAdd) newRoot;
+
+			plans.add( createPlanWithIndexNLJ( gpAdd, subplan) );
+			plans.add( createPlanWithBindJoinFILTER(gpAdd, subplan) );
+			plans.add( createPlanWithBindJoinUNION( gpAdd, subplan) );
+			plans.add( createPlanWithBindJoinVALUES(gpAdd, subplan) );
+		}
+		else {
+			throw new UnsupportedOperationException("unsupported operator: " + newRoot.getClass().getName() );
+		}
+
 		return plans;
 	}
 
 	public static List<PhysicalPlan> enumeratePlansWithUnaryOpFromReq( final PhysicalOpRequestWithTranslation<?, ?> req,
 	                                                                   final PhysicalPlan subplan,
 	                                                                   final List<PhysicalPlan> plans ) {
-		if (IdentifyTypeOfRequestUsedForReq.isBGPRequestOverSPARQLEndpoint(req)) {
-			final LogicalOpBGPAdd newRoot = (LogicalOpBGPAdd) LogicalOpUtils.createLogicalAddOpFromPhysicalReqOp(req);
+		final LogicalOperator lop = ((PhysicalOperatorForLogicalOperator) req).getLogicalOperator();
+		final UnaryLogicalOp newRoot = LogicalOpUtils.createLogicalAddOpFromLogicalReqOp( (LogicalOpRequest<?,?>) lop );
 
-			plans.add( createPlanWithIndexNLJ(newRoot, subplan) );
-			plans.add( createPlanWithBindJoinFILTER(newRoot, subplan) );
-			plans.add( createPlanWithBindJoinUNION(newRoot, subplan) );
-			plans.add( createPlanWithBindJoinVALUES(newRoot, subplan) );
+		// The options that are commented out in the following if-else blocks
+		// are options for which we don't have an explicit physical operator
+		// with vocabulary-related translation built in. Notice also that
+		// using such operators is not the default way of dealing with
+		// vocabulary mappings in HeFQUIN.
 
-		}
-		else if (IdentifyTypeOfRequestUsedForReq.isTriplePatternRequest(req)) {
-			final LogicalOpTPAdd newRoot = (LogicalOpTPAdd) LogicalOpUtils.createLogicalAddOpFromPhysicalReqOp(req);
-			plans.add( createPlanWithIndexNLJ(newRoot, subplan) );
+		if ( newRoot instanceof LogicalOpTPAdd ) {
+			final LogicalOpTPAdd tpAdd = (LogicalOpTPAdd) newRoot;
 
-			final FederationMember fm = ((LogicalOpRequest<?, ?>) req.getLogicalOperator()).getFederationMember();
-			if (fm instanceof SPARQLEndpoint) {
-				plans.add( createPlanWithBindJoinFILTER(newRoot, subplan) );
-				plans.add( createPlanWithBindJoinUNION(newRoot, subplan) );
-				plans.add( createPlanWithBindJoinVALUES(newRoot, subplan) );
+			//plans.add( createPlanWithIndexNLJ( tpAdd, subplan) );
+
+			if ( tpAdd.getFederationMember().getInterface().supportsSPARQLPatternRequests() ) {
+				plans.add( createPlanWithBindJoinFILTER(tpAdd, subplan) );
+				//plans.add( createPlanWithBindJoinUNION( tpAdd, subplan) );
+				//plans.add( createPlanWithBindJoinVALUES(tpAdd, subplan) );
+			}
+
+			if ( tpAdd.getFederationMember() instanceof BRTPFServer ) {
+				//plans.add( createPlanWithBindJoin(tpAdd, subplan) );
 			}
 		}
+		else if ( newRoot instanceof LogicalOpBGPAdd ) {
+			final LogicalOpBGPAdd bgpAdd = (LogicalOpBGPAdd) newRoot;
+
+			//plans.add( createPlanWithIndexNLJ( bgpAdd, subplan) );
+
+			if ( bgpAdd.getFederationMember().getInterface().supportsSPARQLPatternRequests() ) {
+				plans.add( createPlanWithBindJoinFILTER(bgpAdd, subplan) );
+				//plans.add( createPlanWithBindJoinUNION( bgpAdd, subplan) );
+				//plans.add( createPlanWithBindJoinVALUES(bgpAdd, subplan) );
+			}
+		}
+		else if ( newRoot instanceof LogicalOpGPAdd ) {
+			final LogicalOpGPAdd gpAdd = (LogicalOpGPAdd) newRoot;
+
+			//plans.add( createPlanWithIndexNLJ( gpAdd, subplan) );
+
+			plans.add( createPlanWithBindJoinFILTER(gpAdd, subplan) );
+			//plans.add( createPlanWithBindJoinUNION( gpAdd, subplan) );
+			//plans.add( createPlanWithBindJoinVALUES(gpAdd, subplan) );
+		}
+		else {
+			throw new UnsupportedOperationException("unsupported operator: " + newRoot.getClass().getName() );
+		}
+
 		return plans;
 	}
 

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/UnionPullUp.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/UnionPullUp.java
@@ -90,7 +90,11 @@ public class UnionPullUp implements HeuristicForLogicalOptimization
 		     || rootOp instanceof LogicalOpTPOptAdd
 		     || rootOp instanceof LogicalOpBGPAdd
 		     || rootOp instanceof LogicalOpBGPOptAdd
-		     || rootOp instanceof LogicalOpFilter )
+		     || rootOp instanceof LogicalOpGPAdd
+		     || rootOp instanceof LogicalOpGPOptAdd
+		     || rootOp instanceof LogicalOpFilter
+		     || rootOp instanceof LogicalOpLocalToGlobal
+		     || rootOp instanceof LogicalOpGlobalToLocal )
 		{
 			// The listed operators are unary operators; i.e., have exactly one
 			// subplan as child. If that subplan has a union operator as root,
@@ -99,14 +103,6 @@ public class UnionPullUp implements HeuristicForLogicalOptimization
 			if ( ! rewrittenSubPlansWithUnionRoot.isEmpty() )
 				return rewritePlanWithUnaryRootAndUnionChild( (UnaryLogicalOp) rootOp,
 				                                              rewrittenSubPlansWithUnionRoot.get(0) );
-		}
-		else if (    rootOp instanceof LogicalOpLocalToGlobal
-		          || rootOp instanceof LogicalOpGlobalToLocal )
-		{
-			// nothing to do here (if we have a vocabulary translation as root
-			// operator, we do not attempt to pull a potential union out of it)
-
-			// TODO: think about these cases again
 		}
 		else if ( rootOp instanceof LogicalOpUnion || rootOp instanceof LogicalOpMultiwayUnion )
 		{

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/cardinality/VarSpecificCardinalityEstimationImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/cardinality/VarSpecificCardinalityEstimationImpl.java
@@ -11,6 +11,7 @@ import org.apache.jena.sparql.core.Var;
 
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPAdd;
@@ -83,6 +84,10 @@ public class VarSpecificCardinalityEstimationImpl implements VarSpecificCardinal
 		else if ( rootOp instanceof LogicalOpBGPAdd ) {
 			final PhysicalPlan reqBGP = PhysicalPlanFactory.extractRequestAsPlan( (LogicalOpBGPAdd) rootOp );
 			return _initiateJoinCardinalityEstimation( plan.getSubPlan(0), reqBGP, v );
+		}
+		else if ( rootOp instanceof LogicalOpGPAdd ) {
+			final PhysicalPlan reqGP = PhysicalPlanFactory.extractRequestAsPlan( (LogicalOpGPAdd) rootOp );
+			return _initiateJoinCardinalityEstimation( plan.getSubPlan(0), reqGP, v );
 		}
 		else if ( rootOp instanceof LogicalOpJoin ) {
 			return _initiateJoinCardinalityEstimation( plan.getSubPlan(0), plan.getSubPlan(1), v );

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CFRNumberOfRequests.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CFRNumberOfRequests.java
@@ -7,6 +7,7 @@ import se.liu.ida.hefquin.engine.federation.SPARQLEndpoint;
 import se.liu.ida.hefquin.engine.federation.TPFServer;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPAdd;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
@@ -31,6 +32,14 @@ public class CFRNumberOfRequests extends CFRBase
 			LogicalOperator lop = (((PhysicalOpIndexNestedLoopsJoin) rootOp).getLogicalOperator());
 			if ( lop instanceof LogicalOpBGPAdd) {
 				FederationMember fm = ((LogicalOpBGPAdd)((PhysicalOpIndexNestedLoopsJoin) rootOp).getLogicalOperator()).getFederationMember();
+				if (fm instanceof SPARQLEndpoint) {
+					return initiateCardinalityEstimation(plan.getSubPlan(0));
+				}
+				else
+					throw new IllegalArgumentException("Unsupported type of federation member: " + fm.getClass().getName() );
+			}
+			else if ( lop instanceof LogicalOpGPAdd) {
+				FederationMember fm = ((LogicalOpGPAdd)((PhysicalOpIndexNestedLoopsJoin) rootOp).getLogicalOperator()).getFederationMember();
 				if (fm instanceof SPARQLEndpoint) {
 					return initiateCardinalityEstimation(plan.getSubPlan(0));
 				}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CFRNumberOfTermsShippedInRequests.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CFRNumberOfTermsShippedInRequests.java
@@ -5,8 +5,10 @@ import java.util.concurrent.CompletableFuture;
 import se.liu.ida.hefquin.engine.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.engine.federation.access.SPARQLRequest;
 import se.liu.ida.hefquin.engine.federation.access.TriplePatternRequest;
+import se.liu.ida.hefquin.engine.query.SPARQLGraphPattern;
 import se.liu.ida.hefquin.engine.query.impl.QueryPatternUtils;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalOperator;
+import se.liu.ida.hefquin.engine.queryplan.logical.UnaryLogicalOp;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.*;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalOperatorForLogicalOperator;
@@ -31,33 +33,26 @@ public class CFRNumberOfTermsShippedInRequests extends CFRBase
 		final int numberOfJoinVars;
 		final CompletableFuture<Integer> futureIntResSize;
 
-		if ( lop instanceof LogicalOpTPAdd ) {
-			final LogicalOpTPAdd tpAdd = (LogicalOpTPAdd) lop;
-			numberOfTerms = QueryPatternUtils.getNumberOfTermOccurrences( tpAdd.getTP() );
+		if ( lop instanceof UnaryLogicalOp ) {
+			SPARQLGraphPattern pattern;
+			if (lop instanceof LogicalOpTPAdd) {
+				pattern = ((LogicalOpTPAdd) lop).getTP();
+
+			} else if (lop instanceof LogicalOpBGPAdd) {
+				pattern = ((LogicalOpBGPAdd) lop).getBGP();
+
+			} else if (lop instanceof LogicalOpGPAdd) {
+				pattern = ((LogicalOpGPAdd) lop).getPattern();
+			}
+			else {
+				throw createIllegalArgumentException(lop);
+			}
+
+			numberOfTerms = QueryPatternUtils.getNumberOfTermOccurrences( pattern );
 
 			final PhysicalPlan subplan = plan.getSubPlan(0);
-			final PhysicalPlan reqTP = PhysicalPlanFactory.extractRequestAsPlan(tpAdd);
-			numberOfJoinVars = ExpectedVariablesUtils.intersectionOfCertainVariables(subplan,reqTP).size();
-
-			futureIntResSize = initiateCardinalityEstimation(subplan);
-		}
-		else if ( lop instanceof LogicalOpBGPAdd ) {
-			final LogicalOpBGPAdd bgpAdd = (LogicalOpBGPAdd) lop;
-			numberOfTerms = QueryPatternUtils.getNumberOfTermOccurrences( bgpAdd.getBGP() );
-
-			final PhysicalPlan subplan = plan.getSubPlan(0);
-			final PhysicalPlan reqBGP = PhysicalPlanFactory.extractRequestAsPlan(bgpAdd);
-			numberOfJoinVars = ExpectedVariablesUtils.intersectionOfCertainVariables(subplan,reqBGP).size();
-
-			futureIntResSize = initiateCardinalityEstimation(subplan);
-		}
-		else if ( lop instanceof LogicalOpGPAdd ) {
-			final LogicalOpGPAdd gpAdd = (LogicalOpGPAdd) lop;
-			numberOfTerms = QueryPatternUtils.getNumberOfTermOccurrences( gpAdd.getPattern() );
-
-			final PhysicalPlan subplan = plan.getSubPlan(0);
-			final PhysicalPlan reqGP = PhysicalPlanFactory.extractRequestAsPlan(gpAdd);
-			numberOfJoinVars = ExpectedVariablesUtils.intersectionOfCertainVariables(subplan,reqGP).size();
+			final PhysicalPlan req = PhysicalPlanFactory.extractRequestAsPlan( (UnaryLogicalOp) lop );
+			numberOfJoinVars = ExpectedVariablesUtils.intersectionOfCertainVariables(subplan, req).size();
 
 			futureIntResSize = initiateCardinalityEstimation(subplan);
 		}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CFRNumberOfTermsShippedInRequests.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CFRNumberOfTermsShippedInRequests.java
@@ -51,6 +51,16 @@ public class CFRNumberOfTermsShippedInRequests extends CFRBase
 
 			futureIntResSize = initiateCardinalityEstimation(subplan);
 		}
+		else if ( lop instanceof LogicalOpGPAdd ) {
+			final LogicalOpGPAdd gpAdd = (LogicalOpGPAdd) lop;
+			numberOfTerms = QueryPatternUtils.getNumberOfTermOccurrences( gpAdd.getPattern() );
+
+			final PhysicalPlan subplan = plan.getSubPlan(0);
+			final PhysicalPlan reqGP = PhysicalPlanFactory.extractRequestAsPlan(gpAdd);
+			numberOfJoinVars = ExpectedVariablesUtils.intersectionOfCertainVariables(subplan,reqGP).size();
+
+			futureIntResSize = initiateCardinalityEstimation(subplan);
+		}
 		else if ( lop instanceof LogicalOpRequest ) {
 			final DataRetrievalRequest req = ((LogicalOpRequest<?, ?>) lop).getRequest();
 			if ( req instanceof TriplePatternRequest ) {

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CFRNumberOfTermsShippedInResponses.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CFRNumberOfTermsShippedInResponses.java
@@ -57,6 +57,20 @@ public class CFRNumberOfTermsShippedInResponses extends CFRBase
 				throw createIllegalArgumentException(fm);
 			}
 		}
+		else if ( lop instanceof LogicalOpGPAdd ) {
+			final CompletableFuture<Integer> futureIntResSize = initiateCardinalityEstimation(plan);
+			final LogicalOpGPAdd gpAdd = (LogicalOpGPAdd) lop;
+			final FederationMember fm = gpAdd.getFederationMember();
+
+			if ( fm instanceof SPARQLEndpoint ) {
+				final int numberOfVars = QueryPatternUtils.getVariablesInPattern( gpAdd.getPattern() ).size();
+				return futureIntResSize.thenApply( intResSize -> numberOfVars * intResSize );
+			}
+			else {
+				futureIntResSize.cancel(true);
+				throw createIllegalArgumentException(fm);
+			}
+		}
 		else if ( lop instanceof LogicalOpRequest ) {
 			final CompletableFuture<Integer> futureIntResSize = initiateCardinalityEstimation(plan);
 			final FederationMember fm = ((LogicalOpRequest<?, ?>) lop).getFederationMember();

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CFRNumberOfVarsShippedInRequests.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CFRNumberOfVarsShippedInRequests.java
@@ -55,6 +55,20 @@ public class CFRNumberOfVarsShippedInRequests extends CFRBase
 				futureIntResSize = initiateCardinalityEstimation(subplan);
 			}
 		}
+		else if ( lop instanceof LogicalOpGPAdd ) {
+			final LogicalOpGPAdd gpAdd = (LogicalOpGPAdd) lop;
+			numberOfVars = QueryPatternUtils.getNumberOfVarOccurrences( gpAdd.getPattern() );
+
+			final PhysicalPlan subplan = plan.getSubPlan(0);
+			final PhysicalPlan reqGP = PhysicalPlanFactory.extractRequestAsPlan(gpAdd);
+			numberOfJoinVars = ExpectedVariablesUtils.intersectionOfCertainVariables(subplan,reqGP).size();
+
+			if ( pop instanceof PhysicalOpBindJoinWithVALUES ) {
+				futureIntResSize = null; // irrelevant
+			} else {
+				futureIntResSize = initiateCardinalityEstimation(subplan);
+			}
+		}
 		else if ( lop instanceof LogicalOpRequest ) {
 			final DataRetrievalRequest req = ((LogicalOpRequest<?, ?>) lop).getRequest();
 			if ( req instanceof TriplePatternRequest ) {

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CFRNumberOfVarsShippedInResponses.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CFRNumberOfVarsShippedInResponses.java
@@ -55,6 +55,19 @@ public class CFRNumberOfVarsShippedInResponses extends CFRBase
 				throw createIllegalArgumentException(fm);
 			}
 		}
+		else if ( lop instanceof LogicalOpGPAdd ) {
+			final LogicalOpGPAdd gpAdd = (LogicalOpGPAdd) lop;
+			final FederationMember fm = gpAdd.getFederationMember();
+
+			if ( fm instanceof SPARQLEndpoint ) {
+				final int numberOfVars = QueryPatternUtils.getVariablesInPattern( gpAdd.getPattern() ).size();
+				final CompletableFuture<Integer> futureIntResSize = initiateCardinalityEstimation(plan);
+				return futureIntResSize.thenApply( intResSize -> numberOfVars * intResSize );
+			}
+			else {
+				throw createIllegalArgumentException(fm);
+			}
+		}
 		else if ( lop instanceof LogicalOpRequest ) {
 			final FederationMember fm = ((LogicalOpRequest<?, ?>) lop).getFederationMember();
 

--- a/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/UnionPullUpTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/UnionPullUpTest.java
@@ -537,6 +537,7 @@ public class UnionPullUpTest
 	protected static class DummyDataRetrievalInterface implements DataRetrievalInterface {
 		@Override public boolean supportsTriplePatternRequests() { return true; }
 		@Override public boolean supportsBGPRequests() { throw new UnsupportedOperationException(); }
+		@Override public boolean supportsSPARQLPatternRequests() { throw new UnsupportedOperationException(); }
 		@Override public boolean supportsRequest(DataRetrievalRequest req) { throw new UnsupportedOperationException(); }
 	}
 

--- a/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/UnionPullUpTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/UnionPullUpTest.java
@@ -473,16 +473,23 @@ public class UnionPullUpTest
 		final LogicalPlan resultPlan = new UnionPullUp().apply(l2gPlan);
 
 		final LogicalOperator rootOfResultPlan = resultPlan.getRootOperator();
-		assertEquals( l2g, rootOfResultPlan );
-		assertEquals( 1, resultPlan.numberOfSubPlans() );
+		assertTrue( rootOfResultPlan instanceof LogicalOpMultiwayUnion || rootOfResultPlan instanceof LogicalOpUnion );
+		assertEquals( 2, resultPlan.numberOfSubPlans() );
 
-		final LogicalPlan childOfResultPlan = resultPlan.getSubPlan(0);
-		final LogicalOperator rootOfChild = childOfResultPlan.getRootOperator();
-		assertTrue( rootOfChild instanceof LogicalOpMultiwayUnion || rootOfChild instanceof LogicalOpUnion );
-		assertEquals( 2, childOfResultPlan.numberOfSubPlans() );
+		final LogicalPlan child1 = resultPlan.getSubPlan(0);
+		final LogicalPlan child2 = resultPlan.getSubPlan(1);
 
-		final LogicalPlan grandchild1 = childOfResultPlan.getSubPlan(0);
-		final LogicalPlan grandchild2 = childOfResultPlan.getSubPlan(1);
+		assertEquals( 1, child1.numberOfSubPlans() );
+		assertEquals( 1, child2.numberOfSubPlans() );
+
+		final LogicalOperator rootOfChild1 = child1.getRootOperator();
+		final LogicalOperator rootOfChild2 = child2.getRootOperator();
+
+		assertEquals( l2g, rootOfChild1 );
+		assertEquals( l2g, rootOfChild2 );
+
+		final LogicalPlan grandchild1 = child1.getSubPlan(0);
+		final LogicalPlan grandchild2 = child2.getSubPlan(0);
 
 		assertEquals( 1, grandchild1.numberOfSubPlans() );
 		assertEquals( 1, grandchild2.numberOfSubPlans() );


### PR DESCRIPTION
This PR is meant to address #268

Currently, it is still work in progress. Here is a list of things that I still need to do:

- [x] For all subclasses of `BasePhysicalOpSingleInputJoin`, look at their corresponding executable operators and make sure that they support arbitrary `SPARQLGraphPattern` objects.
- [x] Is there anything to do for `LogicalToPhysicalPlanConverterImpl`?
- [x] Extend `PhysicalPlanFactory` (e.g., `enumeratePlansWithUnaryOpFromReq`).
- [x] Extend `UnionPullUp`.
- [x] Extend `MergeRequests`.
- [x] Extend `CardinalityEstimationImpl`.
- [x] Extend `VarSpecificCardinalityEstimationImpl`.
- [x] Extend the classes in `se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.costmodel`.