### PR TITLE
adds FederationDescriptionReader

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/cli/modules/ModFederation.java
+++ b/src/main/java/se/liu/ida/hefquin/cli/modules/ModFederation.java
@@ -1,36 +1,18 @@
 package se.liu.ida.hefquin.cli.modules;
 
-import java.io.File;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.apache.jena.atlas.json.io.parserjavacc.javacc.ParseException;
 import org.apache.jena.cmd.ArgDecl;
 import org.apache.jena.cmd.CmdArgModule;
 import org.apache.jena.cmd.CmdGeneral;
 import org.apache.jena.cmd.ModBase;
-import org.apache.jena.rdf.model.*;
-import org.apache.jena.riot.RDFDataMgr;
-import org.apache.jena.vocabulary.RDF;
 
-import se.liu.ida.hefquin.engine.data.VocabularyMapping;
-import se.liu.ida.hefquin.engine.data.impl.VocabularyMappingImpl;
-import se.liu.ida.hefquin.engine.federation.*;
-import se.liu.ida.hefquin.engine.federation.access.*;
-import se.liu.ida.hefquin.engine.federation.access.impl.iface.*;
 import se.liu.ida.hefquin.engine.federation.catalog.FederationCatalog;
-import se.liu.ida.hefquin.engine.federation.catalog.impl.FederationCatalogImpl;
-import se.liu.ida.hefquin.engine.wrappers.graphqlwrapper.GraphQLEndpointInitializer;
-import se.liu.ida.hefquin.engine.wrappers.graphqlwrapper.impl.GraphQLEndpointInitializerImpl;
-import se.liu.ida.hefquin.vocabulary.FD;
+import se.liu.ida.hefquin.engine.federation.catalog.FederationDescriptionReader;
 
 public class ModFederation extends ModBase
 {
 	protected final ArgDecl fedDescrDecl   = new ArgDecl(ArgDecl.HasValue, "federationDescription", "fd");
 
-	protected final Map<String, FederationMember> membersByURI = new HashMap<>();
+	protected FederationCatalog cat = null; 
 
 	@Override
 	public void registerWith( final CmdGeneral cmdLine ) {
@@ -42,216 +24,13 @@ public class ModFederation extends ModBase
 	public void processArgs( final CmdArgModule cmdLine ) {
 		if ( cmdLine.contains(fedDescrDecl) ) {
 			final String fedDescrFilename = cmdLine.getValue(fedDescrDecl);
-			parseFedDescr(fedDescrFilename);
+			cat = FederationDescriptionReader.readFromFile(fedDescrFilename);
 		}
 	}
 
 
 	public FederationCatalog getFederationCatalog() {
-		return new FederationCatalogImpl(membersByURI);
-	}
-
-	protected void parseFedDescr( final String filename ) {
-		final Model fd = RDFDataMgr.loadModel(filename);
-
-		final ResIterator fedMembers = fd.listResourcesWithProperty(RDF.type, FD.FederationMember);
-		// Iterate over all federation members
-		while ( fedMembers.hasNext() ) {
-			final Resource fedMember = fedMembers.next();
-			VocabularyMapping vocabMap = null;
-			if( fd.contains(fedMember, FD.vocabularyMappingsFile) ){
-				final RDFNode pathToMappingFile = fd.getRequiredProperty(fedMember, FD.vocabularyMappingsFile).getObject();
-
-				final String path = pathToMappingFile.toString();
-				if ( verifyValidVocabMappingFile( path ) ) {
-					vocabMap = new VocabularyMappingImpl(path);
-				}
-			}
-
-			final Resource iface = fedMember.getProperty(FD.interface_).getResource();
-			final RDFNode ifaceType = fd.getRequiredProperty(iface, RDF.type).getObject();
-			// Check the type of interface
-			if ( ifaceType.equals(FD.SPARQLEndpointInterface) ){
-				final RDFNode addr = fd.getRequiredProperty(iface, FD.endpointAddress).getObject();
-
-				final String addrStr;
-				if ( addr.isLiteral() ) {
-					addrStr = addr.asLiteral().getLexicalForm();
-				}
-				else if ( addr.isURIResource() ) {
-					addrStr = addr.asResource().getURI();
-				}
-				else {
-					throw new IllegalArgumentException();
-				}
-				addSPARQLEndpoint(addrStr, vocabMap);
-			}
-			else if ( ifaceType.equals(FD.TPFInterface) ){
-				final RDFNode addr = fd.getRequiredProperty(iface, FD.exampleFragmentAddress).getObject();
-
-				final String addrStr;
-				if ( addr.isLiteral() ) {
-					addrStr = addr.asLiteral().getLexicalForm();
-				}
-				else if ( addr.isURIResource() ) {
-					addrStr = addr.asResource().getURI();
-				}
-				else {
-					throw new IllegalArgumentException();
-				}
-
-				addTPFServer(addrStr, vocabMap);
-			}
-			else if ( ifaceType.equals(FD.brTPFInterface) ){
-				final RDFNode addr = fd.getRequiredProperty(iface, FD.exampleFragmentAddress).getObject();
-
-				final String addrStr;
-				if ( addr.isLiteral() ) {
-					addrStr = addr.asLiteral().getLexicalForm();
-				}
-				else if ( addr.isURIResource() ) {
-					addrStr = addr.asResource().getURI();
-				}
-				else {
-					throw new IllegalArgumentException();
-				}
-
-				addBRTPFServer(addrStr, vocabMap);
-			}
-			else if ( ifaceType.equals(FD.BoltInterface) ){
-				final RDFNode addr = fd.getRequiredProperty(iface, FD.endpointAddress).getObject();
-
-				final String addrStr;
-				if ( addr.isLiteral() ) {
-					addrStr = addr.asLiteral().getLexicalForm();
-				}
-				else if ( addr.isURIResource() ) {
-					addrStr = addr.asResource().getURI();
-				}
-				else {
-					throw new IllegalArgumentException();
-				}
-
-				addNeo4jServer(addrStr, vocabMap);
-			}
-			else if ( ifaceType.equals(FD.GraphQLEndpointInterface) ){
-				final RDFNode addr = fd.getRequiredProperty(iface, FD.endpointAddress).getObject();
-
-				final String addrStr;
-				if ( addr.isLiteral() ) {
-					addrStr = addr.asLiteral().getLexicalForm();
-				}
-				else if ( addr.isURIResource() ) {
-					addrStr = addr.asResource().getURI();
-				}
-				else {
-					throw new IllegalArgumentException();
-				}
-
-				addGraphQLServer(addrStr);
-			}
-
-		}
-	}
-
-	protected void addSPARQLEndpoint( final String sparqlEndpointValue, final VocabularyMapping vocabMappings ) {
-		verifyExpectedURI(sparqlEndpointValue);
-
-		final SPARQLEndpointInterface iface = new SPARQLEndpointInterfaceImpl(sparqlEndpointValue);
-		final SPARQLEndpoint fm = new SPARQLEndpoint() {
-			@Override public SPARQLEndpointInterface getInterface() { return iface; }
-			@Override public VocabularyMapping getVocabularyMapping() { return vocabMappings; }
-			@Override public String toString( ) { return "SPARQL endpoint (" + iface.toString() + ")"; }
-		};
-
-		membersByURI.put(sparqlEndpointValue, fm);
-	}
-
-	protected void addTPFServer( final String uri, final VocabularyMapping vocabMappings ) {
-		verifyExpectedURI(uri);
-
-		final TPFInterface iface = TPFInterfaceUtils.createTPFInterface(uri);
-		final TPFServer fm = new TPFServer() {
-			@Override public VocabularyMapping getVocabularyMapping() { return vocabMappings; }
-			@Override public TPFInterface getInterface() { return iface; }
-			@Override public String toString( ) { return "TPF server (" + iface.toString() + ")"; }
-		};
-
-		membersByURI.put(uri, fm);
-	}
-
-	protected void addBRTPFServer( final String uri, final VocabularyMapping vocabMappings ) {
-		verifyExpectedURI(uri);
-
-		final BRTPFInterface iface = BRTPFInterfaceUtils.createBRTPFInterface(uri);
-		final BRTPFServer fm = new BRTPFServer() {
-			@Override public VocabularyMapping getVocabularyMapping() { return vocabMappings; }
-			@Override public BRTPFInterface getInterface() { return iface; }
-			@Override public String toString( ) { return "brTPF server (" + iface.toString() + ")"; }
-		};
-
-		membersByURI.put(uri, fm);
-	}
-
-	protected void addGraphQLServer( final String uri ) {
-		verifyExpectedURI(uri);
-
-		final GraphQLEndpointInitializer init = new GraphQLEndpointInitializerImpl();
-
-		final int connTimeout = 5000;
-        final int readTimeout = 5000;
-
-		final GraphQLEndpoint fm;
-		try {
-			fm = init.initializeEndpoint(uri, connTimeout, readTimeout);
-			membersByURI.put(uri, fm);
-		}
-		catch ( final FederationAccessException e ) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-		catch ( final ParseException e ) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}
-	}
-
-	protected void addNeo4jServer( final String uri, final VocabularyMapping vocabMappings ) {
-		verifyExpectedURI(uri);
-
-		final Neo4jInterface iface = new Neo4jInterfaceImpl(uri);
-		final Neo4jServer fm = new Neo4jServer() {
-			@Override public VocabularyMapping getVocabularyMapping() { return vocabMappings; }
-			@Override public Neo4jInterface getInterface() { return iface; }
-			@Override public String toString( ) { return "Neo4j server (" + iface.toString() + ")"; }
-		};
-
-		membersByURI.put(uri, fm);
-	}
-
-	protected URI verifyExpectedURI( final String uriString ) {
-		final URI uri;
-		try {
-			uri = new URI(uriString);
-			if (    ! uri.isAbsolute()
-			     || (uri.getScheme().equals("http") && uri.getScheme().equals("https")) ) {
-				throw new IllegalArgumentException( "The following URI is of an unexpected type; it should be an HTTP URI or an HTTPS URI: " + uriString );
-			}
-		}
-		catch ( final URISyntaxException ex ) {
-			throw new IllegalArgumentException("URI parse exception (" + ex.getMessage() + ")");
-		}
-
-		return uri;
-	}
-
-	protected boolean verifyValidVocabMappingFile(final String pathString ) {
-		final File f = new File(pathString);
-		if ( f.exists() && f.isFile() ){
-			return true;
-		}
-		else
-			throw new IllegalArgumentException( "The following path to vocab.mapping does not exist:" + pathString );
+		return cat;
 	}
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/federation/catalog/FederationDescriptionReader.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/federation/catalog/FederationDescriptionReader.java
@@ -1,0 +1,288 @@
+package se.liu.ida.hefquin.engine.federation.catalog;
+
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.jena.atlas.json.io.parserjavacc.javacc.ParseException;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.RDFNode;
+import org.apache.jena.rdf.model.ResIterator;
+import org.apache.jena.rdf.model.Resource;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.vocabulary.RDF;
+
+import se.liu.ida.hefquin.engine.data.VocabularyMapping;
+import se.liu.ida.hefquin.engine.data.impl.VocabularyMappingImpl;
+import se.liu.ida.hefquin.engine.federation.BRTPFServer;
+import se.liu.ida.hefquin.engine.federation.FederationMember;
+import se.liu.ida.hefquin.engine.federation.GraphQLEndpoint;
+import se.liu.ida.hefquin.engine.federation.Neo4jServer;
+import se.liu.ida.hefquin.engine.federation.SPARQLEndpoint;
+import se.liu.ida.hefquin.engine.federation.TPFServer;
+import se.liu.ida.hefquin.engine.federation.access.BRTPFInterface;
+import se.liu.ida.hefquin.engine.federation.access.FederationAccessException;
+import se.liu.ida.hefquin.engine.federation.access.Neo4jInterface;
+import se.liu.ida.hefquin.engine.federation.access.SPARQLEndpointInterface;
+import se.liu.ida.hefquin.engine.federation.access.TPFInterface;
+import se.liu.ida.hefquin.engine.federation.access.impl.iface.BRTPFInterfaceUtils;
+import se.liu.ida.hefquin.engine.federation.access.impl.iface.Neo4jInterfaceImpl;
+import se.liu.ida.hefquin.engine.federation.access.impl.iface.SPARQLEndpointInterfaceImpl;
+import se.liu.ida.hefquin.engine.federation.access.impl.iface.TPFInterfaceUtils;
+import se.liu.ida.hefquin.engine.federation.catalog.impl.FederationCatalogImpl;
+import se.liu.ida.hefquin.engine.wrappers.graphqlwrapper.GraphQLEndpointInitializer;
+import se.liu.ida.hefquin.engine.wrappers.graphqlwrapper.impl.GraphQLEndpointInitializerImpl;
+import se.liu.ida.hefquin.vocabulary.FD;
+
+public class FederationDescriptionReader
+{
+	public static FederationCatalog readFromFile( final String filename ) {
+		return instance.parseFedDescr(filename);
+	}
+
+	public static FederationCatalog readFromModel( final Model fd ) {
+		return instance.parseFedDescr(fd);
+	}
+
+	public static FederationDescriptionReader instance = new FederationDescriptionReader();
+
+	protected FederationDescriptionReader() {}
+
+	public FederationCatalog parseFedDescr( final String filename ) {
+		final Model fd = RDFDataMgr.loadModel(filename);
+		return parseFedDescr(fd);
+	}
+
+	public FederationCatalog parseFedDescr( final Model fd ) {
+		final Map<String, FederationMember> membersByURI = new HashMap<>();
+
+		// Iterate over all federation members mentioned in the description
+		final ResIterator fedMembers = fd.listResourcesWithProperty(RDF.type, FD.FederationMember);
+		while ( fedMembers.hasNext() ) {
+			final Resource fedMember = fedMembers.next();
+			final VocabularyMapping vocabMap = parseVocabMapping(fedMember, fd);
+
+			final Resource iface = fedMember.getProperty(FD.interface_).getResource();
+			final RDFNode ifaceType = fd.getRequiredProperty(iface, RDF.type).getObject();
+
+			// Check the type of interface
+			if ( ifaceType.equals(FD.SPARQLEndpointInterface) ) {
+				final RDFNode addr = fd.getRequiredProperty(iface, FD.endpointAddress).getObject();
+
+				final String addrStr;
+				if ( addr.isLiteral() ) {
+					addrStr = addr.asLiteral().getLexicalForm();
+				}
+				else if ( addr.isURIResource() ) {
+					addrStr = addr.asResource().getURI();
+				}
+				else {
+					throw new IllegalArgumentException();
+				}
+
+				final FederationMember fm = createSPARQLEndpoint(addrStr, vocabMap);
+				membersByURI.put(addrStr, fm);
+			}
+			else if ( ifaceType.equals(FD.TPFInterface) ) {
+				final RDFNode addr = fd.getRequiredProperty(iface, FD.exampleFragmentAddress).getObject();
+
+				final String addrStr;
+				if ( addr.isLiteral() ) {
+					addrStr = addr.asLiteral().getLexicalForm();
+				}
+				else if ( addr.isURIResource() ) {
+					addrStr = addr.asResource().getURI();
+				}
+				else {
+					throw new IllegalArgumentException();
+				}
+
+				final FederationMember fm = createTPFServer(addrStr, vocabMap);
+				membersByURI.put(addrStr, fm);
+			}
+			else if ( ifaceType.equals(FD.brTPFInterface) ) {
+				final RDFNode addr = fd.getRequiredProperty(iface, FD.exampleFragmentAddress).getObject();
+
+				final String addrStr;
+				if ( addr.isLiteral() ) {
+					addrStr = addr.asLiteral().getLexicalForm();
+				}
+				else if ( addr.isURIResource() ) {
+					addrStr = addr.asResource().getURI();
+				}
+				else {
+					throw new IllegalArgumentException();
+				}
+
+				final FederationMember fm = createBRTPFServer(addrStr, vocabMap);
+				membersByURI.put(addrStr, fm);
+			}
+			else if ( ifaceType.equals(FD.BoltInterface) ) {
+				final RDFNode addr = fd.getRequiredProperty(iface, FD.endpointAddress).getObject();
+
+				final String addrStr;
+				if ( addr.isLiteral() ) {
+					addrStr = addr.asLiteral().getLexicalForm();
+				}
+				else if ( addr.isURIResource() ) {
+					addrStr = addr.asResource().getURI();
+				}
+				else {
+					throw new IllegalArgumentException();
+				}
+
+				final FederationMember fm = createNeo4jServer(addrStr, vocabMap);
+				membersByURI.put(addrStr, fm);
+			}
+			else if ( ifaceType.equals(FD.GraphQLEndpointInterface) ) {
+				final RDFNode addr = fd.getRequiredProperty(iface, FD.endpointAddress).getObject();
+
+				final String addrStr;
+				if ( addr.isLiteral() ) {
+					addrStr = addr.asLiteral().getLexicalForm();
+				}
+				else if ( addr.isURIResource() ) {
+					addrStr = addr.asResource().getURI();
+				}
+				else {
+					throw new IllegalArgumentException();
+				}
+
+				final FederationMember fm = createGraphQLServer(addrStr, vocabMap);
+				membersByURI.put(addrStr, fm);
+			}
+			else {
+				throw new IllegalArgumentException( ifaceType.toString() );
+			}
+
+		}
+
+		return new FederationCatalogImpl(membersByURI);
+	}
+
+	/**
+	 * Checks whether given RDF resource (fm) representing a federation
+	 * member is associated with a vocabulary mapping in the given federation
+	 * description (fd) and, if so, parses this vocabulary mapping and returns
+	 * it. Otherwise, this function returns <code>null</code>.
+	 */
+	protected VocabularyMapping parseVocabMapping( final Resource fm, final Model fd ) {
+		if( fd.contains(fm, FD.vocabularyMappingsFile) ){
+			final RDFNode pathToMappingFile = fd.getRequiredProperty(fm, FD.vocabularyMappingsFile).getObject();
+
+			final String path = pathToMappingFile.toString();
+			if ( verifyValidVocabMappingFile(path) ) {
+				return new VocabularyMappingImpl(path);
+			}
+		}
+
+		return null;
+	}
+
+	protected FederationMember createSPARQLEndpoint( final String uri, final VocabularyMapping vm ) {
+		verifyExpectedURI(uri);
+
+		final SPARQLEndpointInterface iface = new SPARQLEndpointInterfaceImpl(uri);
+		final SPARQLEndpoint fm = new SPARQLEndpoint() {
+			@Override public SPARQLEndpointInterface getInterface() { return iface; }
+			@Override public VocabularyMapping getVocabularyMapping() { return vm; }
+			@Override public String toString( ) { return "SPARQL endpoint (" + iface.toString() + ")"; }
+		};
+
+		return fm;
+	}
+
+	protected FederationMember createTPFServer( final String uri, final VocabularyMapping vm ) {
+		verifyExpectedURI(uri);
+
+		final TPFInterface iface = TPFInterfaceUtils.createTPFInterface(uri);
+		final TPFServer fm = new TPFServer() {
+			@Override public VocabularyMapping getVocabularyMapping() { return vm; }
+			@Override public TPFInterface getInterface() { return iface; }
+			@Override public String toString( ) { return "TPF server (" + iface.toString() + ")"; }
+		};
+
+		return fm;
+	}
+
+	protected FederationMember createBRTPFServer( final String uri, final VocabularyMapping vm ) {
+		verifyExpectedURI(uri);
+
+		final BRTPFInterface iface = BRTPFInterfaceUtils.createBRTPFInterface(uri);
+		final BRTPFServer fm = new BRTPFServer() {
+			@Override public VocabularyMapping getVocabularyMapping() { return vm; }
+			@Override public BRTPFInterface getInterface() { return iface; }
+			@Override public String toString( ) { return "brTPF server (" + iface.toString() + ")"; }
+		};
+
+		return fm;
+	}
+
+	protected FederationMember createNeo4jServer( final String uri, final VocabularyMapping vm ) {
+		verifyExpectedURI(uri);
+
+		final Neo4jInterface iface = new Neo4jInterfaceImpl(uri);
+		final Neo4jServer fm = new Neo4jServer() {
+			@Override public VocabularyMapping getVocabularyMapping() { return vm; }
+			@Override public Neo4jInterface getInterface() { return iface; }
+			@Override public String toString( ) { return "Neo4j server (" + iface.toString() + ")"; }
+		};
+
+		return fm;
+	}
+
+	protected FederationMember createGraphQLServer( final String uri, final VocabularyMapping vm ) {
+		verifyExpectedURI(uri);
+
+		final GraphQLEndpointInitializer init = new GraphQLEndpointInitializerImpl();
+
+		final int connTimeout = 5000;
+        final int readTimeout = 5000;
+
+		final GraphQLEndpoint fm;
+		try {
+			fm = init.initializeEndpoint(uri, connTimeout, readTimeout);
+			return fm;
+		}
+		catch ( final FederationAccessException | ParseException e ) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+			throw new IllegalArgumentException(e);
+		}
+	}
+
+	/**
+	 * Verifies that the file at the given path exists.
+	 */
+	protected boolean verifyValidVocabMappingFile( final String pathToMappingFile ) {
+		final File f = new File(pathToMappingFile);
+		if ( f.exists() && f.isFile() ){
+			return true;
+		}
+		else
+			throw new IllegalArgumentException( "The following path to vocab.mapping does not exist:" + pathToMappingFile );
+	}
+
+	/**
+	 * Verifies that the given string represents an HTTP URI
+	 * or an HTTPS URI and, if so, returns that URI.
+	 */
+	protected URI verifyExpectedURI( final String uriString ) {
+		final URI uri;
+		try {
+			uri = new URI(uriString);
+			if (    ! uri.isAbsolute()
+			     || (uri.getScheme().equals("http") && uri.getScheme().equals("https")) ) {
+				throw new IllegalArgumentException( "The following URI is of an unexpected type; it should be an HTTP URI or an HTTPS URI: " + uriString );
+			}
+		}
+		catch ( final URISyntaxException ex ) {
+			throw new IllegalArgumentException("URI parse exception (" + ex.getMessage() + ")");
+		}
+
+		return uri;
+	}
+
+}

