### PR TITLE
Fix an issue in QueryPatternUtils

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/query/impl/QueryPatternUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/query/impl/QueryPatternUtils.java
@@ -1093,7 +1093,7 @@ public class QueryPatternUtils
 				if ( ! bgpAdded && subElmt instanceof ElementTriplesBlock ) {
 					final ElementTriplesBlock copy = new ElementTriplesBlock();
 
-					final Iterator<Triple> it = ((ElementTriplesBlock) elmt).patternElts();
+					final Iterator<Triple> it = ((ElementTriplesBlock) subElmt).patternElts();
 					while ( it.hasNext() ) {
 						copy.addTriple( it.next() );
 					}
@@ -1108,7 +1108,7 @@ public class QueryPatternUtils
 				else if ( ! bgpAdded && subElmt instanceof ElementPathBlock ) {
 					final ElementPathBlock copy = new ElementPathBlock();
 
-					final Iterator<TriplePath> it = ((ElementPathBlock) elmt).patternElts();
+					final Iterator<TriplePath> it = ((ElementPathBlock) subElmt).patternElts();
 					while ( it.hasNext() ) {
 						copy.addTriplePath( it.next() );
 					}


### PR DESCRIPTION
Fix an issue: Class org.apache.jena.sparql.syntax.ElementGroup cannot be cast to class org.apache.jena.sparql.syntax.ElementPathBlock (see the detailed description below):
https://github.com/MaastrichtU-IDS/federatedQueryKG/issues/6
