### PR TITLE
Adds PushJoinUnderUnionWithRequests heuristics

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanUtils.java
@@ -47,6 +47,14 @@ public class LogicalPlanUtils
 	}
 
 	/**
+	 * Creates a {@link LogicalPlan} with a {@link LogicalOpMultiwayJoin} as
+	 * root operator and the given plans as its subplans.
+	 */
+	public static LogicalPlan createPlanWithMultiwayJoin( final List<LogicalPlan> subPlans ) {
+		return createPlanWithSubPlans( LogicalOpMultiwayJoin.getInstance(), subPlans );
+	}
+
+	/**
 	 * Creates a {@link LogicalPlan} with a {@link LogicalOpUnion} as root
 	 * operator and the given plans as its two subplans.
 	 */
@@ -60,6 +68,14 @@ public class LogicalPlanUtils
 	 * root operator and the given plans as its subplans.
 	 */
 	public static LogicalPlan createPlanWithMultiwayUnion( final LogicalPlan ... subPlans ) {
+		return createPlanWithSubPlans( LogicalOpMultiwayUnion.getInstance(), subPlans );
+	}
+
+	/**
+	 * Creates a {@link LogicalPlan} with a {@link LogicalOpMultiwayUnion} as
+	 * root operator and the given plans as its subplans.
+	 */
+	public static LogicalPlan createPlanWithMultiwayUnion( final List<LogicalPlan> subPlans ) {
 		return createPlanWithSubPlans( LogicalOpMultiwayUnion.getInstance(), subPlans );
 	}
 

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/PushJoinUnderUnionWithRequests.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/PushJoinUnderUnionWithRequests.java
@@ -1,0 +1,253 @@
+package se.liu.ida.hefquin.engine.queryproc.impl.loptimizer.heuristics;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import se.liu.ida.hefquin.engine.queryplan.logical.LogicalOperator;
+import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlan;
+import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanUtils;
+import se.liu.ida.hefquin.engine.queryplan.logical.UnaryLogicalOp;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFilter;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayJoin;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayUnion;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpUnion;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalPlanWithUnaryRootImpl;
+import se.liu.ida.hefquin.engine.queryplan.utils.LogicalOpUtils;
+import se.liu.ida.hefquin.engine.queryproc.impl.loptimizer.HeuristicForLogicalOptimization;
+
+/**
+ * In cases in which there are unions with requests under joins (which may
+ * happen only if we do not use {@link UnionPullUp}, this heuristics turns
+ * the requests into xxAdd operators with the previous join arguments as
+ * subplans. The rationale of this heuristics is that it allows us to use
+ * bind joins and index nested loops joins in cases in which otherwise only
+ * local join algorithms (e.g., hash join) could be used. In this sense, the
+ * effect of this heuristics is similar to that of {@link UnionPullUp}, but
+ * without pulling out unions completely and, thus, without producing a great
+ * number of join subplans.
+ *
+ * For instance, consider the following plan.
+ *
+ * <br/>
+ * <code>
+ * mj(
+ *     req_fm1^(s,p,?x),
+ *     mu(
+ *         req_fm2^(?x,p2,?y),
+ *         req_fm3^(?x,p2,?y)
+ *     ),
+ *     mu(
+ *         req_fm2^(?y,p3,?z),
+ *         req_fm3^(?y,p3,?z)
+ *     )
+ * )
+ * </code>
+ * <br/>
+ * 
+ * In this case, the joins can be implemented only by using a local join
+ * algorithm (e.g., hash join), which also means that the requests inside
+ * the unions are executed by physical request operators and, thus, may
+ * end up retrieving a lot of unnecessary triples from fm2 and from fm3
+ * (i.e., triples that do not participate in the joins).
+ * In contrast, when applying this heuristic to that plan, the resulting
+ * plan is:
+ *
+ * <br/>
+ * <code>
+ * mu(
+ *     tpAdd_fm2^(?y,p3,?z) (
+ *         mu(
+ *             tpAdd__fm2^(?x,p2,?y) (
+ *                 req_fm1^(s,p,?x)
+ *             ),
+ *             tpAdd__fm3^(?x,p2,?y) (
+ *                 req_fm1^(s,p,?x)
+ *             )
+ *         )
+ *     ),
+ *     tpAdd_fm3^(?y,p3,?z) (
+ *         mu(
+ *             ...
+ *         )
+ *     )
+ * ),
+ * </code>
+ * <br/>
+ *
+ * where the subplan under the second tpAdd operator is the same as the
+ * subplan under the first tpAdd operator. Now, the tpAdd operators can
+ * be implemented using bind joins or index nested loops joins, which may
+ * reduce the number of unnecessary triples retrieved from fm2 and fm3.
+ *
+ * The heuristic assumes that we have already applied a join ordering
+ * heuristics beforehand; i.e., the subplans under the multiway joins
+ * already have a reasonable order before this heuristics turns such
+ * a multiway join into stages of xxAdd operators (with the union
+ * operators in between the stages). Based on this assumption, the
+ * heuristics always processes the subplans of multiway joins from
+ * left to right; i.e., the left-most union subplan becomes the first
+ * stage and the right-most union subplan becomes the last stage at
+ * the top of the resulting (sub)plan.
+ *
+ * If there are multiple subplans under a join that are not union subplans,
+ * then these are kept together under a join. For instance, if the previous
+ * example plan would contain a second request before the multiway unions,
+ * then that request would be kept together with the first request as a join
+ * under the tpAdd operators created for the first multiway union.
+ *
+ * In addition to requests under unions (that are under joins), this heuristic
+ * even considers combinations of a filter operator with a request operator,
+ * in which case the request would also be turned into an xxAdd operator, but
+ * with the filter on top of it. Moreover, any other subplan under such unions
+ * (that are under joins) is joined with the previous join arguments. To
+ * illustrate these cases, consider the following example plan.
+ *
+ * <br/>
+ * <code>
+ * mj(
+ *     req_fm1^(s,p,?x),
+ *     mu(
+ *         filter^condition(
+ *             req_fm2^(?x,p2,?y)
+ *         ),
+ *         leftjoin( ... )
+ *     )
+ * )
+ * </code>
+ * <br/>
+ *
+ * The resulting plan would then be as follows.
+ *
+ * <br/>
+ * <code>
+ * mu(
+ *     filter^condition(
+ *         tpAdd_fm2^(?x,p2,?y) (
+ *             req_fm1^(s,p,?x)
+ *         )
+ *     ),
+ *     mj(
+ *         req_fm1^(s,p,?x),
+ *         leftjoin( ... )
+ *     )
+ * )
+ * </code>
+ * <br/>
+ *
+ */
+public class PushJoinUnderUnionWithRequests implements HeuristicForLogicalOptimization
+{
+	@Override
+	public LogicalPlan apply( final LogicalPlan inputPlan ) {
+		final int numberOfSubPlans = inputPlan.numberOfSubPlans();
+		if ( numberOfSubPlans == 0 ) {
+			return inputPlan;
+		}
+
+		// First, apply the heuristic recursively to all subplans.
+		final LogicalPlan[] rewrittenSubPlans = new LogicalPlan[numberOfSubPlans];
+		boolean noChanges = true;
+		for ( int i = 0; i < numberOfSubPlans; i++ ) {
+			final LogicalPlan subPlan = inputPlan.getSubPlan(i);
+			final LogicalPlan rewrittenSubPlan = apply(subPlan);
+
+			if ( rewrittenSubPlan.equals(subPlan) ) {
+				rewrittenSubPlans[i] = subPlan;
+			}
+			else {
+				rewrittenSubPlans[i] = rewrittenSubPlan;
+				noChanges = false;
+			}
+		}
+
+		final LogicalOperator rootOp = inputPlan.getRootOperator();
+		if (    !(rootOp instanceof LogicalOpJoin)
+		     && !(rootOp instanceof LogicalOpMultiwayJoin) )
+		{
+			if ( noChanges )
+				return inputPlan;
+			else
+				return LogicalPlanUtils.createPlanWithSubPlans(rootOp, rewrittenSubPlans);
+		}
+
+		if ( numberOfSubPlans == 1 ) return rewrittenSubPlans[0];
+
+		List<LogicalPlan> subPlansAsNextInput = new ArrayList<>();
+		subPlansAsNextInput.add( rewrittenSubPlans[0] );
+		int i = 1;
+		while ( i < numberOfSubPlans ) {
+			final LogicalPlan currSubPlan = rewrittenSubPlans[i];
+			final LogicalOperator subRootOp = currSubPlan.getRootOperator();
+
+			if (    subRootOp instanceof LogicalOpUnion
+			     || subRootOp instanceof LogicalOpMultiwayUnion )
+			{
+				noChanges = false;
+
+				if ( currSubPlan.numberOfSubPlans() == 1 ) {
+					subPlansAsNextInput.add( currSubPlan.getSubPlan(0) );
+				}
+				else {
+					final LogicalPlan currSubPlanNew = rewrite(currSubPlan, subPlansAsNextInput);
+
+					subPlansAsNextInput = new ArrayList<>();
+					subPlansAsNextInput.add(currSubPlanNew);
+				}
+			}
+			else {
+				subPlansAsNextInput.add(currSubPlan);
+			}
+
+			i++;
+		}
+
+		if ( noChanges ) return inputPlan;
+
+		if ( subPlansAsNextInput.size() == 1 )
+			return subPlansAsNextInput.get(0);
+		else
+			return LogicalPlanUtils.createPlanWithMultiwayJoin(subPlansAsNextInput);
+	}
+
+	protected LogicalPlan rewrite( final LogicalPlan unionPlan, final List<LogicalPlan> subPlansAsInput ) {
+		final LogicalPlan inputPlan;
+		if ( subPlansAsInput.size() == 1 )
+			inputPlan = subPlansAsInput.get(0);
+		else
+			inputPlan = LogicalPlanUtils.createPlanWithMultiwayJoin(subPlansAsInput);
+
+		final int numberOfSubPlansUnderUnion = unionPlan.numberOfSubPlans();
+		final LogicalPlan[] newUnionSubPlans = new LogicalPlan[numberOfSubPlansUnderUnion];
+		for ( int i = 0; i < numberOfSubPlansUnderUnion; i++ ) {
+			final LogicalPlan oldSubPlan = unionPlan.getSubPlan(i);
+			final LogicalPlan newSubPlan;
+
+			final LogicalOperator oldSubPlanRootOp = oldSubPlan.getRootOperator();
+			if ( oldSubPlanRootOp instanceof LogicalOpRequest ) {
+				final LogicalOpRequest<?,?> reqOp = (LogicalOpRequest<?,?>) oldSubPlanRootOp;
+				final UnaryLogicalOp addOp = LogicalOpUtils.createLogicalAddOpFromLogicalReqOp(reqOp);
+				final LogicalPlan addOpPlan = new LogicalPlanWithUnaryRootImpl(addOp, inputPlan);
+				newSubPlan = addOpPlan;
+			}
+			else if (    oldSubPlanRootOp instanceof LogicalOpFilter
+			          && oldSubPlan.getSubPlan(0).getRootOperator() instanceof LogicalOpRequest ) {
+				final LogicalOpFilter filterOp = (LogicalOpFilter) oldSubPlanRootOp;
+				final LogicalOpRequest<?,?> reqOp = (LogicalOpRequest<?,?>) oldSubPlan.getSubPlan(0).getRootOperator();
+				final UnaryLogicalOp addOp = LogicalOpUtils.createLogicalAddOpFromLogicalReqOp(reqOp);
+				final LogicalPlan addOpPlan = new LogicalPlanWithUnaryRootImpl(addOp, inputPlan);
+				final LogicalPlan filterOpPlan = new LogicalPlanWithUnaryRootImpl(filterOp, addOpPlan);
+				newSubPlan = filterOpPlan;
+			}
+			else {
+				newSubPlan = LogicalPlanUtils.createPlanWithMultiwayJoin(inputPlan, oldSubPlan);
+			}
+
+			newUnionSubPlans[i] = newSubPlan; 
+		}
+
+		return LogicalPlanUtils.createPlanWithMultiwayUnion(newUnionSubPlans);
+	}
+
+}