--- a/src/test/java/se/liu/ida/hefquin/engine/federation/catalog/FederationDescriptionReaderTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/federation/catalog/FederationDescriptionReaderTest.java
@@ -1,0 +1,59 @@
+package se.liu.ida.hefquin.engine.federation.catalog;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFParser;
+import org.apache.jena.riot.RDFParserBuilder;
+import org.junit.Test;
+
+import se.liu.ida.hefquin.engine.federation.FederationMember;
+import se.liu.ida.hefquin.engine.federation.SPARQLEndpoint;
+import se.liu.ida.hefquin.engine.federation.TPFServer;
+import se.liu.ida.hefquin.engine.federation.access.SPARQLEndpointInterface;
+import se.liu.ida.hefquin.engine.federation.access.TPFInterface;
+
+public class FederationDescriptionReaderTest
+{
+	@Test
+	public void twoFMs() {
+		final String turtle =
+				  "PREFIX fd:     <http://www.example.org/se/liu/ida/hefquin/fd#>\n"
+				+ "PREFIX ex:     <http://example.org/>\n"
+				+ "\n"
+				+ "ex:dbpediaSPARQL\n"
+				+ "      a            fd:FederationMember ;\n"
+				+ "      fd:interface [ a                  fd:SPARQLEndpointInterface ;\n"
+				+ "                     fd:endpointAddress <http://dbpedia.org/sparql> ] .\n"
+				+ "\n"
+				+ "ex:dbpediaTPF\n"
+				+ "      a            fd:FederationMember ;\n"
+				+ "      fd:interface [ a                         fd:TPFInterface ;\n"
+				+ "                     fd:exampleFragmentAddress <http://fragments.dbpedia.org/2016-04/en> ] .";
+
+		final Model fd = ModelFactory.createDefaultModel();
+
+		final RDFParserBuilder b = RDFParser.fromString(turtle);
+		b.lang( Lang.TURTLE );
+		b.parse(fd);
+
+		final FederationCatalog cat = FederationDescriptionReader.readFromModel(fd);
+
+		assertEquals( 2, cat.getAllFederationMembers().size() );
+
+		final FederationMember fm1 = cat.getFederationMemberByURI("http://dbpedia.org/sparql");
+		assertTrue( fm1.getVocabularyMapping() == null );
+		assertTrue( fm1 instanceof SPARQLEndpoint );
+		assertTrue( fm1.getInterface() instanceof SPARQLEndpointInterface );
+		assertEquals( "http://dbpedia.org/sparql", ((SPARQLEndpointInterface) fm1.getInterface()).getURL() );
+
+		final FederationMember fm2 = cat.getFederationMemberByURI("http://fragments.dbpedia.org/2016-04/en");
+		assertTrue( fm2.getVocabularyMapping() == null );
+		assertTrue( fm2 instanceof TPFServer );
+		assertTrue( fm2.getInterface() instanceof TPFInterface );
+	}
+
+}


### PR DESCRIPTION
Moves the functionality of reading an RDF description of a federation out of `ModFederation` into a separate class (`FederationDescriptionReader`).

/cc @chengsijin0817 