### PR TITLE
Longest path fix

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
@@ -189,13 +189,6 @@ public class LabeledGraph {
                 candidate = new Path(start, currentEdge);
             }
             else if (! visitedEdges.contains(currentEdge.id)) {
-                /*if (adjacencyLists.get(candidate.path.get(candidate.path.size()-1).target).stream().noneMatch(
-                        e -> e.edge.equals(currentEdge.edge) && e.target.equals(currentEdge.target)
-                )) {
-                    System.out.println("ERROR: " + currentEdge);
-                    System.out.println("node:" + candidate.path.get(candidate.path.size()-1).target);
-                    System.out.println("doesnt connect with: " + currentEdge.target);
-                }*/
                 candidate.addEdge(currentEdge);
             }
             visitedEdges.add(currentEdge.id);

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
@@ -124,7 +124,7 @@ public class LabeledGraph {
         }
 
         public CypherVar lastTarget() {
-            return path.size()>0 ? path.get(path.size()-1).target : start;
+            return path.get(path.size()-1).target;
         }
     }
 
@@ -185,10 +185,17 @@ public class LabeledGraph {
         Path longest = null;
         while (!toVisit.isEmpty()) {
             final Edge currentEdge = toVisit.pop();
-            if (candidate == null) {
+            if (candidate == null || candidate.size()==0) {
                 candidate = new Path(start, currentEdge);
             }
             else if (! visitedEdges.contains(currentEdge.id)) {
+                /*if (adjacencyLists.get(candidate.path.get(candidate.path.size()-1).target).stream().noneMatch(
+                        e -> e.edge.equals(currentEdge.edge) && e.target.equals(currentEdge.target)
+                )) {
+                    System.out.println("ERROR: " + currentEdge);
+                    System.out.println("node:" + candidate.path.get(candidate.path.size()-1).target);
+                    System.out.println("doesnt connect with: " + currentEdge.target);
+                }*/
                 candidate.addEdge(currentEdge);
             }
             visitedEdges.add(currentEdge.id);
@@ -202,9 +209,9 @@ public class LabeledGraph {
                 if ( longest == null || candidate.size() > longest.size() ) {
                     longest = candidate.copy();
                 }
-                while (candidate.size()>0) {
+                while (true) {
                     candidate.removeLast();
-                    if (visitedEdges.containsAll(adjacencyLists.get(candidate.lastTarget()).stream().map(e->e.id).collect(Collectors.toList()))) {
+                    if (candidate.size()==0 || !visitedEdges.containsAll(adjacencyLists.get(candidate.lastTarget()).stream().map(e->e.id).collect(Collectors.toList()))) {
                         break;
                     }
                 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
@@ -124,7 +124,7 @@ public class LabeledGraph {
         }
 
         public CypherVar lastTarget() {
-            return path.get(path.size()-1).target;
+            return path.size()>0 ? path.get(path.size()-1).target : start;
         }
     }
 
@@ -202,11 +202,9 @@ public class LabeledGraph {
                 if ( longest == null || candidate.size() > longest.size() ) {
                     longest = candidate.copy();
                 }
-                while (true) {
+                while (candidate.size()>0) {
                     candidate.removeLast();
-                    if (candidate.size()==0 ||
-                            !visitedEdges.containsAll(adjacencyLists.get(candidate.lastTarget()).stream().map(e->e.id)
-                                    .collect(Collectors.toList()))) {
+                    if (visitedEdges.containsAll(adjacencyLists.get(candidate.lastTarget()).stream().map(e->e.id).collect(Collectors.toList()))) {
                         break;
                     }
                 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/utils/LabeledGraph.java
@@ -122,6 +122,10 @@ public class LabeledGraph {
         public List<Edge> getEdges() {
             return path;
         }
+
+        public CypherVar lastTarget() {
+            return path.get(path.size()-1).target;
+        }
     }
 
     protected final Map<CypherVar, List<Edge>> adjacencyLists;
@@ -198,7 +202,14 @@ public class LabeledGraph {
                 if ( longest == null || candidate.size() > longest.size() ) {
                     longest = candidate.copy();
                 }
-                candidate.removeLast();
+                while (true) {
+                    candidate.removeLast();
+                    if (candidate.size()==0 ||
+                            !visitedEdges.containsAll(adjacencyLists.get(candidate.lastTarget()).stream().map(e->e.id)
+                                    .collect(Collectors.toList()))) {
+                        break;
+                    }
+                }
             }
         }
         return longest;

--- a/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/LabeledGraphTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/LabeledGraphTest.java
@@ -32,16 +32,19 @@ public class LabeledGraphTest {
         final LabeledGraph.Edge wczl2r = new LabeledGraph.Edge(3, c, z, LabeledGraph.Direction.LEFT2RIGHT);
         final LabeledGraph.Edge zbyr2l = new LabeledGraph.Edge(2, b, y, LabeledGraph.Direction.RIGHT2LEFT);
         final LabeledGraph.Edge yaxr2l = new LabeledGraph.Edge(1, a, x, LabeledGraph.Direction.RIGHT2LEFT);
-
-        adjacencyList.put(x, List.of(new LabeledGraph.Edge(1, a, y, LabeledGraph.Direction.LEFT2RIGHT)));
-        adjacencyList.put(y, List.of(yaxr2l, new LabeledGraph.Edge(2, b, z, LabeledGraph.Direction.LEFT2RIGHT)));
-        adjacencyList.put(z, List.of(zbyr2l, new LabeledGraph.Edge(3, c, w, LabeledGraph.Direction.RIGHT2LEFT)));
-        adjacencyList.put(w, List.of(wczl2r, new LabeledGraph.Edge(4, d, u, LabeledGraph.Direction.LEFT2RIGHT),
-                new LabeledGraph.Edge(5, e, t, LabeledGraph.Direction.LEFT2RIGHT)));
+        final LabeledGraph.Edge xayl2r = new LabeledGraph.Edge(1, a, y, LabeledGraph.Direction.LEFT2RIGHT);
+        final LabeledGraph.Edge ybzl2r = new LabeledGraph.Edge(2, b, z, LabeledGraph.Direction.LEFT2RIGHT);
+        final LabeledGraph.Edge zcwr2l = new LabeledGraph.Edge(3, c, w, LabeledGraph.Direction.RIGHT2LEFT);
+        final LabeledGraph.Edge wdul2r = new LabeledGraph.Edge(4, d, u, LabeledGraph.Direction.LEFT2RIGHT);
+        final LabeledGraph.Edge wetl2r = new LabeledGraph.Edge(5, e, t, LabeledGraph.Direction.LEFT2RIGHT);
+        adjacencyList.put(x, List.of(xayl2r));
+        adjacencyList.put(y, List.of(yaxr2l, ybzl2r));
+        adjacencyList.put(z, List.of(zbyr2l, zcwr2l));
+        adjacencyList.put(w, List.of(wczl2r, wdul2r, wetl2r));
         adjacencyList.put(u, List.of(new LabeledGraph.Edge(4, d, w, LabeledGraph.Direction.RIGHT2LEFT)));
         adjacencyList.put(t, List.of(tewr2l));
         final LabeledGraph graph = new LabeledGraph(adjacencyList);
-        assertEquals(new LabeledGraph.Path(t, List.of(tewr2l, wczl2r, zbyr2l, yaxr2l)),
+        assertEquals(new LabeledGraph.Path(x, List.of(xayl2r, ybzl2r, zcwr2l, wetl2r)),
                 graph.getLongestPath());
     }
 
@@ -84,6 +87,29 @@ public class LabeledGraphTest {
         updatedAdjacencyList.put(z, List.of(zcxr2l));
 
         assertEquals(new LabeledGraph(updatedAdjacencyList), graph);
+    }
+
+    @Test
+    public void goBack2Test() {
+        final Map<CypherVar, List<LabeledGraph.Edge>> adjacencyList = new HashMap<>();
+        final LabeledGraph.Edge xayl2r = new LabeledGraph.Edge(1, a, y, LabeledGraph.Direction.LEFT2RIGHT);
+        final LabeledGraph.Edge ybzl2r = new LabeledGraph.Edge(2, b, z, LabeledGraph.Direction.LEFT2RIGHT);
+        final LabeledGraph.Edge zcul2r = new LabeledGraph.Edge(3, c, u, LabeledGraph.Direction.LEFT2RIGHT);
+        final LabeledGraph.Edge ydwl2r = new LabeledGraph.Edge(4, d, w, LabeledGraph.Direction.LEFT2RIGHT);
+        final LabeledGraph.Edge wetl2r = new LabeledGraph.Edge(5, e, t, LabeledGraph.Direction.LEFT2RIGHT);
+        final LabeledGraph.Edge yaxr2l = new LabeledGraph.Edge(1, a, x, LabeledGraph.Direction.RIGHT2LEFT);
+        final LabeledGraph.Edge zbyr2l = new LabeledGraph.Edge(2, b, y, LabeledGraph.Direction.RIGHT2LEFT);
+        final LabeledGraph.Edge uczr2l = new LabeledGraph.Edge(3, c, z, LabeledGraph.Direction.RIGHT2LEFT);
+        final LabeledGraph.Edge wdyr2l = new LabeledGraph.Edge(4, d, y, LabeledGraph.Direction.RIGHT2LEFT);
+        final LabeledGraph.Edge tewr2l = new LabeledGraph.Edge(5, e, w, LabeledGraph.Direction.RIGHT2LEFT);
+        adjacencyList.put(x, List.of(xayl2r));
+        adjacencyList.put(y, List.of(ybzl2r, ydwl2r, yaxr2l));
+        adjacencyList.put(z, List.of(zcul2r, zbyr2l));
+        adjacencyList.put(w, List.of(wetl2r, wdyr2l));
+        adjacencyList.put(u, List.of(uczr2l));
+        adjacencyList.put(t, List.of(tewr2l));
+        final LabeledGraph graph = new LabeledGraph(adjacencyList);
+        System.out.println(graph.getLongestPath());
     }
 
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/LabeledGraphTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/LabeledGraphTest.java
@@ -32,19 +32,16 @@ public class LabeledGraphTest {
         final LabeledGraph.Edge wczl2r = new LabeledGraph.Edge(3, c, z, LabeledGraph.Direction.LEFT2RIGHT);
         final LabeledGraph.Edge zbyr2l = new LabeledGraph.Edge(2, b, y, LabeledGraph.Direction.RIGHT2LEFT);
         final LabeledGraph.Edge yaxr2l = new LabeledGraph.Edge(1, a, x, LabeledGraph.Direction.RIGHT2LEFT);
-        final LabeledGraph.Edge xayl2r = new LabeledGraph.Edge(1, a, y, LabeledGraph.Direction.LEFT2RIGHT);
-        final LabeledGraph.Edge ybzl2r = new LabeledGraph.Edge(2, b, z, LabeledGraph.Direction.LEFT2RIGHT);
-        final LabeledGraph.Edge zcwr2l = new LabeledGraph.Edge(3, c, w, LabeledGraph.Direction.RIGHT2LEFT);
-        final LabeledGraph.Edge wdul2r = new LabeledGraph.Edge(4, d, u, LabeledGraph.Direction.LEFT2RIGHT);
-        final LabeledGraph.Edge wetl2r = new LabeledGraph.Edge(5, e, t, LabeledGraph.Direction.LEFT2RIGHT);
-        adjacencyList.put(x, List.of(xayl2r));
-        adjacencyList.put(y, List.of(yaxr2l, ybzl2r));
-        adjacencyList.put(z, List.of(zbyr2l, zcwr2l));
-        adjacencyList.put(w, List.of(wczl2r, wdul2r, wetl2r));
+
+        adjacencyList.put(x, List.of(new LabeledGraph.Edge(1, a, y, LabeledGraph.Direction.LEFT2RIGHT)));
+        adjacencyList.put(y, List.of(yaxr2l, new LabeledGraph.Edge(2, b, z, LabeledGraph.Direction.LEFT2RIGHT)));
+        adjacencyList.put(z, List.of(zbyr2l, new LabeledGraph.Edge(3, c, w, LabeledGraph.Direction.RIGHT2LEFT)));
+        adjacencyList.put(w, List.of(wczl2r, new LabeledGraph.Edge(4, d, u, LabeledGraph.Direction.LEFT2RIGHT),
+                new LabeledGraph.Edge(5, e, t, LabeledGraph.Direction.LEFT2RIGHT)));
         adjacencyList.put(u, List.of(new LabeledGraph.Edge(4, d, w, LabeledGraph.Direction.RIGHT2LEFT)));
         adjacencyList.put(t, List.of(tewr2l));
         final LabeledGraph graph = new LabeledGraph(adjacencyList);
-        assertEquals(new LabeledGraph.Path(x, List.of(xayl2r, ybzl2r, zcwr2l, wetl2r)),
+        assertEquals(new LabeledGraph.Path(t, List.of(tewr2l, wczl2r, zbyr2l, yaxr2l)),
                 graph.getLongestPath());
     }
 
@@ -109,7 +106,7 @@ public class LabeledGraphTest {
         adjacencyList.put(u, List.of(uczr2l));
         adjacencyList.put(t, List.of(tewr2l));
         final LabeledGraph graph = new LabeledGraph(adjacencyList);
-        System.out.println(graph.getLongestPath());
+        assertEquals(new LabeledGraph.Path(t, List.of(tewr2l, wdyr2l, ybzl2r, zcul2r)), graph.getLongestPath());
     }
 
 }


### PR DESCRIPTION
Fixes a bug on the `longestPath` method, where it would only go back one step after finding a dead end. Now it goes back however many steps necessary to find a new path.