--- a/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/PushJoinUnderUnionWithRequestsTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/PushJoinUnderUnionWithRequestsTest.java
@@ -1,0 +1,333 @@
+package se.liu.ida.hefquin.engine.queryproc.impl.loptimizer.heuristics;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.expr.E_IsIRI;
+import org.apache.jena.sparql.expr.Expr;
+import org.apache.jena.sparql.expr.ExprVar;
+import org.junit.Test;
+
+import se.liu.ida.hefquin.engine.EngineTestBase;
+import se.liu.ida.hefquin.engine.federation.FederationMember;
+import se.liu.ida.hefquin.engine.federation.access.impl.req.SPARQLRequestImpl;
+import se.liu.ida.hefquin.engine.federation.access.impl.req.TriplePatternRequestImpl;
+import se.liu.ida.hefquin.engine.query.TriplePattern;
+import se.liu.ida.hefquin.engine.query.impl.TriplePatternImpl;
+import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlan;
+import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanUtils;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFilter;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayJoin;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayUnion;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalPlanWithNullaryRootImpl;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalPlanWithUnaryRootImpl;
+
+public class PushJoinUnderUnionWithRequestsTest extends EngineTestBase
+{
+	@Test
+	public void pushJoinUnderUnionPossible1() {
+		// a join of a SPARQL request and a union where the union contains two
+		// triple pattern requests; the two triple pattern requests should be
+		// turned into tpAdd operators with the SPARQL request as their input
+		// and the union on top
+
+		// set up
+		final Var v1 = Var.alloc("x");
+		final Var v2 = Var.alloc("y");
+		final FederationMember fmA = new SPARQLEndpointForTest("http://exA.org");
+		final FederationMember fmB = new TPFServerForTest();
+		final FederationMember fmC = new TPFServerForTest();
+
+		final TriplePattern tp1 = new TriplePatternImpl(v1, v1, v1);
+		final LogicalOpRequest<?,?> reqOp1 = new LogicalOpRequest<>( fmA, new SPARQLRequestImpl(tp1) );
+
+		final TriplePattern tp2 = new TriplePatternImpl(v2 ,v2, v2);
+		final LogicalOpRequest<?,?> reqOp2 = new LogicalOpRequest<>( fmB, new TriplePatternRequestImpl(tp2) );
+		final LogicalOpRequest<?,?> reqOp3 = new LogicalOpRequest<>( fmC, new TriplePatternRequestImpl(tp2) );
+
+		final LogicalPlan unionSubPlan = LogicalPlanUtils.createPlanWithBinaryUnion(
+				new LogicalPlanWithNullaryRootImpl(reqOp2),
+				new LogicalPlanWithNullaryRootImpl(reqOp3) );
+
+		final LogicalPlan joinPlan = LogicalPlanUtils.createPlanWithBinaryJoin(
+				new LogicalPlanWithNullaryRootImpl(reqOp1),
+				unionSubPlan );
+
+		// test
+		final LogicalPlan result = new PushJoinUnderUnionWithRequests().apply(joinPlan);
+
+		// check
+		assertTrue( result.getRootOperator() instanceof LogicalOpMultiwayUnion );
+		assertEquals( 2, result.numberOfSubPlans() );
+
+		final LogicalPlan subResult1 = result.getSubPlan(0);
+		final LogicalPlan subResult2 = result.getSubPlan(1);
+		assertTrue( subResult1.getRootOperator() instanceof LogicalOpTPAdd );
+		assertTrue( subResult2.getRootOperator() instanceof LogicalOpTPAdd );
+
+		final LogicalOpTPAdd tpAddOp1 = (LogicalOpTPAdd) subResult1.getRootOperator();
+		final LogicalOpTPAdd tpAddOp2 = (LogicalOpTPAdd) subResult2.getRootOperator();
+
+		assertTrue( tpAddOp1.getTP().equals(tp2) );
+		assertTrue( tpAddOp2.getTP().equals(tp2) );
+		assertTrue( tpAddOp1.getFederationMember().equals(fmB) || tpAddOp1.getFederationMember().equals(fmC) );
+		assertTrue( tpAddOp2.getFederationMember().equals(fmB) || tpAddOp2.getFederationMember().equals(fmC) );
+		assertTrue( tpAddOp1.getFederationMember() != tpAddOp2.getFederationMember() );
+
+		final LogicalPlan subsubResult1 = subResult1.getSubPlan(0);
+		final LogicalPlan subsubResult2 = subResult2.getSubPlan(0);
+
+		assertTrue( subsubResult1.getRootOperator() instanceof LogicalOpRequest );
+		assertTrue( subsubResult2.getRootOperator() instanceof LogicalOpRequest );
+		assertTrue( subsubResult1 == subsubResult2 );
+	}
+
+	@Test
+	public void pushJoinUnderUnionImpossible() {
+		// a join of a union and a SPARQL request where the union
+		// contains two triple pattern requests (i.e., almost the
+		// same as in pushJoinUnderUnionPossible1, but the two
+		// subplans under the join have the reverse order);
+		// since the union is the first input to the join, the
+		// join cannot be pushed
+
+		// set up
+		final Var v1 = Var.alloc("x");
+		final Var v2 = Var.alloc("y");
+		final FederationMember fmA = new SPARQLEndpointForTest("http://exA.org");
+		final FederationMember fmB = new TPFServerForTest();
+		final FederationMember fmC = new TPFServerForTest();
+
+		final TriplePattern tp1 = new TriplePatternImpl(v1, v1, v1);
+		final LogicalOpRequest<?,?> reqOp1 = new LogicalOpRequest<>( fmA, new SPARQLRequestImpl(tp1) );
+
+		final TriplePattern tp2 = new TriplePatternImpl(v2 ,v2, v2);
+		final LogicalOpRequest<?,?> reqOp2 = new LogicalOpRequest<>( fmB, new TriplePatternRequestImpl(tp2) );
+		final LogicalOpRequest<?,?> reqOp3 = new LogicalOpRequest<>( fmC, new TriplePatternRequestImpl(tp2) );
+
+		final LogicalPlan unionSubPlan = LogicalPlanUtils.createPlanWithBinaryUnion(
+				new LogicalPlanWithNullaryRootImpl(reqOp2),
+				new LogicalPlanWithNullaryRootImpl(reqOp3) );
+
+		final LogicalPlan joinPlan = LogicalPlanUtils.createPlanWithBinaryJoin(
+				unionSubPlan,
+				new LogicalPlanWithNullaryRootImpl(reqOp1) );
+
+		// test
+		final LogicalPlan result = new PushJoinUnderUnionWithRequests().apply(joinPlan);
+
+		// check
+		assertTrue( result.equals(joinPlan) );
+	}
+
+	@Test
+	public void pushJoinUnderUnionWithFilter() {
+		// like pushJoinUnderUnionPossible1 but with filters under the union
+
+		// set up
+		final Var v1 = Var.alloc("x");
+		final Var v2 = Var.alloc("y");
+		final FederationMember fmA = new SPARQLEndpointForTest("http://exA.org");
+		final FederationMember fmB = new TPFServerForTest();
+		final FederationMember fmC = new TPFServerForTest();
+
+		final TriplePattern tp1 = new TriplePatternImpl(v1, v1, v1);
+		final LogicalOpRequest<?,?> reqOp1 = new LogicalOpRequest<>( fmA, new SPARQLRequestImpl(tp1) );
+
+		final TriplePattern tp2 = new TriplePatternImpl(v2 ,v2, v2);
+		final LogicalOpRequest<?,?> reqOp2 = new LogicalOpRequest<>( fmB, new TriplePatternRequestImpl(tp2) );
+		final LogicalOpRequest<?,?> reqOp3 = new LogicalOpRequest<>( fmC, new TriplePatternRequestImpl(tp2) );
+
+		final Expr e = new E_IsIRI( new ExprVar(v2) );
+		final LogicalOpFilter filterOp = new LogicalOpFilter(e);
+		
+		final LogicalPlan unionSubPlan = LogicalPlanUtils.createPlanWithBinaryUnion(
+				new LogicalPlanWithUnaryRootImpl(filterOp, new LogicalPlanWithNullaryRootImpl(reqOp2)),
+				new LogicalPlanWithUnaryRootImpl(filterOp, new LogicalPlanWithNullaryRootImpl(reqOp3)) );
+
+		final LogicalPlan joinPlan = LogicalPlanUtils.createPlanWithBinaryJoin(
+				new LogicalPlanWithNullaryRootImpl(reqOp1),
+				unionSubPlan );
+
+		// test
+		final LogicalPlan result = new PushJoinUnderUnionWithRequests().apply(joinPlan);
+
+		// check
+		assertTrue( result.getRootOperator() instanceof LogicalOpMultiwayUnion );
+		assertEquals( 2, result.numberOfSubPlans() );
+
+		final LogicalPlan subResult1 = result.getSubPlan(0);
+		final LogicalPlan subResult2 = result.getSubPlan(1);
+		assertTrue( subResult1.getRootOperator().equals(filterOp) );
+		assertTrue( subResult2.getRootOperator().equals(filterOp) );
+
+		final LogicalPlan subsubResult1 = subResult1.getSubPlan(0);
+		final LogicalPlan subsubResult2 = subResult2.getSubPlan(0);
+		assertTrue( subsubResult1.getRootOperator() instanceof LogicalOpTPAdd );
+		assertTrue( subsubResult2.getRootOperator() instanceof LogicalOpTPAdd );
+
+		final LogicalOpTPAdd tpAddOp1 = (LogicalOpTPAdd) subsubResult1.getRootOperator();
+		final LogicalOpTPAdd tpAddOp2 = (LogicalOpTPAdd) subsubResult2.getRootOperator();
+
+		assertTrue( tpAddOp1.getTP().equals(tp2) );
+		assertTrue( tpAddOp2.getTP().equals(tp2) );
+		assertTrue( tpAddOp1.getFederationMember().equals(fmB) || tpAddOp1.getFederationMember().equals(fmC) );
+		assertTrue( tpAddOp2.getFederationMember().equals(fmB) || tpAddOp2.getFederationMember().equals(fmC) );
+		assertTrue( tpAddOp1.getFederationMember() != tpAddOp2.getFederationMember() );
+
+		final LogicalPlan sssResult1 = subsubResult1.getSubPlan(0);
+		final LogicalPlan sssResult2 = subsubResult2.getSubPlan(0);
+
+		assertTrue( sssResult1.getRootOperator() instanceof LogicalOpRequest );
+		assertTrue( sssResult2.getRootOperator() instanceof LogicalOpRequest );
+		assertTrue( sssResult1 == sssResult2 );
+	}
+
+	@Test
+	public void pushJoinUnderUnionPossible2() {
+		// a join of a SPARQL request and a union where the union contains two
+		// gpAdd operators; the two gpAdd operators should be joined with the
+		// with the SPARQL request, respectively, with the union on top
+
+		// set up
+		final Var v1 = Var.alloc("x");
+		final Var v2 = Var.alloc("y");
+		final Var v3 = Var.alloc("z");
+		final FederationMember fmA = new TPFServerForTest();
+		final FederationMember fmB = new TPFServerForTest();
+		final FederationMember fmC = new TPFServerForTest();
+		final FederationMember fmD = new SPARQLEndpointForTest("http://exD.org");
+
+		final TriplePattern tp1 = new TriplePatternImpl(v1, v1, v1);
+		final TriplePattern tp2 = new TriplePatternImpl(v2 ,v2, v2);
+		final TriplePattern tp3 = new TriplePatternImpl(v3 ,v3, v3);
+		final TriplePattern tp4 = new TriplePatternImpl(v1 ,v2, v3);
+
+		final LogicalOpRequest<?,?> reqOp1 = new LogicalOpRequest<>( fmA, new TriplePatternRequestImpl(tp1) );
+		final LogicalOpRequest<?,?> reqOp2 = new LogicalOpRequest<>( fmB, new TriplePatternRequestImpl(tp2) );
+		final LogicalOpRequest<?,?> reqOp3 = new LogicalOpRequest<>( fmC, new TriplePatternRequestImpl(tp3) );
+
+		final LogicalPlan gpAddPlan1 = new LogicalPlanWithUnaryRootImpl( new LogicalOpGPAdd(fmD, tp4),
+		                                                                 new LogicalPlanWithNullaryRootImpl(reqOp1) );
+
+		final LogicalPlan gpAddPlan2 = new LogicalPlanWithUnaryRootImpl( new LogicalOpGPAdd(fmD, tp4),
+		                                                                 new LogicalPlanWithNullaryRootImpl(reqOp2) );
+
+		final LogicalPlan unionSubPlan = LogicalPlanUtils.createPlanWithBinaryUnion(gpAddPlan1, gpAddPlan2);
+
+		final LogicalPlan reqPlan = new LogicalPlanWithNullaryRootImpl(reqOp3);
+
+		final LogicalPlan joinPlan = LogicalPlanUtils.createPlanWithBinaryJoin(reqPlan, unionSubPlan);
+
+		// test
+		final LogicalPlan result = new PushJoinUnderUnionWithRequests().apply(joinPlan);
+
+		// check
+		assertTrue( result.getRootOperator() instanceof LogicalOpMultiwayUnion );
+		assertEquals( 2, result.numberOfSubPlans() );
+
+		final LogicalPlan subResult1 = result.getSubPlan(0);
+		final LogicalPlan subResult2 = result.getSubPlan(1);
+		assertTrue( subResult1.getRootOperator() instanceof LogicalOpMultiwayJoin );
+		assertTrue( subResult2.getRootOperator() instanceof LogicalOpMultiwayJoin );
+
+		assertEquals( 2, subResult1.numberOfSubPlans() );
+		assertEquals( 2, subResult2.numberOfSubPlans() );
+
+		assertTrue( subResult1.getSubPlan(0).equals(reqPlan) );
+		assertTrue( subResult2.getSubPlan(0).equals(reqPlan) );
+
+		assertTrue( subResult1.getSubPlan(1).equals(gpAddPlan1) || subResult1.getSubPlan(1).equals(gpAddPlan2) );
+		if ( subResult1.getSubPlan(1).equals(gpAddPlan1) ) {
+			assertTrue( subResult2.getSubPlan(1).equals(gpAddPlan2) );
+		}
+		else {
+			assertTrue( subResult2.getSubPlan(1).equals(gpAddPlan1) );
+		}
+	}
+
+	@Test
+	public void pushJoinUnderUnionTwice() {
+		// a join of a SPARQL request and two unions where both unions contain
+		// two triple pattern requests each; the two pairs of triple pattern
+		// requests should be turned into pairs tpAdd operators, with the
+		// SPARQL request as the input to the first pair, a union on top,
+		// and that union input to the next pair, plus a final union on top
+
+		// set up
+		final Var v1 = Var.alloc("x");
+		final Var v2 = Var.alloc("y");
+		final Var v3 = Var.alloc("z");
+		final FederationMember fmA = new SPARQLEndpointForTest("http://exA.org");
+		final FederationMember fmB = new TPFServerForTest();
+		final FederationMember fmC = new TPFServerForTest();
+
+		final TriplePattern tp1 = new TriplePatternImpl(v1, v1, v1);
+		final LogicalOpRequest<?,?> reqOp1 = new LogicalOpRequest<>( fmA, new SPARQLRequestImpl(tp1) );
+
+		final TriplePattern tp2 = new TriplePatternImpl(v2 ,v2, v2);
+		final LogicalOpRequest<?,?> reqOp2B = new LogicalOpRequest<>( fmB, new TriplePatternRequestImpl(tp2) );
+		final LogicalOpRequest<?,?> reqOp2C = new LogicalOpRequest<>( fmC, new TriplePatternRequestImpl(tp2) );
+
+		final TriplePattern tp3 = new TriplePatternImpl(v3 ,v3, v3);
+		final LogicalOpRequest<?,?> reqOp3B = new LogicalOpRequest<>( fmB, new TriplePatternRequestImpl(tp3) );
+		final LogicalOpRequest<?,?> reqOp3C = new LogicalOpRequest<>( fmC, new TriplePatternRequestImpl(tp3) );
+
+		final LogicalPlan unionSubPlan1 = LogicalPlanUtils.createPlanWithBinaryUnion(
+				new LogicalPlanWithNullaryRootImpl(reqOp2B),
+				new LogicalPlanWithNullaryRootImpl(reqOp2C) );
+
+		final LogicalPlan unionSubPlan2 = LogicalPlanUtils.createPlanWithBinaryUnion(
+				new LogicalPlanWithNullaryRootImpl(reqOp3B),
+				new LogicalPlanWithNullaryRootImpl(reqOp3C) );
+
+		final LogicalPlan reqPlan = new LogicalPlanWithNullaryRootImpl(reqOp1);
+
+		final LogicalPlan joinPlan = LogicalPlanUtils.createPlanWithMultiwayJoin(
+				reqPlan,
+				unionSubPlan1,
+				unionSubPlan2 );
+
+		// test
+		final LogicalPlan result = new PushJoinUnderUnionWithRequests().apply(joinPlan);
+
+		// check
+		assertTrue( result.getRootOperator() instanceof LogicalOpMultiwayUnion );
+		assertEquals( 2, result.numberOfSubPlans() );
+
+		final LogicalPlan subResult1 = result.getSubPlan(0);
+		final LogicalPlan subResult2 = result.getSubPlan(1);
+		assertTrue( subResult1.getRootOperator() instanceof LogicalOpTPAdd );
+		assertTrue( subResult2.getRootOperator() instanceof LogicalOpTPAdd );
+
+		final LogicalOpTPAdd tpAddOp1 = (LogicalOpTPAdd) subResult1.getRootOperator();
+		final LogicalOpTPAdd tpAddOp2 = (LogicalOpTPAdd) subResult2.getRootOperator();
+
+		assertTrue( tpAddOp1.getTP().equals(tp3) );
+		assertTrue( tpAddOp2.getTP().equals(tp3) );
+
+		final LogicalPlan subsubResult = subResult1.getSubPlan(0);
+		assertTrue( subsubResult.equals( subResult2.getSubPlan(0) ) );
+		assertTrue( subsubResult.getRootOperator() instanceof LogicalOpMultiwayUnion );
+		assertEquals( 2, subsubResult.numberOfSubPlans() );
+
+		final LogicalPlan sssResult1 = subsubResult.getSubPlan(0);
+		final LogicalPlan sssResult2 = subsubResult.getSubPlan(1);
+		assertTrue( sssResult1.getRootOperator() instanceof LogicalOpTPAdd );
+		assertTrue( sssResult2.getRootOperator() instanceof LogicalOpTPAdd );
+
+		final LogicalOpTPAdd tpAddOp1_1 = (LogicalOpTPAdd) sssResult1.getRootOperator();
+		final LogicalOpTPAdd tpAddOp2_2 = (LogicalOpTPAdd) sssResult2.getRootOperator();
+
+		assertTrue( tpAddOp1_1.getTP().equals(tp2) );
+		assertTrue( tpAddOp2_2.getTP().equals(tp2) );
+
+		assertTrue( sssResult1.getSubPlan(0).equals(reqPlan) );
+		assertTrue( sssResult2.getSubPlan(0).equals(reqPlan) );
+	}
+
+}


