### PR TITLE
Handle BIND clause in logical plan: OpExtend

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanUtils.java
@@ -6,26 +6,7 @@ import java.util.List;
 import se.liu.ida.hefquin.engine.federation.access.BGPRequest;
 import se.liu.ida.hefquin.engine.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.engine.federation.access.TriplePatternRequest;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPOptAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFilter;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGlobalToLocal;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRightJoin;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpLocalToGlobal;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayJoin;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayLeftJoin;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayUnion;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPOptAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpUnion;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalPlanWithBinaryRootImpl;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalPlanWithNaryRootImpl;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalPlanWithNullaryRootImpl;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalPlanWithUnaryRootImpl;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.*;
 
 public class LogicalPlanUtils
 {
@@ -178,6 +159,9 @@ public class LogicalPlanUtils
 
 		@Override
 		public void visit( final LogicalOpFilter op )        { subplanCount++; }
+
+		@Override
+		public void visit( final LogicalOpExtend op )        { subplanCount++; }
 
 		@Override
 		public void visit( final LogicalOpLocalToGlobal op ) { subplanCount++; }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanVisitor.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanVisitor.java
@@ -1,21 +1,6 @@
 package se.liu.ida.hefquin.engine.queryplan.logical;
 
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPOptAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFilter;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGlobalToLocal;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRightJoin;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpLocalToGlobal;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayJoin;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayLeftJoin;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayUnion;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPOptAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpUnion;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.*;
 
 public interface LogicalPlanVisitor
 {
@@ -38,6 +23,7 @@ public interface LogicalPlanVisitor
 	void visit( final LogicalOpMultiwayUnion op );
 	
 	void visit( final LogicalOpFilter op );
+	void visit( final LogicalOpExtend op );
 	void visit( final LogicalOpLocalToGlobal op );
 	void visit( final LogicalOpGlobalToLocal op );
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanVisitorBase.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanVisitorBase.java
@@ -1,21 +1,6 @@
 package se.liu.ida.hefquin.engine.queryplan.logical;
 
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPOptAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFilter;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGlobalToLocal;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRightJoin;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpLocalToGlobal;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayJoin;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayLeftJoin;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayUnion;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPOptAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpUnion;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.*;
 
 public class LogicalPlanVisitorBase implements LogicalPlanVisitor
 {
@@ -60,6 +45,9 @@ public class LogicalPlanVisitorBase implements LogicalPlanVisitor
 
 	@Override
 	public void visit( final LogicalOpFilter op )            {}
+
+	@Override
+	public void visit( final LogicalOpExtend op )            {}
 
 	@Override
 	public void visit( final LogicalOpLocalToGlobal op )     {}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalOpExtend.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalOpExtend.java
@@ -1,0 +1,53 @@
+package se.liu.ida.hefquin.engine.queryplan.logical.impl;
+
+import org.apache.jena.sparql.core.VarExprList;
+import se.liu.ida.hefquin.engine.queryplan.ExpectedVariables;
+import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanVisitor;
+import se.liu.ida.hefquin.engine.queryplan.logical.UnaryLogicalOp;
+
+public class LogicalOpExtend implements UnaryLogicalOp
+{
+	protected final VarExprList extendExpressions;
+
+	public LogicalOpExtend(final VarExprList extendExpressions ) {
+		assert extendExpressions != null;
+		assert ! extendExpressions.isEmpty();
+
+		this.extendExpressions = extendExpressions;
+	}
+
+	@Override
+	public ExpectedVariables getExpectedVariables( final ExpectedVariables... inputVars ) {
+		assert inputVars.length == 1;
+
+		return inputVars[0];
+	}
+
+	@Override
+	public boolean equals( final Object o ) {
+		if ( o == this ) return true;
+		if ( ! (o instanceof LogicalOpExtend) ) return false;
+
+		final LogicalOpExtend oo = (LogicalOpExtend) o;
+		return oo.extendExpressions.equals(extendExpressions);
+	}
+
+	@Override
+	public int hashCode(){
+		return extendExpressions.hashCode();
+	}
+
+	public VarExprList getExtendExpressions() {
+		return extendExpressions;
+	}
+
+	@Override
+	public void visit( final LogicalPlanVisitor visitor ) {
+		visitor.visit(this);
+	}
+
+	@Override
+	public String toString() {
+		return "> Extend ( " + extendExpressions.toString() + " )";
+	}
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalPlanPrinter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalPlanPrinter.java
@@ -3,22 +3,7 @@ package se.liu.ida.hefquin.engine.queryplan.utils;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanVisitor;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanWalker;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPOptAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFilter;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGlobalToLocal;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRightJoin;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpLocalToGlobal;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayJoin;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayLeftJoin;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayUnion;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPOptAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpUnion;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.*;
 
 public class LogicalPlanPrinter extends PlanPrinter{
 
@@ -143,6 +128,14 @@ public class LogicalPlanPrinter extends PlanPrinter{
 			builder.append(System.lineSeparator());
 			indentLevel++;
 		}
+
+		@Override
+		public void visit(final LogicalOpExtend op) {
+			addTabs();
+			builder.append( op.toString() );
+			builder.append(System.lineSeparator());
+			indentLevel++;
+		}
 		
 		@Override
 		public void visit(final LogicalOpLocalToGlobal op) {
@@ -230,6 +223,11 @@ public class LogicalPlanPrinter extends PlanPrinter{
 
 		@Override
 		public void visit(final LogicalOpFilter op) {
+			indentLevel--;
+		}
+
+		@Override
+		public void visit(final LogicalOpExtend op) {
 			indentLevel--;
 		}
 

--- a/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalToPhysicalOpConverter.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalToPhysicalOpConverter.java
@@ -58,6 +58,7 @@ public class LogicalToPhysicalOpConverter
 		else if ( lop instanceof LogicalOpGPAdd )    return convert( (LogicalOpGPAdd) lop );
 		else if ( lop instanceof LogicalOpGPOptAdd ) return convert( (LogicalOpGPOptAdd) lop );
 		else if ( lop instanceof LogicalOpFilter )    return convert( (LogicalOpFilter) lop );
+//		else if ( lop instanceof LogicalOpExtend )    return convert( (LogicalOpExtend) lop );
 		else if ( lop instanceof LogicalOpLocalToGlobal ) return convert ( (LogicalOpLocalToGlobal) lop);
 		else if ( lop instanceof LogicalOpGlobalToLocal ) return convert ( (LogicalOpGlobalToLocal) lop);
 		else throw new UnsupportedOperationException("Unsupported type of logical operator: " + lop.getClass().getName() + ".");
@@ -190,6 +191,11 @@ public class LogicalToPhysicalOpConverter
 	public static UnaryPhysicalOp convert( final LogicalOpFilter lop ) {
 		return new PhysicalOpFilter(lop);
 	}
+
+//	TODO
+//	public static UnaryPhysicalOp convert( final LogicalOpExtend lop ) {
+//		return new PhysicalOpExtend(lop);
+//	}
 
 	public static UnaryPhysicalOp convert( final LogicalOpLocalToGlobal lop ) {
 		return new PhysicalOpLocalToGlobal(lop);

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/MergeRequests.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/MergeRequests.java
@@ -23,23 +23,7 @@ import se.liu.ida.hefquin.engine.query.impl.SPARQLUnionPatternImpl;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanUtils;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBGPOptAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFilter;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGlobalToLocal;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpLocalToGlobal;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayJoin;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayLeftJoin;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayUnion;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRightJoin;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpTPOptAdd;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpUnion;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalPlanWithNullaryRootImpl;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.*;
 import se.liu.ida.hefquin.engine.queryproc.impl.loptimizer.HeuristicForLogicalOptimization;
 
 /**
@@ -200,6 +184,19 @@ public class MergeRequests implements HeuristicForLogicalOptimization
 					return mergeFilterIntoSPARQLEndpointRequest( (LogicalOpFilter) rootOp,
 					                                             (SPARQLEndpoint) reqOp.getFederationMember(),
 					                                             (SPARQLRequest) reqOp.getRequest() );
+				}
+			}
+		}
+		else if ( rootOp instanceof LogicalOpExtend)
+		{
+			// The BIND clause can be merged into a request operator if that request is for a SPARQL endpoint.
+			final LogicalOperator childOp = rewrittenSubPlans.get(0).getRootOperator();
+			if ( childOp instanceof LogicalOpRequest<?,?> ) {
+				final LogicalOpRequest<?,?> reqOp = (LogicalOpRequest<?,?>) childOp;
+				if ( reqOp.getFederationMember().getInterface().supportsSPARQLPatternRequests() ) {
+					return mergeExtendIntoSPARQLEndpointRequest( (LogicalOpExtend) rootOp,
+							(SPARQLEndpoint) reqOp.getFederationMember(),
+							(SPARQLRequest) reqOp.getRequest() );
 				}
 			}
 		}
@@ -377,6 +374,16 @@ public class MergeRequests implements HeuristicForLogicalOptimization
 	                                                                final SPARQLRequest req ) {
 		final SPARQLGraphPattern mergedPattern = QueryPatternUtils.merge( filterOp.getFilterExpressions(),
 		                                                                  req.getQueryPattern() );
+		final SPARQLRequest mergedReq = new SPARQLRequestImpl(mergedPattern);
+		final LogicalOpRequest<?,?> reqOp = new LogicalOpRequest<>(ep, mergedReq);
+		return new LogicalPlanWithNullaryRootImpl(reqOp);
+	}
+
+	public static LogicalPlan mergeExtendIntoSPARQLEndpointRequest( final LogicalOpExtend extendOp,
+																	final SPARQLEndpoint ep,
+																	final SPARQLRequest req ) {
+		final SPARQLGraphPattern mergedPattern = QueryPatternUtils.merge( extendOp.getExtendExpressions(),
+				req.getQueryPattern() );
 		final SPARQLRequest mergedReq = new SPARQLRequestImpl(mergedPattern);
 		final LogicalOpRequest<?,?> reqOp = new LogicalOpRequest<>(ep, mergedReq);
 		return new LogicalPlanWithNullaryRootImpl(reqOp);

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/srcsel/ServiceClauseBasedSourcePlannerImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/srcsel/ServiceClauseBasedSourcePlannerImpl.java
@@ -5,14 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.jena.sparql.algebra.Op;
-import org.apache.jena.sparql.algebra.op.OpBGP;
-import org.apache.jena.sparql.algebra.op.OpConditional;
-import org.apache.jena.sparql.algebra.op.OpFilter;
-import org.apache.jena.sparql.algebra.op.OpJoin;
-import org.apache.jena.sparql.algebra.op.OpLeftJoin;
-import org.apache.jena.sparql.algebra.op.OpSequence;
-import org.apache.jena.sparql.algebra.op.OpService;
-import org.apache.jena.sparql.algebra.op.OpUnion;
+import org.apache.jena.sparql.algebra.op.*;
 import org.apache.jena.sparql.core.BasicPattern;
 
 import se.liu.ida.hefquin.engine.federation.FederationMember;
@@ -29,15 +22,7 @@ import se.liu.ida.hefquin.engine.query.impl.QueryPatternUtils;
 import se.liu.ida.hefquin.engine.query.impl.GenericSPARQLGraphPatternImpl2;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlan;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFilter;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayJoin;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayLeftJoin;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayUnion;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRightJoin;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalPlanWithNaryRootImpl;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalPlanWithNullaryRootImpl;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalPlanWithUnaryRootImpl;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.*;
 import se.liu.ida.hefquin.engine.queryproc.QueryProcContext;
 import se.liu.ida.hefquin.engine.queryproc.SourcePlanner;
 import se.liu.ida.hefquin.engine.queryproc.SourcePlanningException;
@@ -86,6 +71,9 @@ public class ServiceClauseBasedSourcePlannerImpl extends SourcePlannerBase
 		}
 		else if ( jenaOp instanceof OpFilter ) {
 			return createPlanForFilter( (OpFilter) jenaOp );
+		}
+		else if ( jenaOp instanceof OpExtend ) {
+			return createPlanForBind( (OpExtend) jenaOp );
 		}
 		else if ( jenaOp instanceof OpService ) {
 			return createPlanForServicePattern( (OpService) jenaOp ); 
@@ -139,6 +127,12 @@ public class ServiceClauseBasedSourcePlannerImpl extends SourcePlannerBase
 	protected LogicalPlan createPlanForFilter( final OpFilter jenaOp ) {
 		final LogicalPlan subPlan = createPlan( jenaOp.getSubOp() );
 		final LogicalOpFilter rootOp = new LogicalOpFilter( jenaOp.getExprs() );
+		return new LogicalPlanWithUnaryRootImpl(rootOp, subPlan);
+	}
+
+	protected LogicalPlan createPlanForBind( final OpExtend jenaOp ) {
+		final LogicalPlan subPlan = createPlan( jenaOp.getSubOp() );
+		final LogicalOpExtend rootOp = new LogicalOpExtend( jenaOp.getVarExprList() );
 		return new LogicalPlanWithUnaryRootImpl(rootOp, subPlan);
 	}
 

--- a/src/main/java/se/liu/ida/hefquin/jenaintegration/sparql/engine/main/OpExecutorHeFQUIN.java
+++ b/src/main/java/se/liu/ida/hefquin/jenaintegration/sparql/engine/main/OpExecutorHeFQUIN.java
@@ -166,6 +166,16 @@ public class OpExecutorHeFQUIN extends OpExecutor
 	}
 
 	@Override
+	protected QueryIterator execute( final OpExtend opExtend, final QueryIterator input ) {
+		if ( isSupportedOp(opExtend) ) {
+			return executeSupportedOp( opExtend, input );
+		}
+		else {
+			return super.execute(opExtend, input);
+		}
+	}
+
+	@Override
 	protected QueryIterator execute( final OpFilter opFilter, final QueryIterator input ) {
 		if ( isSupportedOp(opFilter) ) {
 			return executeSupportedOp( opFilter, input );
@@ -289,7 +299,7 @@ public class OpExecutorHeFQUIN extends OpExecutor
 
 	    @Override public void visit(OpDisjunction opDisjunction)  { unsupportedOpFound = true; }
 
-	    @Override public void visit(OpLeftJoin opLeftJoin)        {} // supported
+		@Override public void visit(OpLeftJoin opLeftJoin)        {} // supported
 
 	    @Override public void visit(OpConditional opCond)         {} // supported
 
@@ -317,7 +327,8 @@ public class OpExecutorHeFQUIN extends OpExecutor
 
 	    @Override public void visit(OpAssign opAssign)            { unsupportedOpFound = true; }
 
-	    @Override public void visit(OpExtend opExtend)            { unsupportedOpFound = true; }
+//	    @Override public void visit(OpExtend opExtend)            { unsupportedOpFound = true; }
+	    @Override public void visit(OpExtend opExtend)            {} // supported
 
 	    //@Override public void visit(OpFind opFind)                { unsupportedOpFound = true; }
 

--- a/src/main/java/se/liu/ida/hefquin/jenaintegration/sparql/engine/main/OpExecutorHeFQUIN.java
+++ b/src/main/java/se/liu/ida/hefquin/jenaintegration/sparql/engine/main/OpExecutorHeFQUIN.java
@@ -327,7 +327,6 @@ public class OpExecutorHeFQUIN extends OpExecutor
 
 	    @Override public void visit(OpAssign opAssign)            { unsupportedOpFound = true; }
 
-//	    @Override public void visit(OpExtend opExtend)            { unsupportedOpFound = true; }
 	    @Override public void visit(OpExtend opExtend)            {} // supported
 
 	    //@Override public void visit(OpFind opFind)                { unsupportedOpFound = true; }


### PR DESCRIPTION
To handle the BIND clause of a SPARQL query, a new operator has been added:
- Add a logical operator for OpExtend: LogicalOpExtend
- In logical plan optimization, merge the BIND clause into a request operator if that request is for a SPARQL endpoint.

With this new operator, the issue mentioned [here](https://github.com/MaastrichtU-IDS/federatedQueryKG/issues/9) is partially solved (i.e., A SPARQL query with BIND clause can be answered over SPARQL endpoints).


TODOs: For complete support of BIND clause, the implementation of the physical operator and executable operator for OpExtend still needs to be done. 