### PR TITLE
Cardinality based greedy join plan optimizer

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/HeFQUINEngineConfig.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/HeFQUINEngineConfig.java
@@ -18,7 +18,6 @@ import se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.evolutionaryAlgorithm
 import se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.evolutionaryAlgorithm.TerminatedByNumberOfGenerations;
 import se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.evolutionaryAlgorithm.TerminationCriterionFactory;
 import se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.simple.*;
-import se.liu.ida.hefquin.engine.queryproc.impl.srcsel.ExhaustiveSourcePlannerImpl;
 import se.liu.ida.hefquin.engine.queryproc.impl.srcsel.ServiceClauseBasedSourcePlannerImpl;
 import se.liu.ida.hefquin.jenaintegration.sparql.HeFQUINConstants;
 
@@ -74,6 +73,7 @@ public class HeFQUINEngineConfig
 			public PhysicalOptimizer createQueryOptimizer( final QueryOptimizationContext ctxt ) {
 //				return createQueryOptimizerWithoutOptimization(ctxt);
 //				return createGreedyJoinPlanOptimizer(ctxt);
+//				return createGreedyBasedTwoPhaseJoinPlanOptimizerImpl(ctxt);
 				return createDPBasedBushyJoinPlanOptimizer(ctxt);
 //				return createDPBasedLinearJoinPlanOptimizer(ctxt);
 //				return createEvolutionaryAlgorithmQueryOptimizer(ctxt);
@@ -86,7 +86,12 @@ public class HeFQUINEngineConfig
 	}
 
 	protected PhysicalOptimizer createGreedyJoinPlanOptimizer( final QueryOptimizationContext ctxt ) {
-		final JoinPlanOptimizer joinOpt = new GreedyJoinPlanOptimizerImpl( ctxt.getCostModel() );
+		final JoinPlanOptimizer joinOpt = new CostModelBasedGreedyJoinPlanOptimizerImpl( ctxt.getCostModel() );
+		return new SimpleJoinOrderingQueryOptimizer(joinOpt, ctxt);
+	}
+
+	protected PhysicalOptimizer createGreedyBasedTwoPhaseJoinPlanOptimizerImpl( final QueryOptimizationContext ctxt ) {
+		final JoinPlanOptimizer joinOpt = new CardinalityBasedGreedyJoinPlanOptimizerImpl( ctxt.getFederationAccessMgr() );
 		return new SimpleJoinOrderingQueryOptimizer(joinOpt, ctxt);
 	}
 

--- a/src/main/java/se/liu/ida/hefquin/engine/HeFQUINEngineConfig.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/HeFQUINEngineConfig.java
@@ -18,6 +18,7 @@ import se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.evolutionaryAlgorithm
 import se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.evolutionaryAlgorithm.TerminatedByNumberOfGenerations;
 import se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.evolutionaryAlgorithm.TerminationCriterionFactory;
 import se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.simple.*;
+import se.liu.ida.hefquin.engine.queryproc.impl.srcsel.ExhaustiveSourcePlannerImpl;
 import se.liu.ida.hefquin.engine.queryproc.impl.srcsel.ServiceClauseBasedSourcePlannerImpl;
 import se.liu.ida.hefquin.jenaintegration.sparql.HeFQUINConstants;
 

--- a/src/main/java/se/liu/ida/hefquin/engine/HeFQUINEngineConfig.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/HeFQUINEngineConfig.java
@@ -72,8 +72,8 @@ public class HeFQUINEngineConfig
 			@Override
 			public PhysicalOptimizer createQueryOptimizer( final QueryOptimizationContext ctxt ) {
 //				return createQueryOptimizerWithoutOptimization(ctxt);
-//				return createGreedyJoinPlanOptimizer(ctxt);
-//				return createGreedyBasedTwoPhaseJoinPlanOptimizerImpl(ctxt);
+//				return createCostModelBasedGreedyJoinPlanOptimizerImpl(ctxt);
+//				return createCardinalityBasedGreedyJoinPlanOptimizerImpl(ctxt);
 				return createDPBasedBushyJoinPlanOptimizer(ctxt);
 //				return createDPBasedLinearJoinPlanOptimizer(ctxt);
 //				return createEvolutionaryAlgorithmQueryOptimizer(ctxt);
@@ -85,12 +85,12 @@ public class HeFQUINEngineConfig
 		return new PhysicalOptimizerImpl(ctxt);
 	}
 