### PR DESCRIPTION
This PR adds another heuristics.   /cc @chengsijin0817 

In cases in which there are unions with requests under joins (which may happen only if we do not use UnionPullUp), this heuristics turns the requests into xxAdd operators with the previous join arguments as subplans. The rationale of this heuristics is that it allows us to use bind joins and index nested loops joins in cases in which otherwise only local join algorithms (e.g., hash join) could be used. In this sense, the effect of this heuristics is similar to that of UnionPullUp, but without pulling out unions completely and, thus, without producing a great number of join subplans.

For instance, consider the following plan.
```
mj(
     req_fm1^(s,p,?x),
     mu(
         req_fm2^(?x,p2,?y),
         req_fm3^(?x,p2,?y)
     ),
     mu(
         req_fm2^(?y,p3,?z),
         req_fm3^(?y,p3,?z)
     )
)
```
In this case, the joins can be implemented only by using a local join algorithm (e.g., hash join), which also means that the requests inside the unions are executed by physical request operators and, thus, may end up retrieving a lot of unnecessary triples from fm2 and from fm3 (i.e., triples that do not participate in the joins). In contrast, when applying this heuristic to that plan, the resulting plan is:
```
mu(
    tpAdd_fm2^(?y,p3,?z) (
        mu(
            tpAdd__fm2^(?x,p2,?y) (
                req_fm1^(s,p,?x)
            ),
            tpAdd__fm3^(?x,p2,?y) (
                req_fm1^(s,p,?x)
            )
        )
    ),
    tpAdd_fm3^(?y,p3,?z) (
        mu(
            ...
        )
    )
)
```
where the subplan under the second tpAdd operator is the same as the subplan under the first tpAdd operator. Now, the tpAdd operators can be implemented using bind joins or index nested loops joins, which may reduce the number of unnecessary triples retrieved from fm2 and fm3.

