### PR TITLE
Extend the implementation of 'ApplyVocabularyMappings'

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/LogicalOptimizerImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/LogicalOptimizerImpl.java
@@ -37,7 +37,7 @@ public class LogicalOptimizerImpl implements LogicalOptimizer
 		//// vocabulary mappings is only supported by the naive algorithm
 		//// currently since the cost model needs to be extended to consider
 		//// operators PhysicalOpLocalToGlobal and PhysicalOpGlobalToLocal.
-		//heuristics.add( new ApplyVocabularyMappings());
+		// heuristics.add( new ApplyVocabularyMappings(false) );
 	}
 
 	@Override


### PR DESCRIPTION
Extend the implementation of the class 'ApplyVocabularyMappings' to generate query plans that fully consider all possible vocabulary mapping, or generate a compressed version of the query plan by configuring 'compressVocabularyRewriting'.

In order to generate a compressed version of a query plan, check if adding an l2g operator over a request is necessary by examining the form of the graph pattern. 
(Note the current implementation assumes that only concepts and roles are considered in vocabulary mapping.)