-	protected PhysicalOptimizer createGreedyJoinPlanOptimizer( final QueryOptimizationContext ctxt ) {
+	protected PhysicalOptimizer createCostModelBasedGreedyJoinPlanOptimizerImpl( final QueryOptimizationContext ctxt ) {
 		final JoinPlanOptimizer joinOpt = new CostModelBasedGreedyJoinPlanOptimizerImpl( ctxt.getCostModel() );
 		return new SimpleJoinOrderingQueryOptimizer(joinOpt, ctxt);
 	}
 
-	protected PhysicalOptimizer createGreedyBasedTwoPhaseJoinPlanOptimizerImpl( final QueryOptimizationContext ctxt ) {
+	protected PhysicalOptimizer createCardinalityBasedGreedyJoinPlanOptimizerImpl( final QueryOptimizationContext ctxt ) {
 		final JoinPlanOptimizer joinOpt = new CardinalityBasedGreedyJoinPlanOptimizerImpl( ctxt.getFederationAccessMgr() );
 		return new SimpleJoinOrderingQueryOptimizer(joinOpt, ctxt);
 	}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/PhysicalPlanFactory.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/PhysicalPlanFactory.java
@@ -672,7 +672,7 @@ public class PhysicalPlanFactory
 			newUnionSubPlans[i] = newSubPlan;
 		}
 
-		return PhysicalPlanFactory.createPlan( LogicalOpMultiwayUnion.getInstance(), newUnionSubPlans );
+		return createPlan( LogicalOpMultiwayUnion.getInstance(), newUnionSubPlans );
 	}
 
 	/**

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/PhysicalPlanFactory.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/PhysicalPlanFactory.java
@@ -716,23 +716,20 @@ public class PhysicalPlanFactory
 			return false;
 		}
 
-		boolean applicable = true;
 		for ( int i = 0; i < unionPlan.numberOfSubPlans(); i++ ) {
 			final PhysicalPlan subPlan = unionPlan.getSubPlan(i);
 			final PhysicalOperator subRootOp = subPlan.getRootOperator();
 			if ( !(subRootOp instanceof PhysicalOpRequest || subRootOp instanceof PhysicalOpFilter) ) {
-				applicable = false;
-				break;
+				return false;
 			}
 
 			if ( subRootOp instanceof PhysicalOpFilter){
 				if ( !( subPlan.getSubPlan(0) instanceof PhysicalOpRequest) ){
-					applicable = false;
-					break;
+					return false;
 				}
 			}
 		}
-		return applicable;
+		return true;
 	}
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/PhysicalPlanFactory.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/PhysicalPlanFactory.java
@@ -704,7 +704,7 @@ public class PhysicalPlanFactory
 				throw new IllegalArgumentException("Unsupported type of subquery under UNION");
 		}
 		else
-			return PhysicalPlanFactory.createPlanWithJoin(inputPlan, nextPlan);
+			return createPlanWithJoin(inputPlan, nextPlan);
 	}
 
 	/**

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/PhysicalPlanFactory.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/PhysicalPlanFactory.java
@@ -659,9 +659,11 @@ public class PhysicalPlanFactory
 	}
 
 	/**
-	 * If the right input of a join is a union with requests,
-	 * this function turns the requests into xxAdd operators with the previous join arguments as subplans.
-	 **/
+	 * This function take a inputPlan and unionPlan as input,
+	 * where the unionPlan is required to be a plan with union as root operator, and all subPlans under the UNION are all requests or filters with request.
+	 *
+	 * In such cases, this function turns the requests under UNION into xxAdd operators with the inputPlan as subplans.
+	 */
 	public static PhysicalPlan createPlanWithUnaryOpForUnionPlan( final PhysicalPlan inputPlan, final PhysicalPlan unionPlan ) {
 		final int numberOfSubPlansUnderUnion = unionPlan.numberOfSubPlans();
 		final PhysicalPlan[] newUnionSubPlans = new PhysicalPlan[numberOfSubPlansUnderUnion];
@@ -676,10 +678,10 @@ public class PhysicalPlanFactory
 	}
 
 	/**
-	 * If the right input of a join operator is a request, filter with request, or union with requests,
-	 * this function turns the requests into xxAdd operators with the previous join arguments as subplans.
+	 * If the nextPlan is in the form of a request, filter with request, or union with requests,
+	 * this function turns the requests into xxAdd operators with the inputPlan as subplans.
 	 *
-	 * Otherwise, create a plan with a binary join as root operator (using the default physical operator).
+	 * Otherwise, it constructs a plan with a binary join between inputPlan and nextPlan (using the default physical operator)
 	 **/
 	public static PhysicalPlan createPlanWithDefaultUnaryOpIfPossible( final PhysicalPlan inputPlan, final PhysicalPlan nextPlan ) {
 		final PhysicalOperator oldSubPlanRootOp = nextPlan.getRootOperator();

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CFRNumberOfRequests.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CFRNumberOfRequests.java
@@ -17,7 +17,7 @@ import se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.CardinalityEstimation
 
 public class CFRNumberOfRequests extends CFRBase
 {
-	public static final int defaultPageSize = 30;
+	public static final int defaultPageSize = 100;
 	public CFRNumberOfRequests( final CardinalityEstimation cardEstimate ) {
 		super(cardEstimate);
 	}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CFRNumberOfRequests.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CFRNumberOfRequests.java
@@ -17,6 +17,7 @@ import se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.CardinalityEstimation
 
 public class CFRNumberOfRequests extends CFRBase
 {
+	public static final int defaultPageSize = 30;
 	public CFRNumberOfRequests( final CardinalityEstimation cardEstimate ) {
 		super(cardEstimate);
 	}
@@ -25,7 +26,7 @@ public class CFRNumberOfRequests extends CFRBase
 	public CompletableFuture<Integer> initiateCostEstimation( final PhysicalPlan plan ) {
 		final PhysicalOperator rootOp = plan.getRootOperator();
 
-		final double pageSize = 100.0;
+		final double pageSize = defaultPageSize;
 		final double blockSize = BaseForExecOpBindJoin.defaultPreferredInputBlockSize;
 		final CompletableFuture<Integer> numReq;
 

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/simple/CardinalityBasedGreedyJoinPlanOptimizerImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/simple/CardinalityBasedGreedyJoinPlanOptimizerImpl.java
@@ -204,7 +204,7 @@ public class CardinalityBasedGreedyJoinPlanOptimizerImpl extends JoinPlanOptimiz
                 accNumBJ += currentPlan.getCandidate() / blockSize;
             }
 
-            PhysicalPlan newPlan;
+            final PhysicalPlan newPlan;
             if ( accNumSHJ <= accNumBJ ) {
                 newPlan = PhysicalPlanFactory.createPlanWithJoin(currentPlan.plan, nextPlan.plan);
             }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/simple/CardinalityBasedGreedyJoinPlanOptimizerImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/simple/CardinalityBasedGreedyJoinPlanOptimizerImpl.java
@@ -264,23 +264,15 @@ public class CardinalityBasedGreedyJoinPlanOptimizerImpl extends JoinPlanOptimiz
 
     class PhysicalPlanWithStatistics {
         public final PhysicalPlan plan;
-        protected int cardinality;
-        protected int numOfAccess;
-        protected List<FederationMember> fms;
-
-        public PhysicalPlanWithStatistics( final PhysicalPlan plan ){
-            this.plan = plan;
-        }
+        protected final int cardinality;
+        protected final int numOfAccess;
+        protected final List<FederationMember> fms;
 
         public PhysicalPlanWithStatistics( final PhysicalPlan plan, final List<FederationMember> fms, final int cardinality, final int numOfAccess ){
             this.plan = plan;
             this.fms = fms;
             this.cardinality = cardinality;
             this.numOfAccess = numOfAccess;
-        }
-
-        public void setCardinality( final int cardinality ){
-            this.cardinality = cardinality;
         }
 
         public int getCardinality( ){

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/simple/CardinalityBasedGreedyJoinPlanOptimizerImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/simple/CardinalityBasedGreedyJoinPlanOptimizerImpl.java
@@ -1,0 +1,260 @@
+package se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.simple;
+
+import se.liu.ida.hefquin.engine.federation.BRTPFServer;
+import se.liu.ida.hefquin.engine.federation.FederationMember;
+import se.liu.ida.hefquin.engine.federation.SPARQLEndpoint;
+import se.liu.ida.hefquin.engine.federation.TPFServer;
+import se.liu.ida.hefquin.engine.federation.access.*;
+import se.liu.ida.hefquin.engine.federation.access.impl.req.BRTPFRequestImpl;
+import se.liu.ida.hefquin.engine.federation.access.impl.req.TPFRequestImpl;
+import se.liu.ida.hefquin.engine.federation.access.utils.FederationAccessUtils;
+import se.liu.ida.hefquin.engine.federation.access.utils.RequestMemberPair;
+import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalOperator;
+import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
+import se.liu.ida.hefquin.engine.queryplan.physical.impl.*;
+import se.liu.ida.hefquin.engine.queryplan.utils.PhysicalPlanFactory;
+import se.liu.ida.hefquin.engine.queryproc.PhysicalOptimizationException;
+
+import java.util.*;
+
+/**
+ * This class implements a query optimizer that builds left-deep query plans,
+ * for which it uses a greedy approach to determine the join order based on cardinality estimation,
+ * and then choose physical algorithm according to the estimated number of request to execute the join.
+ */
+public class CardinalityBasedGreedyJoinPlanOptimizerImpl extends JoinPlanOptimizerBase
+{
+    protected final FederationAccessManager fedAccessMgr;
+
+    public CardinalityBasedGreedyJoinPlanOptimizerImpl(final FederationAccessManager fedAccessMgr ) {
+        this.fedAccessMgr = fedAccessMgr;
+    }
+
+    @Override
+	public EnumerationAlgorithm initializeEnumerationAlgorithm( final List<PhysicalPlan> subplans ) {
+		return new GreedyConstructionAlgorithm(subplans);
+	}
+
+	protected class GreedyConstructionAlgorithm implements EnumerationAlgorithm {
+        protected final List<PhysicalPlan> subplans;
+
+        public GreedyConstructionAlgorithm( final List<PhysicalPlan> subplans ) {
+            this.subplans = subplans;
+        }
+
+        public PhysicalPlan getResultingPlan() throws PhysicalOptimizationException {
+            final List<RequestMemberPair> flattenRequestMemPairs = new ArrayList<>();
+            for ( final PhysicalPlan plan : subplans ) {
+                flattenRequestMemPairs.addAll( createRequestMemPairsFromSourceAssignment(plan) );
+            }
+
+            final CardinalityResponse[] resps;
+            try {
+                resps = FederationAccessUtils.performCardinalityRequests(fedAccessMgr, flattenRequestMemPairs.toArray(new RequestMemberPair[0]));
+            } catch (final FederationAccessException e) {
+                throw new RuntimeException("Issuing a cardinality request caused an exception.", e);
+            }
+
+            final List<PhysicalPlanWithStatistics> subPlansWithStatistics = associateCardWithSubPlans( flattenRequestMemPairs, resps);
+
+            PhysicalPlanWithStatistics currentPlan = null;
+            for ( int k = 0; k < subplans.size(); k++ ) {
+                final PhysicalPlanWithStatistics nextPlan = chooseNextSubPlanBasedOnCard(subPlansWithStatistics);
+                if ( k == 0 ) {
+                    currentPlan = nextPlan;
+                }
+                else {
+                    currentPlan = decidePhysicalAlgorithm( currentPlan, nextPlan );
+                }
+
+                subPlansWithStatistics.remove( nextPlan );
+            }
+
+            return currentPlan.plan;
+        }
+
+        protected List<RequestMemberPair> createRequestMemPairsFromSourceAssignment( final PhysicalPlan plan ) {
+            final PhysicalOperator pop = plan.getRootOperator();
+
+            if (pop instanceof PhysicalOpRequest) {
+                return new ArrayList<>( Arrays.asList(getRequestMemPairFromRequest((PhysicalOpRequest) pop)) );
+            }
+            else if (pop instanceof PhysicalOpFilter) {
+                return new ArrayList<>( Arrays.asList( getRequestMemPairFromRequest((PhysicalOpRequest) plan.getSubPlan(0))) );
+            }
+            else if (pop instanceof PhysicalOpBinaryUnion || pop instanceof PhysicalOpMultiwayUnion) {
+                final List<RequestMemberPair> requestMemPairs = new ArrayList<>();
+                final int numOfSubPlans = plan.numberOfSubPlans();
+                for (int i = 0; i < numOfSubPlans; i++) {
+                    requestMemPairs.addAll( createRequestMemPairsFromSourceAssignment(plan.getSubPlan(i)) );
+                }
+                return requestMemPairs;
+            } else
+                throw new IllegalArgumentException("Unsupported type of subquery in source assignment (" + pop.getClass().getName() + ")");
+        }
+
+        protected RequestMemberPair getRequestMemPairFromRequest( final PhysicalOpRequest pop ) {
+            final FederationMember fm = pop.getLogicalOperator().getFederationMember();
+            DataRetrievalRequest req = pop.getLogicalOperator().getRequest();
+            if ( fm instanceof TPFServer ) {
+                req = ensureTPFRequest( (TriplePatternRequest) req );
+            }
+            else if ( fm instanceof BRTPFServer && req instanceof TriplePatternRequest ) {
+                req = ensureTPFRequest( (TriplePatternRequest) req );
+            }
+            else if ( fm instanceof BRTPFServer && req instanceof BindingsRestrictedTriplePatternRequest ) {
+                req = ensureBRTPFRequest( (BindingsRestrictedTriplePatternRequest) req );
+            }
+
+            return new RequestMemberPair(req, fm);
+        }
+
+        protected TPFRequest ensureTPFRequest( final TriplePatternRequest req ) {
+            if ( req instanceof TPFRequest ) {
+                return (TPFRequest) req;
+            }
+            else {
+                return new TPFRequestImpl( req.getQueryPattern() );
+            }
+        }
+
+        protected BRTPFRequest ensureBRTPFRequest( final BindingsRestrictedTriplePatternRequest req ) {
+            if ( req instanceof BRTPFRequest ) {
+                return (BRTPFRequest) req;
+            }
+            else {
+                return new BRTPFRequestImpl( req.getTriplePattern(), req.getSolutionMappings() );
+            }
+        }
+
+        protected List<PhysicalPlanWithStatistics> associateCardWithSubPlans( final List<RequestMemberPair> flattenRequestMemPairs, final CardinalityResponse[] resps ){
+            final List<PhysicalPlanWithStatistics> subPlansWithStatistics = new ArrayList<>();
+
+            int index = 0;
+            for ( final PhysicalPlan plan : subplans ) {
+                final PhysicalOperator pop = plan.getRootOperator();
+
+                final PhysicalPlanWithStatistics planWithStatistics = new PhysicalPlanWithStatistics(plan);
+                if ( pop instanceof PhysicalOpRequest || pop instanceof PhysicalOpFilter ) {
+                    planWithStatistics.addCandidate( resps[index].getCardinality() );
+
+                    final FederationMember fm = flattenRequestMemPairs.get(index).getMember();
+                    planWithStatistics.addNumOfAccess( accessNumForReq( resps[index].getCardinality(), fm ) );
+
+                    index++;
+                }
+                else if (pop instanceof PhysicalOpBinaryUnion || pop instanceof PhysicalOpMultiwayUnion) {
+                    int sumCard = 0, sumAccess = 0;
+                    for ( int count = 0; count < plan.numberOfSubPlans(); count++ ) {
+                        sumCard += resps[index].getCardinality();
+
+                        final FederationMember fm = flattenRequestMemPairs.get(index).getMember();
+                        sumAccess += accessNumForReq( resps[index].getCardinality(), fm );
+
+                        index++;
+                    }
+
+                    planWithStatistics.addCandidate( sumCard );
+                    planWithStatistics.addNumOfAccess( sumAccess );
+                }
+                else
+                    throw new IllegalArgumentException("Unsupported type of subquery in source assignment (" + pop.getClass().getName() + ")");
+
+                subPlansWithStatistics.add( planWithStatistics );
+            }
+
+            return subPlansWithStatistics;
+        }
+
+        /**
+         * Compares all available subplans in terms of their cardinality estimation
+         * and returns the one with the lowest estimated cardinality.
+         */
+        protected PhysicalPlanWithStatistics chooseNextSubPlanBasedOnCard( final List<PhysicalPlanWithStatistics> subPlansWithStatistics ) {
+            PhysicalPlanWithStatistics bestPlanWithCandidate = subPlansWithStatistics.get(0);
+            int lowestCost = bestPlanWithCandidate.getCandidate();
+
+            for ( int i = 1; i < subPlansWithStatistics.size(); i++ ) {
+                PhysicalPlanWithStatistics current = subPlansWithStatistics.get(i);
+                if ( current.getCandidate() < lowestCost ) {
+                    lowestCost = current.getCandidate();
+                    bestPlanWithCandidate = current;
+                }
+            }
+
+            return bestPlanWithCandidate;
+        }
+
+        /**
+         * The physical algorithm is determined based on the estimated number of requests to execute the join
+         * - SHJ: Card(T1)/PageSize + Card(T2)/PageSize
+         * - BJ: Card(T1)/PageSize + Card(T1)/blockSize
+         * For the comparison, only keeping the second element is enough.
+         */
+        protected PhysicalPlanWithStatistics decidePhysicalAlgorithm( final PhysicalPlanWithStatistics currentPlan, final PhysicalPlanWithStatistics nextPlan ) {
+            final double blockSize = 30;
+            final double accNumSHJ = // currentPlan.getNumOfAccess() +
+                                        nextPlan.getNumOfAccess();
+            final double accNumBJ = // currentPlan.getNumOfAccess() +
+                                       currentPlan.getCandidate() / blockSize;
+
+            PhysicalPlan newPlan = null;
+            if ( accNumSHJ <= accNumBJ ) {
+                newPlan = PhysicalPlanFactory.createPlanWithJoin(currentPlan.plan, nextPlan.plan);
+            }
+            else {
+                newPlan = PhysicalPlanFactory.createPlanWithDefaultUnaryOpIfPossible(currentPlan.plan, nextPlan.plan);
+            }
+
+            final PhysicalPlanWithStatistics newPlanWithStatistics = new PhysicalPlanWithStatistics( newPlan );
+
+            final int joinCardinality = Math.min( currentPlan.getCandidate(), nextPlan.getCandidate() );
+            newPlanWithStatistics.addCandidate( joinCardinality );
+
+            return newPlanWithStatistics;
+        }
+
+        /**
+         * The number of requests depends on the page size of response.
+         */
+        protected int accessNumForReq( final int cardinality, final FederationMember fm ) {
+            if ( fm instanceof SPARQLEndpoint){
+                return 1;
+            }
+            else if ( (fm instanceof TPFServer) || (fm instanceof BRTPFServer) ){
+                final double pageSize = 100.0;
+                return (int) Math.ceil( cardinality/pageSize );
+            }
+            else
+                throw new IllegalArgumentException("Unsupported type of federation member: " + fm.getClass().getName() );
+        }
+    }
+        
+}
+
+class PhysicalPlanWithStatistics {
+    public final PhysicalPlan plan;
+    protected int candidate;
+    protected int numOfAccess;
+
+    public PhysicalPlanWithStatistics( final PhysicalPlan plan ){
+        this.plan = plan;
+    }
+
+    public void addCandidate( final int candidate ){
+        this.candidate = candidate;
+    }
+
+    public void addNumOfAccess( final int numOfAccess ){
+        this.numOfAccess = numOfAccess;
+    }
+
+    public int getCandidate( ){
+        return candidate;
+    }
+
+    public int getNumOfAccess( ){
+        return numOfAccess;
+    }
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/simple/CardinalityBasedGreedyJoinPlanOptimizerImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/simple/CardinalityBasedGreedyJoinPlanOptimizerImpl.java
@@ -240,10 +240,7 @@ public class CardinalityBasedGreedyJoinPlanOptimizerImpl extends JoinPlanOptimiz
          * The block size (number of bindings can be attached) depends on the type of interface
          */
         protected double setBlockSize( final FederationMember fm ) {
-            if ( fm instanceof SPARQLEndpoint ){
-                return 50;
-            }
-            else if ( fm instanceof BRTPFServer ){
+            if ( (fm instanceof SPARQLEndpoint) || (fm instanceof BRTPFServer) ){
                 return 30;
             }
             else if ( fm instanceof TPFServer ){

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/simple/CardinalityBasedGreedyJoinPlanOptimizerImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/simple/CardinalityBasedGreedyJoinPlanOptimizerImpl.java
@@ -198,9 +198,8 @@ public class CardinalityBasedGreedyJoinPlanOptimizerImpl extends JoinPlanOptimiz
         protected PhysicalPlanWithStatistics decidePhysicalAlgorithm( final PhysicalPlanWithStatistics currentPlan, final PhysicalPlanWithStatistics nextPlan ) {
             final double accNumSHJ = nextPlan.getNumOfAccess();
 
-            final List<FederationMember> fms = nextPlan.getFederationMembers();
             double accNumBJ = 0;
-            for ( final FederationMember fm: fms ) {
+            for ( final FederationMember fm: nextPlan.getFederationMembers() ) {
                 double blockSize = setBlockSize(fm);
                 accNumBJ += currentPlan.getCandidate() / blockSize;
             }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/simple/CardinalityBasedGreedyJoinPlanOptimizerImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/simple/CardinalityBasedGreedyJoinPlanOptimizerImpl.java
@@ -229,10 +229,7 @@ public class CardinalityBasedGreedyJoinPlanOptimizerImpl extends JoinPlanOptimiz
             final int joinCardinality = Math.min( currentPlan.getCardinality(), nextPlan.getCardinality() );
 
             // The list of fed.members and numOfAccess will not be accessed anymore for this new PhysicalPlanWithStatistics object
-            final PhysicalPlanWithStatistics newPlanWithStatistics = new PhysicalPlanWithStatistics( newPlan );
-            newPlanWithStatistics.setCardinality( joinCardinality );
-
-            return newPlanWithStatistics;
+            return new PhysicalPlanWithStatistics( newPlan, null, joinCardinality, -1 );
         }
 
         /**

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/simple/CostModelBasedGreedyJoinPlanOptimizerImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/simple/CostModelBasedGreedyJoinPlanOptimizerImpl.java
@@ -14,11 +14,11 @@ import se.liu.ida.hefquin.engine.queryproc.PhysicalOptimizationException;
 import se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.CostModel;
 import se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.utils.CostEstimationUtils;
 
-public class GreedyJoinPlanOptimizerImpl extends JoinPlanOptimizerBase
+public class CostModelBasedGreedyJoinPlanOptimizerImpl extends JoinPlanOptimizerBase
 {
 	protected final CostModel costModel;
 
-	public GreedyJoinPlanOptimizerImpl( final CostModel costModel ) {
+	public CostModelBasedGreedyJoinPlanOptimizerImpl(final CostModel costModel ) {
 		assert costModel != null;
 		this.costModel= costModel;
 	}


### PR DESCRIPTION
Implements a query optimizer that builds left-deep query plans, for which it uses a greedy approach to determine the join order based on cardinality estimation, and then choose the physical algorithm according to the estimated number of requests to execute the join.