The heuristic assumes that we have already applied a join ordering heuristics beforehand; i.e., the subplans under the multiway joins already have a reasonable order before this heuristics turns such a multiway join into stages of xxAdd operators (with the union operators in between the stages). Based on this assumption, the heuristics always processes the subplans of multiway joins from left to right; i.e., the left-most union subplan becomes the first stage and the right-most union subplan becomes the last stage at the top of the resulting (sub)plan.

If there are multiple subplans under a join that are not union subplans, then these are kept together under a join. For instance, if the previous example plan would contain a second request before the multiway unions, then that request would be kept together with the first request as a join under the tpAdd operators created for the first multiway union.

In addition to requests under unions (that are under joins), this heuristic even considers combinations of a filter operator with a request operator, in which case the request would also be turned into an xxAdd operator, but with the filter on top of it. Moreover, any other subplan under such unions (that are under joins) is joined with the previous join arguments. To illustrate these cases, consider the following example plan.
```
mj(
    req_fm1^(s,p,?x),
    mu(
        filter^condition(
            req_fm2^(?x,p2,?y)
        ),
        leftjoin( ... )
    )
)
```
The resulting plan would then be as follows.
```
mu(
    filter^condition(
        tpAdd_fm2^(?x,p2,?y) (
            req_fm1^(s,p,?x)
        )
    ),
    mj(
        req_fm1^(s,p,?x),
        leftjoin( ... )
    )
)
```