### PR TITLE
Avoid counting duplicates in cost model

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CFRBasedCostFunctionForPlan.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CFRBasedCostFunctionForPlan.java
@@ -1,5 +1,6 @@
 package se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.costmodel;
 
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
@@ -22,19 +23,24 @@ public class CFRBasedCostFunctionForPlan implements CostFunctionForPlan
 	}
 
 	@Override
-	public CompletableFuture<Integer> initiateCostEstimation( final PhysicalPlan plan ) {
+	public CompletableFuture<Integer> initiateCostEstimation( final Set<PhysicalPlan> visitedPlans, final PhysicalPlan plan ) {
+		if ( visitedPlans.contains( plan ) ){
+			return CompletableFuture.completedFuture(0);
+		}
+
+		visitedPlans.add(plan);
 		final CompletableFuture<Integer> futureForRoot = costFctForRoot.initiateCostEstimation(plan);
 		if ( plan.numberOfSubPlans() == 0 ) {
 			return futureForRoot;
 		}
-		return aggregateValueForAllSubPlans(futureForRoot, plan);
+		return aggregateValueForAllSubPlans( visitedPlans, futureForRoot, plan );
 	}
 
-	public CompletableFuture<Integer> aggregateValueForAllSubPlans( final CompletableFuture<Integer> futureForRoot, final PhysicalPlan plan ) {
+	public CompletableFuture<Integer> aggregateValueForAllSubPlans( final Set<PhysicalPlan> visitedPlan, final CompletableFuture<Integer> futureForRoot, final PhysicalPlan plan ) {
 		CompletableFuture<Integer> f = futureForRoot;
 		for ( int i = 0; i < plan.numberOfSubPlans(); i++ ) {
 			final PhysicalPlan subPlan = plan.getSubPlan(i);
-			f = f.thenCombine( initiateCostEstimation(subPlan),
+			f = f.thenCombine( initiateCostEstimation( visitedPlan, subPlan),
 					(total,valueForSubPlan) -> (total + valueForSubPlan) < 0 ? Integer.MAX_VALUE : (total + valueForSubPlan) );
 		}
 

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CFRBasedParallelismCostFunctionForPlan.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CFRBasedParallelismCostFunctionForPlan.java
@@ -35,7 +35,9 @@ public class CFRBasedParallelismCostFunctionForPlan extends CFRBasedCostFunction
 			CompletableFuture<Integer> f = futureForRoot;
 			for ( int i = 0; i < plan.numberOfSubPlans(); i++ ) {
 				final PhysicalPlan subPlan = plan.getSubPlan(i);
-				cardForSubPlan = cardForSubPlan.thenCombine( initiateCostEstimation( visitedPlans, subPlan), (m, v) -> Math.max(m, v));
+
+				// To get a fair maximum value, the visited subPlans should not be skipped.
+				cardForSubPlan = cardForSubPlan.thenCombine( initiateCostEstimation( new HashSet<>(), subPlan), (m, v) -> Math.max(m, v));
 			}
 			return f.thenCombine(cardForSubPlan, ( total, valueForSubPlan) -> (total + valueForSubPlan) < 0 ? Integer.MAX_VALUE : (total + valueForSubPlan) );
 		}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CostFunctionForPlan.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CostFunctionForPlan.java
@@ -11,5 +11,11 @@ import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
  */
 public interface CostFunctionForPlan
 {
+	/**
+	 * A function for estimating the cost of a plan.
+	 * @param visitedPlans: 
+	 * Record a set of sub-plans (of plan) that have been visited during the cost estimation.
+	 * This set can be used for checking if a subplan has been visited or not.
+	 */
 	CompletableFuture<Integer> initiateCostEstimation( final Set<PhysicalPlan> visitedPlans, final PhysicalPlan plan );
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CostFunctionForPlan.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CostFunctionForPlan.java
@@ -1,5 +1,6 @@
 package se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.costmodel;
 
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
@@ -10,5 +11,5 @@ import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
  */
 public interface CostFunctionForPlan
 {
-	CompletableFuture<Integer> initiateCostEstimation( PhysicalPlan plan );
+	CompletableFuture<Integer> initiateCostEstimation( final Set<PhysicalPlan> visitedPlans, final PhysicalPlan plan );
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CostModelImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CostModelImpl.java
@@ -5,7 +5,9 @@ import se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.CardinalityEstimation
 import se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.CostModel;
 
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 
 public class CostModelImpl implements CostModel
@@ -30,7 +32,10 @@ public class CostModelImpl implements CostModel
                 new CostDimension( 1.0, new CFRBasedCostFunctionForPlan(new CFRNumberOfVarsShippedInRequests(cardEstimation)) ),
                 new CostDimension( 1.0, new CFRBasedCostFunctionForPlan(new CFRNumberOfTermsShippedInResponses(cardEstimation)) ),
                 new CostDimension( 1.0, new CFRBasedCostFunctionForPlan(new CFRNumberOfVarsShippedInResponses(cardEstimation)) ),
+
+                  // Two functions can be used to estimate the amount of work that needs to be done (for all operators) at the federation engine
                 new CostDimension( 1.0, new CFRBasedCostFunctionForPlan(new CFRNumberOfProcessedSolMaps(cardEstimation)) )
+//                new CostDimension( 1.0, new CFRBasedParallelismCostFunctionForPlan(new CFRNumberOfProcessedSolMaps(cardEstimation)) )
             };
     	}
 
@@ -76,12 +81,13 @@ public class CostModelImpl implements CostModel
     {
         CompletableFuture<Double> f = CompletableFuture.completedFuture( Double.valueOf(0) );
         for ( int i = 0; i < dimensions.length; ++i ) {
+            final Set<PhysicalPlan> visitedPlans = new HashSet<>();
+
             final CostFunctionForPlan costFct = dimensions[i].costFct;
             final double weight = dimensions[i].weight;
-            f = f.thenCombine( costFct.initiateCostEstimation(plan),
-                               (aggregate,costValue) -> aggregate + weight * (costValue < 0 ? Integer.MAX_VALUE: costValue) );
+            f = f.thenCombine( costFct.initiateCostEstimation( visitedPlans, plan),
+                    (aggregate,costValue) -> aggregate + weight * (costValue < 0 ? Integer.MAX_VALUE: costValue) );
         }
-
         return f;
     }
 

--- a/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CostModelImplTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/costmodel/CostModelImplTest.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.costmodel;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Date;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
@@ -20,9 +21,6 @@ import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.utils.PhysicalPlanFactory;
 import se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.CostEstimationException;
 import se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.CostModel;
-import se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.costmodel.CostDimension;
-import se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.costmodel.CostFunctionForPlan;
-import se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.costmodel.CostModelImpl;
 
 /**
  * Attention: the tests here do NOT actually test the cost model. Instead,
@@ -184,7 +182,7 @@ public class CostModelImplTest extends EngineTestBase
 		final TriplePattern tp = new TriplePatternImpl(
 				NodeFactory.createBlankNode(),
 				NodeFactory.createBlankNode(),
-				NodeFactory.createBlankNode() ); 
+				NodeFactory.createBlankNode() );
 		final TriplePatternRequest req = new TriplePatternRequestImpl(tp);
 		final FederationMember fm = new TPFServerForTest();
 
@@ -218,7 +216,7 @@ public class CostModelImplTest extends EngineTestBase
 		}
 
 		@Override
-		public CompletableFuture<Integer> initiateCostEstimation( final PhysicalPlan plan ) {
+		public CompletableFuture<Integer> initiateCostEstimation( final Set<PhysicalPlan> visitedPlan, final PhysicalPlan plan ) {
 			return CompletableFuture.supplyAsync( () -> {
 				if ( sleepMillis > 0L ) {
 					try {


### PR DESCRIPTION
When aggregating cost values in the cost model, avoid counting duplicates by skipping the subquery that has already been visited.