### PR TITLE
Adds physical + executable operator for multiway unions

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/NaryExecutableOp.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/NaryExecutableOp.java
@@ -1,6 +1,34 @@
 package se.liu.ida.hefquin.engine.queryplan.executable;
 
+import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
+
 public interface NaryExecutableOp extends ExecutableOperator
 {
-	// TODO define this interface
+	/**
+	 * Returns the preferred block size of input blocks that are
+	 * passed to this executable operator from any of its operands.
+	 *
+	 * A query planner may use this number as an optimization hint
+	 * but it does not have to use it.
+	 */
+	int preferredInputBlockSizeFromChilden();
+
+	/**
+	 * Processes the given input coming from the x-th operand
+	 * and sends the produced result elements (if any) to the
+	 * given sink.
+	 */
+	void processBlockFromXthChild( int x,
+	                               IntermediateResultBlock input,
+	                               IntermediateResultElementSink sink,
+	                               ExecutionContext execCxt ) throws ExecOpExecutionException;
+
+	/**
+	 * Finishes up any processing related to the input coming
+	 * from the x-th operand and sends the remaining result
+	 * elements (if any) to the given sink.
+	 */
+	void wrapUpForXthChild( int x,
+	                        IntermediateResultElementSink sink,
+	                        ExecutionContext execCxt ) throws ExecOpExecutionException;
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpMultiwayUnion.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpMultiwayUnion.java
@@ -1,0 +1,39 @@
+package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
+
+import se.liu.ida.hefquin.engine.data.SolutionMapping;
+import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultBlock;
+import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
+import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
+
+public class ExecOpMultiwayUnion extends NaryExecutableOpBase
+{
+	public ExecOpMultiwayUnion( final int numberOfChildren, final boolean collectExceptions ) {
+		super(numberOfChildren, collectExceptions);
+	}
+
+	@Override
+	public int preferredInputBlockSizeFromChilden() {
+		// Since this algorithm processes the input solution mappings
+		// sequentially (one at a time), an input block size of 1 may
+		// reduce the response time of the overall execution process.
+		return 1;
+	}
+
+	@Override
+	protected void _processBlockFromXthChild( final int x,
+	                                          final IntermediateResultBlock input,
+	                                          final IntermediateResultElementSink sink,
+	                                          final ExecutionContext execCxt) {
+		for ( final SolutionMapping sm : input.getSolutionMappings() ) {
+			sink.send(sm);
+		}
+	}
+
+	@Override
+	protected void _wrapUpForXthChild( final int x,
+	                                   final IntermediateResultElementSink sink,
+	                                   final ExecutionContext execCxt ) {
+		// nothing to be done here
+	}
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/NaryExecutableOpBase.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/NaryExecutableOpBase.java
@@ -1,21 +1,109 @@
 package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
+import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutableOperatorStats;
+import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultBlock;
+import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.NaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
+import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 /**
  * Top-level base class for all implementations of {@link NaryExecutableOp}.
  */
 public abstract class NaryExecutableOpBase extends BaseForExecOps implements NaryExecutableOp
 {
-	public NaryExecutableOpBase( final boolean collectExceptions ) {
+	protected final int numberOfChildren;
+
+	private boolean[] xthInputConsumed;
+	private int[] numberOfBlocksFromXthInputProcessed;
+	private long[] numberOfMappingsFromXthInputProcessed;
+	private long[] sumOfProcessingTimesXthInput;
+	private long[] minProcessingTimeXthInput;
+	private long[] maxProcessingTimeXthInput;
+	protected long[] timeAtCurrentProcStartXthInput;
+
+	public NaryExecutableOpBase( final int numberOfChildren, final boolean collectExceptions ) {
 		super(collectExceptions);
+
+		this.numberOfChildren = numberOfChildren;
+
+		xthInputConsumed                   = new boolean[numberOfChildren];
+		numberOfBlocksFromXthInputProcessed   = new int[numberOfChildren];
+		numberOfMappingsFromXthInputProcessed = new long[numberOfChildren];
+		sumOfProcessingTimesXthInput           = new long[numberOfChildren];
+		minProcessingTimeXthInput              = new long[numberOfChildren];
+		maxProcessingTimeXthInput              = new long[numberOfChildren];
+		timeAtCurrentProcStartXthInput         = new long[numberOfChildren];
+
+		resetStats();
+	}
+
+	@Override
+	public final void processBlockFromXthChild( final int x,
+	                                            final IntermediateResultBlock input,
+	                                            final IntermediateResultElementSink sink,
+	                                            final ExecutionContext execCxt ) throws ExecOpExecutionException {
+		assert x >= 0;
+		assert x < numberOfChildren;
+
+		timeAtCurrentProcStartXthInput[x] = System.currentTimeMillis();
+
+		if ( collectExceptions ) {
+			try {
+				_processBlockFromXthChild(x, input, sink, execCxt);
+			}
+			catch ( final ExecOpExecutionException e ) {
+				recordExceptionCaughtDuringExecution(e);
+			}
+		}
+		else {
+			_processBlockFromXthChild(x, input, sink, execCxt);
+		}
+
+		final long processingTime = System.currentTimeMillis() - timeAtCurrentProcStartXthInput[x];
+
+		sumOfProcessingTimesXthInput[x] += processingTime;
+		if ( processingTime < minProcessingTimeXthInput[x] ) { minProcessingTimeXthInput[x] = processingTime; }
+		if ( processingTime > maxProcessingTimeXthInput[x] ) { maxProcessingTimeXthInput[x] = processingTime; }
+
+		numberOfMappingsFromXthInputProcessed[x] += input.size();
+		numberOfBlocksFromXthInputProcessed[x]++;
+	}
+
+	@Override
+	public final void wrapUpForXthChild( int x,
+            IntermediateResultElementSink sink,
+            ExecutionContext execCxt ) throws ExecOpExecutionException {
+		assert x >= 0;
+		assert x < numberOfChildren;
+
+		xthInputConsumed[x] = true;
+		_wrapUpForXthChild(x, sink, execCxt);
 	}
 
 	@Override
 	public void resetStats() {
+		for ( int i = 0; i < numberOfChildren; i++ ) {
+			xthInputConsumed[i] = false;
+			numberOfBlocksFromXthInputProcessed[i] = 0;
+			numberOfMappingsFromXthInputProcessed[i] = 0L;
+			sumOfProcessingTimesXthInput[i] = 0L;
+			minProcessingTimeXthInput[i] = Long.MAX_VALUE;
+			maxProcessingTimeXthInput[i] = 0L;
+			timeAtCurrentProcStartXthInput[i] = 0L;
+		}
 	}
+
+	protected abstract void _processBlockFromXthChild(
+			final int x,
+			final IntermediateResultBlock input,
+			final IntermediateResultElementSink sink,
+			final ExecutionContext execCxt ) throws ExecOpExecutionException;
+
+	protected abstract void _wrapUpForXthChild( final int x,
+	                                            final IntermediateResultElementSink sink,
+	                                            final ExecutionContext execCxt ) throws ExecOpExecutionException;
 
 	@Override
 	public final ExecutableOperatorStats getStats() {
@@ -24,6 +112,9 @@ public abstract class NaryExecutableOpBase extends BaseForExecOps implements Nar
 
 	protected ExecutableOperatorStatsImpl createStats() {
 		final ExecutableOperatorStatsImpl s = new ExecutableOperatorStatsImpl(this);
+		s.put( "xthInputConsumed", xthInputConsumed );
+		s.put( "numberOfBlocksFromXthInputProcessed",    numberOfBlocksFromXthInputProcessed );
+		s.put( "numberOfMappingsFromXthInputProcessed",  numberOfMappingsFromXthInputProcessed );
 		return s;
 	}
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/pushbased/PushBasedExecPlanTaskForNaryOperator.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/pushbased/PushBasedExecPlanTaskForNaryOperator.java
@@ -1,0 +1,61 @@
+package se.liu.ida.hefquin.engine.queryplan.executable.impl.pushbased;
+
+import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
+import se.liu.ida.hefquin.engine.queryplan.executable.ExecutableOperator;
+import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultBlock;
+import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
+import se.liu.ida.hefquin.engine.queryplan.executable.NaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecPlanTask;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecPlanTaskInputException;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecPlanTaskInterruptionException;
+import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
+
+public class PushBasedExecPlanTaskForNaryOperator extends PushBasedExecPlanTaskBase
+{
+	protected final NaryExecutableOp op;
+	protected final ExecPlanTask[] inputs;
+
+	public PushBasedExecPlanTaskForNaryOperator( final NaryExecutableOp op,
+	                                             final ExecPlanTask[] inputs,
+	                                             final ExecutionContext execCxt,
+	                                             final int minimumBlockSize ) {
+		super(execCxt, minimumBlockSize);
+
+		assert op != null;
+		assert inputs != null;
+		assert inputs.length > 0;
+
+		this.op = op;
+		this.inputs = inputs;
+	}
+
+	@Override
+	protected ExecutableOperator getExecOp() {
+		return op;
+	}
+
+	@Override
+	protected void produceOutput( final IntermediateResultElementSink sink )
+			throws ExecOpExecutionException, ExecPlanTaskInputException, ExecPlanTaskInterruptionException {
+
+		// Attention: the current implementation of this method simply consumes
+		// and pushes the complete i-th child input first before moving on to
+		// the (i+1)-th child. Hence, with this implementation we do not
+		// actually benefit from the parallelization.
+
+		for ( int i = 0; i < inputs.length; i++ ) {
+			boolean inputConsumed = false;
+			while ( ! inputConsumed ) {
+				final IntermediateResultBlock nextInputBlock = inputs[i].getNextIntermediateResultBlock();
+				if ( nextInputBlock != null ) {
+					op.processBlockFromXthChild(i, nextInputBlock, sink, execCxt);
+				}
+				else {
+					op.wrapUpForXthChild(i, sink, execCxt);
+					inputConsumed = true;
+				}
+			}
+		}
+	}
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/PhysicalPlanVisitor.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/PhysicalPlanVisitor.java
@@ -23,6 +23,7 @@ public interface PhysicalPlanVisitor
 	void visit( PhysicalOpHashRJoin op );
 
 	void visit( PhysicalOpBinaryUnion op );
+	void visit( PhysicalOpMultiwayUnion op );
 
 	void visit( PhysicalOpFilter op );
 	void visit( PhysicalOpLocalToGlobal op );

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpMultiwayUnion.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpMultiwayUnion.java
@@ -42,4 +42,9 @@ public class PhysicalOpMultiwayUnion implements NaryPhysicalOpForLogicalOp
 		return LogicalOpMultiwayUnion.getInstance().hashCode();
 	}
 
+	@Override
+	public String toString(){
+		return "> multiwayUnion ";
+	}
+
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpMultiwayUnion.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpMultiwayUnion.java
@@ -1,0 +1,45 @@
+package se.liu.ida.hefquin.engine.queryplan.physical.impl;
+
+import se.liu.ida.hefquin.engine.queryplan.ExpectedVariables;
+import se.liu.ida.hefquin.engine.queryplan.executable.NaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpMultiwayUnion;
+import se.liu.ida.hefquin.engine.queryplan.logical.NaryLogicalOp;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayUnion;
+import se.liu.ida.hefquin.engine.queryplan.physical.NaryPhysicalOpForLogicalOp;
+import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
+
+public class PhysicalOpMultiwayUnion implements NaryPhysicalOpForLogicalOp
+{
+
+	@Override
+	public ExpectedVariables getExpectedVariables( final ExpectedVariables... inputVars ) {
+		return getLogicalOperator().getExpectedVariables(inputVars);
+	}
+
+	@Override
+	public void visit( final PhysicalPlanVisitor visitor ) {
+		visitor.visit(this);
+	}
+
+	@Override
+	public NaryExecutableOp createExecOp( final boolean collectExceptions,
+	                                      final ExpectedVariables... inputVars) {
+		return new ExecOpMultiwayUnion( inputVars.length, collectExceptions );
+	}
+
+	@Override
+	public NaryLogicalOp getLogicalOperator() {
+		return LogicalOpMultiwayUnion.getInstance();
+	}
+
+	@Override
+	public boolean equals( final Object o ) {
+		return o instanceof PhysicalOpMultiwayUnion;
+	}
+
+	@Override
+	public int hashCode() {
+		return LogicalOpMultiwayUnion.getInstance().hashCode();
+	}
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalToPhysicalOpConverter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalToPhysicalOpConverter.java
@@ -238,7 +238,7 @@ public class LogicalToPhysicalOpConverter
 	}
 
 	public static NaryPhysicalOp convert( final LogicalOpMultiwayUnion lop ) {
-		throw new UnsupportedOperationException();
+		return new PhysicalOpMultiwayUnion();
 	}
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalToPhysicalPlanConverterImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalToPhysicalPlanConverterImpl.java
@@ -140,11 +140,6 @@ public class LogicalToPhysicalPlanConverterImpl implements LogicalToPhysicalPlan
 			else if ( lop instanceof LogicalOpMultiwayLeftJoin ) {
 				return createPhysicalPlanForMultiwayLeftJoin( (LogicalOpMultiwayLeftJoin) lop, children, keepMultiwayJoins );
 			}
-			else if ( lop instanceof LogicalOpMultiwayUnion ) {
-				// TODO: remove this else-if branch, including the method that it
-				// calls, once we have a physical operator for multiway union 
-				return createPhysicalPlanForMultiwayUnion( (LogicalOpMultiwayUnion) lop, children );
-			}
 			else {
 				return PhysicalPlanFactory.createPlan(lop, children);
 			}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/PhysicalPlanPrinter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/PhysicalPlanPrinter.java
@@ -128,6 +128,14 @@ public class PhysicalPlanPrinter extends PlanPrinter{
         }
 
         @Override
+        public void visit( final PhysicalOpMultiwayUnion op ) {
+            addTabs();
+            builder.append( op.toString() );
+            builder.append( System.lineSeparator() );
+            indentLevel++;
+        }
+
+        @Override
         public void visit( final PhysicalOpFilter op ) {
             addTabs();
             builder.append( op.toString() );
@@ -221,6 +229,11 @@ public class PhysicalPlanPrinter extends PlanPrinter{
 
         @Override
         public void visit(final PhysicalOpBinaryUnion op) {
+            indentLevel--;
+        }
+
+        @Override
+        public void visit(final PhysicalOpMultiwayUnion op) {
             indentLevel--;
         }
 

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/compiler/PullBasedQueryPlanCompilerImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/compiler/PullBasedQueryPlanCompilerImpl.java
@@ -1,6 +1,7 @@
 package se.liu.ida.hefquin.engine.queryproc.impl.compiler;
 
 import se.liu.ida.hefquin.engine.queryplan.executable.BinaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.executable.NaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.NullaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecPlanTask;
@@ -38,6 +39,14 @@ public class PullBasedQueryPlanCompilerImpl extends TaskBasedQueryPlanCompilerBa
 	                                                  final ExecutionContext execCxt,
 	                                                  final int preferredOutputBlockSize ) {
 		return new PullBasedExecPlanTaskForBinaryOperator(op, childTask1, childTask2, execCxt, preferredOutputBlockSize);
+	}
+
+	@Override
+	protected ExecPlanTask createTaskForNaryExecOp( final NaryExecutableOp op,
+	                                                final ExecPlanTask[] childTasks,
+	                                                final ExecutionContext execCxt,
+	                                                final int preferredOutputBlockSize ) {
+		throw new UnsupportedOperationException();
 	}
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/compiler/PushBasedQueryPlanCompilerImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/compiler/PushBasedQueryPlanCompilerImpl.java
@@ -5,12 +5,14 @@ import java.util.LinkedList;
 import java.util.Map;
 
 import se.liu.ida.hefquin.engine.queryplan.executable.BinaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.executable.NaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.NullaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecPlanTask;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.pushbased.ConnectorForAdditionalConsumer;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.pushbased.PushBasedExecPlanTask;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.pushbased.PushBasedExecPlanTaskForBinaryOperator;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.pushbased.PushBasedExecPlanTaskForNaryOperator;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.pushbased.PushBasedExecPlanTaskForNullaryOperator;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.pushbased.PushBasedExecPlanTaskForUnaryOperator;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
@@ -45,6 +47,14 @@ public class PushBasedQueryPlanCompilerImpl extends TaskBasedQueryPlanCompilerBa
 	                                                  final ExecutionContext execCxt,
 	                                                  final int preferredOutputBlockSize ) {
 		return new PushBasedExecPlanTaskForBinaryOperator(op, childTask1, childTask2, execCxt, preferredOutputBlockSize);
+	}
+
+	@Override
+	protected ExecPlanTask createTaskForNaryExecOp( final NaryExecutableOp op,
+	                                                final ExecPlanTask[] childTasks,
+	                                                final ExecutionContext execCxt,
+	                                                final int preferredOutputBlockSize ) {
+		return new PushBasedExecPlanTaskForNaryOperator(op, childTasks, execCxt, preferredOutputBlockSize);
 	}
 
 	@Override

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/compiler/TaskBasedQueryPlanCompilerBase.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/compiler/TaskBasedQueryPlanCompilerBase.java
@@ -2,13 +2,20 @@ package se.liu.ida.hefquin.engine.queryproc.impl.compiler;
 
 import java.util.LinkedList;
 
+import se.liu.ida.hefquin.engine.queryplan.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.BinaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutablePlan;
+import se.liu.ida.hefquin.engine.queryplan.executable.NaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.NullaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecPlanTask;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.TaskBasedExecutablePlanImpl;
+import se.liu.ida.hefquin.engine.queryplan.physical.BinaryPhysicalOp;
+import se.liu.ida.hefquin.engine.queryplan.physical.NaryPhysicalOp;
+import se.liu.ida.hefquin.engine.queryplan.physical.NullaryPhysicalOp;
+import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
+import se.liu.ida.hefquin.engine.queryplan.physical.UnaryPhysicalOp;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 import se.liu.ida.hefquin.engine.queryproc.QueryProcContext;
 
@@ -51,28 +58,29 @@ public abstract class TaskBasedQueryPlanCompilerBase extends QueryPlanCompilerBa
 		                                     final LinkedList<ExecPlanTask> tasks,
 		                                     final int preferredOutputBlockSize,
 		                                     final ExecutionContext execCxt ) {
-			if ( qep.numberOfSubPlans() == 0 )
+			final PhysicalOperator pop = qep.getRootOperator();
+			if ( pop instanceof NullaryPhysicalOp )
 			{
-				final NullaryExecutableOp execOp = (NullaryExecutableOp) qep.getRootOperator().createExecOp(true);
+				final NullaryExecutableOp execOp = (NullaryExecutableOp) pop.createExecOp(true);
 				return createTaskForNullaryExecOp(execOp, execCxt, preferredOutputBlockSize);
 			}
-			else if ( qep.numberOfSubPlans() == 1 )
+			else if ( pop instanceof UnaryPhysicalOp )
 			{
 				final PhysicalPlan subPlan = qep.getSubPlan(0);
 
-				final UnaryExecutableOp execOp = (UnaryExecutableOp) qep.getRootOperator().createExecOp( true, subPlan.getExpectedVariables() );
+				final UnaryExecutableOp execOp = (UnaryExecutableOp) pop.createExecOp( true, subPlan.getExpectedVariables() );
 
 				createTasks( subPlan, tasks, execOp.preferredInputBlockSize(), execCxt );
 				final ExecPlanTask childTask = tasks.getFirst();
 
 				return createTaskForUnaryExecOp(execOp, childTask, execCxt, preferredOutputBlockSize);
 			}
-			else if ( qep.numberOfSubPlans() == 2 )
+			else if ( pop instanceof BinaryPhysicalOp )
 			{
 				final PhysicalPlan subPlan1 = qep.getSubPlan(0);
 				final PhysicalPlan subPlan2 = qep.getSubPlan(1);
 
-				final BinaryExecutableOp execOp = (BinaryExecutableOp) qep.getRootOperator().createExecOp(
+				final BinaryExecutableOp execOp = (BinaryExecutableOp) pop.createExecOp(
 						true,
 						subPlan1.getExpectedVariables(),
 						subPlan2.getExpectedVariables() );
@@ -84,6 +92,27 @@ public abstract class TaskBasedQueryPlanCompilerBase extends QueryPlanCompilerBa
 				final ExecPlanTask childTask2 = tasks.getFirst();
 
 				return createTaskForBinaryExecOp(execOp, childTask1, childTask2, execCxt, preferredOutputBlockSize);
+			}
+			else if ( pop instanceof NaryPhysicalOp )
+			{
+				final ExpectedVariables[] expVars = new ExpectedVariables[ qep.numberOfSubPlans() ];
+				for ( int i = 0; i < expVars.length; i++ ) {
+					expVars[i] = qep.getSubPlan(i).getExpectedVariables();
+				}
+
+				final NaryExecutableOp execOp = (NaryExecutableOp) pop.createExecOp(true, expVars);
+
+				final ExecPlanTask[] childTasks = new ExecPlanTask[ qep.numberOfSubPlans() ];
+				for ( int i = 0; i < childTasks.length; i++ ) {
+					createTasks( qep.getSubPlan(i),
+					             tasks,
+					             execOp.preferredInputBlockSizeFromChilden(),
+					             execCxt );
+
+					childTasks[i] = tasks.getFirst();
+				}
+
+				return createTaskForNaryExecOp(execOp, childTasks, execCxt, preferredOutputBlockSize);
 			}
 			else
 			{
@@ -107,4 +136,9 @@ public abstract class TaskBasedQueryPlanCompilerBase extends QueryPlanCompilerBa
 	                                                           ExecPlanTask childTask2,
 	                                                           ExecutionContext execCxt,
 	                                                           int preferredOutputBlockSize );
+
+	protected abstract ExecPlanTask createTaskForNaryExecOp( NaryExecutableOp op,
+	                                                         ExecPlanTask[] childTasks,
+	                                                         ExecutionContext execCxt,
+	                                                         int preferredOutputBlockSize );
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpMultiwayUnionTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpMultiwayUnionTest.java
@@ -1,0 +1,36 @@
+package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
+
+import org.junit.Test;
+
+import se.liu.ida.hefquin.engine.queryplan.executable.NaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryproc.ExecutionException;
+
+public class ExecOpMultiwayUnionTest extends TestsForUnionAlgorithms
+{
+	@Test
+	public void testSimpleUnion() throws ExecutionException {
+		_testSimpleUnion();
+	}
+	
+	@Test
+	public void testUnboundUnion() throws ExecutionException {
+		_testUnboundUnion();
+	}
+	
+	@Test
+	public void testKeepUnionDuplicates() throws ExecutionException {
+		_testKeepUnionDuplicates();
+	}
+	
+	@Test
+	public void testKeepUnionDuplicatesFromSameMember() throws ExecutionException {
+		_testKeepUnionDuplicatesFromSameMember();
+	}
+
+	@Override
+	protected NaryExecutableOp createExecOpForTest() {
+		// TODO Auto-generated method stub
+		return new ExecOpMultiwayUnion(2, false);
+	}
+
+}

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/TestsForUnionAlgorithms.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/TestsForUnionAlgorithms.java
@@ -20,7 +20,9 @@ import org.apache.jena.sparql.engine.binding.Binding;
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.data.utils.SolutionMappingUtils;
 import se.liu.ida.hefquin.engine.queryplan.executable.BinaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.executable.ExecutableOperator;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultBlock;
+import se.liu.ida.hefquin.engine.queryplan.executable.NaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.GenericIntermediateResultBlockImpl;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.CollectingIntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionException;
@@ -289,12 +291,23 @@ public abstract class TestsForUnionAlgorithms extends ExecOpTestBase {
 	{
 		final CollectingIntermediateResultElementSink sink = new CollectingIntermediateResultElementSink();
 		
-		final BinaryExecutableOp op = createExecOpForTest();
-		op.processBlockFromChild1(input1, sink, null);
-		op.processBlockFromChild2(input2, sink, null);
+		final ExecutableOperator op = createExecOpForTest();
+
+		if ( op instanceof BinaryExecutableOp ) {
+			( (BinaryExecutableOp) op).processBlockFromChild1(input1, sink, null);
+			( (BinaryExecutableOp) op).processBlockFromChild2(input2, sink, null);
+		}
+		else if ( op instanceof NaryExecutableOp ) {
+			( (NaryExecutableOp) op).processBlockFromXthChild(0, input1, sink, null);
+			( (NaryExecutableOp) op).processBlockFromXthChild(1, input2, sink, null);
+		}
+		else {
+			throw new IllegalArgumentException();
+		}
+
 		return sink.getCollectedSolutionMappings().iterator();
 	}
 
-	protected abstract BinaryExecutableOp createExecOpForTest() ;
+	protected abstract ExecutableOperator createExecOpForTest() ;
 	
 }


### PR DESCRIPTION
closes #123 

@chengsijin0817 Just for your information, I have implemented a physical operator for multiway unions. This way, we do not anymore need to convert logical multiway unions into a left-deep trees of binary unions on the physical plan level. This has two advantages: First, we need only one thread per multiway union. Second, the printed plans are easier to read.