### PR TITLE
Make NodeLabelMapping more flexible

### DIFF
--- a/ExampleLPG2RDF.ttl
+++ b/ExampleLPG2RDF.ttl
@@ -23,7 +23,19 @@ PREFIX ex:     <http://example.org/>
 #
 #ex:IRIBasedNodeLabelMapping a rdfs:Class ;
 #   rdfs:subClassOf ex:NodeLabelMapping .
+
 #
+#ex:RegexIRIBasedNodeLabelMapping a rdfs:Class ;
+#   rdfs:subClassOf ex:NodeLabelMapping .
+#
+#ex:SingleLiteralBasedNodeLabelMapping a rdfs:Class ;
+#   rdfs:subClassOf ex:NodeLabelMapping .
+#
+#ex:SingleIRIBasedNodeLabelMapping a rdfs:Class ;
+#   rdfs:subClassOf ex:NodeLabelMapping .
+#
+#ex:CombinedNodeLabelMapping a rdfs:Class ;
+#   rdfs:subClassOf ex:NodeLabelMapping .
 
 #ex:EdgeLabelMapping a rdfs:Class ;
 #
@@ -71,6 +83,14 @@ PREFIX ex:     <http://example.org/>
 #ex:prefixOfIRIs a rdf:Property ;
 #   rdfs:range xsd:anyURI .
 
+#ex:literal a rdf:Property ;
+#   rdfs:domain ex:SingleLiteralBasedNodeLabelMapping ;
+#   rdfs:range xsd:string .
+
+#ex:nodeLabelMappings a rdf:Property ;
+#   rdfs:domain ex:CombinedNodeLabelMapping ;
+#   rdfs:range rdfs:List .
+
 #ex:edgeLabelMapping a rdf:Property ;
 #   rdfs:domain ex:LPGtoRDFConfiguration ;
 #   rdfs:range ex:EdgeLabelMapping .
@@ -107,7 +127,12 @@ PREFIX ex:     <http://example.org/>
 ex:LPGtoRDFConfig a lr:LPGtoRDFConfiguration ;
     lr:labelPredicate "http://www.w3.org/2000/01/rdf-schema#label"^^xsd:anyURI ;
     lr:nodeMapping ex:IRINodeMapping ;
-    lr:nodeLabelMapping ex:IRINodeLabelMapping ;
+#   lr:nodeLabelMapping ex:LiteralNodeLabelMapping ;
+#   lr:nodeLabelMapping ex:IRINodeLabelMapping ;
+#   lr:nodeLabelMapping ex:RegexIRINodeLabelMapping ;
+#   lr:nodeLabelMapping ex:SingleLiteralNodeLabelMapping ;
+#   lr:nodeLabelMapping ex:SingleIRINodeLabelMapping ;
+    lr:nodeLabelMapping ex:CombinedNodeLabelMapping ;
 #   lr:edgeLabelMapping ex:IRIEdgeLabelMapping ;
 #   lr:edgeLabelMapping ex:RegexEdgeLabelMapping ;
 #   lr:edgeLabelMapping ex:SingleIRIEdgeLabelMapping ;
@@ -122,6 +147,23 @@ ex:IRINodeMapping a lr:IRIBasedNodeMapping ;
 
 ex:IRINodeLabelMapping a lr:IRIBasedNodeLabelMapping ;
     lr:prefixOfIRIs "https://example.org/label/"^^xsd:anyURI .
+
+ex:LiteralNodeLabelMapping a lr:LiteralBasedNodeLabelMapping .
+
+ex:RegexIRINodeLabelMapping a lr:RegexIRIBasedNodeLabelMapping ;
+    lr:regex "^\\w+" ;
+    lr:prefixOfIRIs "http://purl.org/dc/terms/"^^xsd:anyURI .
+
+ex:SingleIRINodeLabelMapping a lr:SingleIRIBasedNodeLabelMapping ;
+    lr:label "DIRECTED" ;
+    lr:iri "http://dsgfrjlk.org/kdfj/directorOf"^^xsd:anyURI .
+
+ex:SingleLiteralNodeLabelMapping a lr:SingleLiteralBasedNodeLabelMapping ;
+    lr:label "DIRECTED" ;
+    lr:literal "DirectorOf" .
+
+ex:CombinedNodeLabelMapping a lr:CombinedNodeLabelMapping ;
+    lr:nodeLabelMappings (ex:SingleLiteralNodeLabelMapping ex:SingleIRINodeLabelMapping ex:RegexIRINodeLabelMapping ex:IRINodeLabelMapping) .
 
 ex:IRIEdgeLabelMapping a lr:IRIBasedEdgeLabelMapping ;
     lr:prefixOfIRIs "https://example.org/relationship/"^^xsd:anyURI .

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/CombinedNodeLabelMappingImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/CombinedNodeLabelMappingImpl.java
@@ -1,0 +1,46 @@
+package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl;
+
+import org.apache.jena.graph.Node;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl.exceptions.UnSupportedNodeLabelException;
+
+import java.util.List;
+
+public class CombinedNodeLabelMappingImpl implements NodeLabelMapping {
+
+    protected final List<NodeLabelMapping> nodeLabelMappings;
+
+    public CombinedNodeLabelMappingImpl(final List<NodeLabelMapping> nodeLabelMappings){
+        this.nodeLabelMappings = nodeLabelMappings;
+    }
+
+    @Override
+    public Node map(final String label) {
+        for (final NodeLabelMapping nodeLabelMapping : nodeLabelMappings) {
+            try {
+                return nodeLabelMapping.map(label);
+            }
+            catch (final UnSupportedNodeLabelException e) {}
+        }
+        throw new UnSupportedNodeLabelException("The given node label (" + label + ") is not a supported label in the image of this node label mapping.");
+    }
+
+    public String unmap(final Node node) {
+        for (final NodeLabelMapping nodeLabelMapping : nodeLabelMappings) {
+            try {
+                return nodeLabelMapping.unmap(node);
+            }
+            catch (final UnSupportedNodeLabelException e) {}
+        }
+        throw new UnSupportedNodeLabelException("The given RDF term (" + node.toString() + ") is not an URI node or not in the image of this node label mapping.");
+    }
+
+    @Override
+    public boolean isPossibleResult(final Node node) {
+        for (final NodeLabelMapping nodeLabelMapping : nodeLabelMappings) {
+                if(nodeLabelMapping.isPossibleResult(node)){
+                    return true;
+                }
+        }
+        return false;
+    }
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/LPG2RDFConfigurationReader.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/LPG2RDFConfigurationReader.java
@@ -131,6 +131,179 @@ public class LPG2RDFConfigurationReader {
         }
     }
 
+    public NodeLabelMapping createIRIBasedNodeLabelMapping(final Resource nodeLabelMappingResource){
+        final StmtIterator prefixOfIRIsIterator = nodeLabelMappingResource.listProperties(LPG2RDF.prefixOfIRIs);
+        if(!prefixOfIRIsIterator.hasNext()){
+            throw new IllegalArgumentException("prefixOfIRIs is required!");
+        }
+        final RDFNode prefixOfIRIObj = prefixOfIRIsIterator.next().getObject();
+        if(prefixOfIRIsIterator.hasNext()){
+            throw new IllegalArgumentException("An instance of IRIBasedNodeLabelMapping has more than one prefixOfIRIs property!");
+        }
+
+        if (!prefixOfIRIObj.isLiteral() || !prefixOfIRIObj.asLiteral().getDatatypeURI().equals(XSD.anyURI.getURI())){
+            throw new IllegalArgumentException("prefixOfIRIs is invalid, it should be a xsd:anyURI!");
+        }
+        final String prefixOfIRIUri = prefixOfIRIObj.asLiteral().getString();
+        try{
+            return new NodeLabelMappingToURIsImpl(URI.create(prefixOfIRIUri).toString());
+        }
+        catch (final IllegalArgumentException e){
+            throw new IllegalArgumentException("prefixOfIRIs (" + prefixOfIRIUri + ") is an invalid URI!");
+        }
+    }
+
+    public NodeLabelMapping createRegexIRIBasedNodeLabelMapping(final Resource nodeLabelMappingResource){
+        final StmtIterator regexIterator = nodeLabelMappingResource.listProperties(LPG2RDF.regex);
+        if (!regexIterator.hasNext()) {
+            throw new IllegalArgumentException("regex is required!");
+        }
+        final RDFNode regexObj = regexIterator.next().getObject();
+        if (regexIterator.hasNext()) {
+            throw new IllegalArgumentException("An instance of RegexIRIBasedNodeLabelMapping has more than one regex property!");
+        }
+
+        if (!regexObj.isLiteral() || !regexObj.asLiteral().getDatatypeURI().equals(XSD.xstring.getURI())) {
+            throw new IllegalArgumentException("Regex is invalid, it should be a xsd:string!");
+        }
+        final StmtIterator prefixOfIRIsIterator = nodeLabelMappingResource.listProperties(LPG2RDF.prefixOfIRIs);
+        if(!prefixOfIRIsIterator.hasNext()){
+            throw new IllegalArgumentException("prefixOfIRIs is required!");
+        }
+        final RDFNode prefixOfIRIObj = prefixOfIRIsIterator.next().getObject();
+        if(prefixOfIRIsIterator.hasNext()){
+            throw new IllegalArgumentException("An instance of RegexIRIBasedNodeLabelMapping has more than one prefixOfIRIs property!");
+        }
+
+        if (!prefixOfIRIObj.isLiteral() || !prefixOfIRIObj.asLiteral().getDatatypeURI().equals(XSD.anyURI.getURI())){
+            throw new IllegalArgumentException("prefixOfIRIs is invalid, it should be a xsd:anyURI!");
+        }
+        final String regex = regexObj.asLiteral().getString();
+        final String prefixOfIRIUri = prefixOfIRIObj.asLiteral().getString();
+        try {
+            return new RegexBasedNodeLabelMappingToURIsImpl(regex, URI.create(prefixOfIRIUri).toString());
+        } catch (final IllegalArgumentException e) {
+            throw new IllegalArgumentException("prefixOfIRIs (" + prefixOfIRIUri + ") is an invalid URI!");
+        }
+    }
+
+    public NodeLabelMapping createSingleIRIBasedNodeLabelMapping(final Resource nodeLabelMappingResource){
+        final StmtIterator labelIterator = nodeLabelMappingResource.listProperties(LPG2RDF.label);
+        if (!labelIterator.hasNext()) {
+            throw new IllegalArgumentException("label is required!");
+        }
+        final RDFNode labelObj = labelIterator.next().getObject();
+        if (labelIterator.hasNext()) {
+            throw new IllegalArgumentException("An instance of SingleIRIBasedNodeLabelMapping has more than one label property!");
+        }
+
+        if (!labelObj.isLiteral() || !labelObj.asLiteral().getDatatypeURI().equals(XSD.xstring.getURI())) {
+            throw new IllegalArgumentException("Label is invalid, it should be a xsd:string!");
+        }
+        final StmtIterator iriIterator = nodeLabelMappingResource.listProperties(LPG2RDF.iri);
+        if(!iriIterator.hasNext()){
+            throw new IllegalArgumentException("iri is required!");
+        }
+        final RDFNode iriObj = iriIterator.next().getObject();
+        if(iriIterator.hasNext()){
+            throw new IllegalArgumentException("An instance of SingleIRIBasedNodeLabelMapping has more than one iri property!");
+        }
+
+        if (!iriObj.isLiteral() || !iriObj.asLiteral().getDatatypeURI().equals(XSD.anyURI.getURI())){
+            throw new IllegalArgumentException("iri is invalid, it should be a xsd:anyURI!");
+        }
+        final String label = labelObj.asLiteral().getString();
+        final String iri = iriObj.asLiteral().getString();
+        try {
+            return new SingleNodeLabelMappingToURIsImpl(label,iri);
+        } catch (final IllegalArgumentException e) {
+            throw new IllegalArgumentException("iri (" + iri +") is an invalid URI!");
+        }
+    }
+
+    public NodeLabelMapping createSingleLiteralBasedNodeLabelMapping(final Resource nodeLabelMappingResource){
+        final StmtIterator labelIterator = nodeLabelMappingResource.listProperties(LPG2RDF.label);
+        if (!labelIterator.hasNext()) {
+            throw new IllegalArgumentException("label is required!");
+        }
+        final RDFNode labelObj = labelIterator.next().getObject();
+        if (labelIterator.hasNext()) {
+            throw new IllegalArgumentException("An instance of SingleLiteralBasedNodeLabelMapping has more than one label property!");
+        }
+
+        if (!labelObj.isLiteral() || !labelObj.asLiteral().getDatatypeURI().equals(XSD.xstring.getURI())) {
+            throw new IllegalArgumentException("Label is invalid, it should be a xsd:string!");
+        }
+        final StmtIterator literalIterator = nodeLabelMappingResource.listProperties(LPG2RDF.literal);
+        if(!literalIterator.hasNext()){
+            throw new IllegalArgumentException("literal is required!");
+        }
+        final RDFNode literalObj = literalIterator.next().getObject();
+        if(literalIterator.hasNext()){
+            throw new IllegalArgumentException("An instance of SingleLiteralBasedNodeLabelMapping has more than one literal property!");
+        }
+
+        if (!literalObj.isLiteral() || !literalObj.asLiteral().getDatatypeURI().equals(XSD.xstring.getURI())){
+            throw new IllegalArgumentException("literal is invalid, it should be a xsd:string!");
+        }
+        final String label = labelObj.asLiteral().getString();
+        final String literal = literalObj.asLiteral().getString();
+        return new SingleNodeLabelMappingToLiteralsImpl(label,literal);
+    }
+
+    public NodeLabelMapping createCombinedNodeLabelMapping(final Resource nodeLabelMappingResource){
+        final List<NodeLabelMapping> nodeLabelMappings = new ArrayList<>();
+        final StmtIterator nodeLabelMappingsPropertyIterator = nodeLabelMappingResource.listProperties(LPG2RDF.nodeLabelMappings);
+        if (!nodeLabelMappingsPropertyIterator.hasNext()) {
+            throw new IllegalArgumentException("nodeLabelMappings is required!");
+        }
+        final RDFNode nodeLabelMappingsList = nodeLabelMappingsPropertyIterator.next().getObject();
+        if(!nodeLabelMappingsList.canAs(RDFList.class)){
+            throw new IllegalArgumentException("NodeLabelMappings property of CombinedNodeLabelMapping should be a list!");
+        }
+        final Iterator nodeLabelMappingsIterator = nodeLabelMappingsList.as(RDFList.class).iterator();
+
+        if (!nodeLabelMappingsIterator.hasNext()) {
+            throw new IllegalArgumentException("NodeLabelMappings list of CombinedNodeLabelMapping should not be empty!");
+        }
+
+        do{
+            final Resource nodeLabelMapping = (Resource)nodeLabelMappingsIterator.next();
+            final RDFNode nodeLabelMappingType = nodeLabelMapping.getProperty(RDF.type).getObject();
+            if(nodeLabelMappingType.equals(LPG2RDF.CombinedNodeLabelMapping)
+                    || (nodeLabelMappingType.equals(LPG2RDF.NodeLabelMapping) && nodeLabelMapping.hasProperty(LPG2RDF.nodeLabelMappings))){
+                throw new IllegalArgumentException("CombinedNodeLabelMapping Should not have an object of CombinedNodeLabelMapping as nodeLabelMapping!");
+            }
+            nodeLabelMappings.add(createNodeLabelMapping(nodeLabelMapping, nodeLabelMappingType));
+        }while(nodeLabelMappingsIterator.hasNext());
+        return new CombinedNodeLabelMappingImpl(nodeLabelMappings);
+    }
+
+    public NodeLabelMapping createNodeLabelMapping(final Resource nodeLabelMappingResource, final RDFNode nodeLabelMappingResourceType){
+        if (nodeLabelMappingResourceType.equals(LPG2RDF.RegexIRIBasedNodeLabelMapping)
+                || (nodeLabelMappingResourceType.equals(LPG2RDF.NodeLabelMapping) && nodeLabelMappingResource.hasProperty(LPG2RDF.regex)&& nodeLabelMappingResource.hasProperty(LPG2RDF.prefixOfIRIs))) {
+            return createRegexIRIBasedNodeLabelMapping(nodeLabelMappingResource);
+        }else if ( nodeLabelMappingResourceType.equals(LPG2RDF.IRIBasedNodeLabelMapping)
+                || (nodeLabelMappingResourceType.equals(LPG2RDF.NodeLabelMapping) && nodeLabelMappingResource.hasProperty(LPG2RDF.prefixOfIRIs)) ) {
+            return createIRIBasedNodeLabelMapping(nodeLabelMappingResource);
+        } else if (nodeLabelMappingResourceType.equals(LPG2RDF.LiteralBasedNodeLabelMapping)) {
+            return new NodeLabelMappingToLiteralsImpl();
+        } else if (nodeLabelMappingResourceType.equals(LPG2RDF.SingleIRIBasedNodeLabelMapping)
+                || (nodeLabelMappingResourceType.equals(LPG2RDF.NodeLabelMapping) && nodeLabelMappingResource.hasProperty(LPG2RDF.label)
+                && nodeLabelMappingResource.hasProperty(LPG2RDF.iri))) {
+            return createSingleIRIBasedNodeLabelMapping(nodeLabelMappingResource);
+        }else if (nodeLabelMappingResourceType.equals(LPG2RDF.SingleLiteralBasedNodeLabelMapping)
+                || (nodeLabelMappingResourceType.equals(LPG2RDF.NodeLabelMapping) && nodeLabelMappingResource.hasProperty(LPG2RDF.label)
+                && nodeLabelMappingResource.hasProperty(LPG2RDF.literal))) {
+            return createSingleLiteralBasedNodeLabelMapping(nodeLabelMappingResource);
+        } else if (nodeLabelMappingResourceType.equals(LPG2RDF.CombinedNodeLabelMapping)
+                || (nodeLabelMappingResourceType.equals(LPG2RDF.NodeLabelMapping) && nodeLabelMappingResource.hasProperty(LPG2RDF.nodeLabelMappings))) {
+            return createCombinedNodeLabelMapping(nodeLabelMappingResource);
+        } else {
+            throw new IllegalArgumentException("NodeLabelMapping type (" + nodeLabelMappingResourceType + ") is unexpected!");
+        }
+    }
+
     public NodeLabelMapping getNodeLabelMapping(final Model lpg2Rdf, final Resource lpg2rdfConfig){
 
         final StmtIterator nodeLabelMappingIterator = lpg2rdfConfig.listProperties(LPG2RDF.nodeLabelMapping);
@@ -145,34 +318,7 @@ public class LPG2RDFConfigurationReader {
 
         final RDFNode nodeLabelMappingResourceType = lpg2Rdf.getRequiredProperty(nodeLabelMappingResource, RDF.type).getObject();
 
-        if ( nodeLabelMappingResourceType.equals(LPG2RDF.IRIBasedNodeLabelMapping)
-                || (nodeLabelMappingResourceType.equals(LPG2RDF.NodeLabelMapping) && nodeLabelMappingResource.hasProperty(LPG2RDF.prefixOfIRIs)) ) {
-            final StmtIterator prefixOfIRIsIterator = nodeLabelMappingResource.listProperties(LPG2RDF.prefixOfIRIs);
-            if(!prefixOfIRIsIterator.hasNext()){
-                throw new IllegalArgumentException("prefixOfIRIs is required!");
-            }
-            final RDFNode prefixOfIRIObj = prefixOfIRIsIterator.next().getObject();
-            if(prefixOfIRIsIterator.hasNext()){
-                throw new IllegalArgumentException("An instance of IRIBasedNodeLabelMapping has more than one prefixOfIRIs property!");
-            }
-
-            if (!prefixOfIRIObj.isLiteral() || !prefixOfIRIObj.asLiteral().getDatatypeURI().equals(XSD.anyURI.getURI())){
-                throw new IllegalArgumentException("prefixOfIRIs is invalid, it should be a xsd:anyURI!");
-            }
-            final String prefixOfIRIUri = prefixOfIRIObj.asLiteral().getString();
-            try{
-                return new NodeLabelMappingToURIsImpl(URI.create(prefixOfIRIUri).toString());
-            }
-            catch (final IllegalArgumentException e){
-                throw new IllegalArgumentException("prefixOfIRIs (" + prefixOfIRIUri + ") is an invalid URI!");
-            }
-        }
-        else if ( nodeLabelMappingResourceType.equals(LPG2RDF.LiteralBasedNodeLabelMapping)) {
-            return new NodeLabelMappingToLiteralsImpl();
-        }
-        else {
-            throw new IllegalArgumentException("NodeLabelMapping type (" + nodeLabelMappingResourceType + ") is unexpected!");
-        }
+        return createNodeLabelMapping(nodeLabelMappingResource, nodeLabelMappingResourceType);
     }
 
     public EdgeLabelMapping createIRIBasedEdgeLabelMapping(final Resource edgeLabelMappingResource){
@@ -294,15 +440,14 @@ public class LPG2RDFConfigurationReader {
     }
 
     public EdgeLabelMapping createEdgeLabelMapping(final Resource edgeLabelMappingResource, final RDFNode edgeLabelMappingResourceType){
-        if ( edgeLabelMappingResourceType.equals(LPG2RDF.IRIBasedEdgeLabelMapping)
-                || (edgeLabelMappingResourceType.equals(LPG2RDF.EdgeLabelMapping) && edgeLabelMappingResource.hasProperty(LPG2RDF.prefixOfIRIs)) ) {
-            return createIRIBasedEdgeLabelMapping(edgeLabelMappingResource);
-        }
-        else if ( edgeLabelMappingResourceType.equals(LPG2RDF.RegexBasedEdgeLabelMapping)
+        if ( edgeLabelMappingResourceType.equals(LPG2RDF.RegexBasedEdgeLabelMapping)
                 || (edgeLabelMappingResourceType.equals(LPG2RDF.EdgeLabelMapping) && edgeLabelMappingResource.hasProperty(LPG2RDF.regex)) ) {
             return createRegexBasedEdgeLabelMapping(edgeLabelMappingResource);
         }
-
+        else if ( edgeLabelMappingResourceType.equals(LPG2RDF.IRIBasedEdgeLabelMapping)
+                || (edgeLabelMappingResourceType.equals(LPG2RDF.EdgeLabelMapping) && edgeLabelMappingResource.hasProperty(LPG2RDF.prefixOfIRIs)) ) {
+            return createIRIBasedEdgeLabelMapping(edgeLabelMappingResource);
+        }
         else if ( edgeLabelMappingResourceType.equals(LPG2RDF.SingleEdgeLabelMapping)
                 || (edgeLabelMappingResourceType.equals(LPG2RDF.EdgeLabelMapping) && edgeLabelMappingResource.hasProperty(LPG2RDF.label)
                 && edgeLabelMappingResource.hasProperty(LPG2RDF.iri))) {
@@ -453,13 +598,13 @@ public class LPG2RDFConfigurationReader {
     }
 
     public PropertyNameMapping createPropertyNameMapping(final Resource propertyNameMappingResource, final RDFNode propertyNameMappingResourceType){
-        if ( propertyNameMappingResourceType.equals(LPG2RDF.IRIBasedPropertyNameMapping)
-                || (propertyNameMappingResourceType.equals(LPG2RDF.PropertyNameMapping) && propertyNameMappingResource.hasProperty(LPG2RDF.prefixOfIRIs)) ) {
-            return createIRIBasedPropertyNameMapping(propertyNameMappingResource);
-        }
-        else if ( propertyNameMappingResourceType.equals(LPG2RDF.RegexBasedPropertyNameMapping)
+        if ( propertyNameMappingResourceType.equals(LPG2RDF.RegexBasedPropertyNameMapping)
                 || (propertyNameMappingResourceType.equals(LPG2RDF.PropertyNameMapping) && propertyNameMappingResource.hasProperty(LPG2RDF.regex)) ) {
             return createRegexBasedPropertyNameMapping(propertyNameMappingResource);
+        }
+        else if ( propertyNameMappingResourceType.equals(LPG2RDF.IRIBasedPropertyNameMapping)
+                || (propertyNameMappingResourceType.equals(LPG2RDF.PropertyNameMapping) && propertyNameMappingResource.hasProperty(LPG2RDF.prefixOfIRIs)) ) {
+            return createIRIBasedPropertyNameMapping(propertyNameMappingResource);
         }
         else if ( propertyNameMappingResourceType.equals(LPG2RDF.SinglePropertyNameMapping)
                 || (propertyNameMappingResourceType.equals(LPG2RDF.PropertyNameMapping) && propertyNameMappingResource.hasProperty(LPG2RDF.propertyName)

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/NodeLabelMappingToLiteralsImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/NodeLabelMappingToLiteralsImpl.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.vocabulary.XSD;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl.exceptions.UnSupportedNodeLabelException;
 
 public class NodeLabelMappingToLiteralsImpl implements NodeLabelMapping{
 
@@ -14,7 +15,7 @@ public class NodeLabelMappingToLiteralsImpl implements NodeLabelMapping{
     @Override
     public String unmap(final Node node) {
         if (!isPossibleResult(node))
-            throw new IllegalArgumentException("The given RDF term (" + node.toString() + ") is not a literal.");
+            throw new UnSupportedNodeLabelException("The given RDF term (" + node.toString() + ") is not a literal.");
         return node.getLiteralLexicalForm();
     }
 

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/NodeLabelMappingToURIsImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/NodeLabelMappingToURIsImpl.java
@@ -2,6 +2,7 @@ package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl.exceptions.UnSupportedNodeLabelException;
 
 public class NodeLabelMappingToURIsImpl implements NodeLabelMapping{
 
@@ -20,7 +21,7 @@ public class NodeLabelMappingToURIsImpl implements NodeLabelMapping{
     @Override
     public String unmap(final Node node) {
         if (!isPossibleResult(node))
-            throw new IllegalArgumentException("The given RDF term (" + node.toString() + ") is not an URI node or not in the image of this node label mapping.");
+            throw new UnSupportedNodeLabelException("The given RDF term (" + node.toString() + ") is not an URI node or not in the image of this node label mapping.");
         return node.getURI().replaceAll(NSNODELABEL, "");
     }
 

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/RegexBasedNodeLabelMappingToURIsImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/RegexBasedNodeLabelMappingToURIsImpl.java
@@ -1,0 +1,24 @@
+package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl;
+
+import org.apache.jena.graph.Node;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl.exceptions.UnSupportedNodeLabelException;
+
+public class RegexBasedNodeLabelMappingToURIsImpl extends NodeLabelMappingToURIsImpl {
+
+    protected final String regex;
+
+    public RegexBasedNodeLabelMappingToURIsImpl(final String regex, final String NSNODELABEL){
+        super(NSNODELABEL);
+        this.regex = regex;
+    }
+
+    @Override
+    public Node map(final String label) {
+        if (label.matches(regex)) {
+            return super.map(label);
+        }
+        else {
+            throw new UnSupportedNodeLabelException("The given node label (" + label + ") is not a supported label in the image of this node label mapping.");
+        }
+    }
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SingleNodeLabelMappingToLiteralsImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SingleNodeLabelMappingToLiteralsImpl.java
@@ -33,7 +33,7 @@ public class SingleNodeLabelMappingToLiteralsImpl implements NodeLabelMapping {
 
     @Override
     public boolean isPossibleResult(final Node node) {
-        return node.isLiteral() && XSD.xstring.getURI().equals(node.getLiteral().getDatatypeURI()) && node.getLiteral().toString().equals(this.node.getLiteral().toString());
+        return node.equals( this.node );
     }
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SingleNodeLabelMappingToLiteralsImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SingleNodeLabelMappingToLiteralsImpl.java
@@ -1,0 +1,39 @@
+package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.vocabulary.XSD;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl.exceptions.UnSupportedNodeLabelException;
+
+public class SingleNodeLabelMappingToLiteralsImpl implements NodeLabelMapping {
+
+    protected final String label;
+    protected final Node node;
+
+    public SingleNodeLabelMappingToLiteralsImpl(final String label, final String literal){
+        this.label=label;
+        this.node = NodeFactory.createLiteral(literal);
+    }
+
+    @Override
+    public Node map(final String label) {
+        if (label.equals(this.label)) {
+            return this.node;
+        }
+        else {
+            throw new UnSupportedNodeLabelException("The given node label (" + label + ") is not a supported label in the image of this node label mapping.");
+        }
+    }
+
+    public String unmap(final Node node) {
+        if (!isPossibleResult(node))
+            throw new UnSupportedNodeLabelException("The given RDF term (" + node.toString() + ") is not a literal.");
+        return this.label;
+    }
+
+    @Override
+    public boolean isPossibleResult(final Node node) {
+        return node.isLiteral() && XSD.xstring.getURI().equals(node.getLiteral().getDatatypeURI()) && node.getLiteral().toString().equals(this.node.getLiteral().toString());
+    }
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SingleNodeLabelMappingToURIsImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SingleNodeLabelMappingToURIsImpl.java
@@ -1,0 +1,38 @@
+package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl.exceptions.UnSupportedNodeLabelException;
+
+public class SingleNodeLabelMappingToURIsImpl implements NodeLabelMapping {
+
+    protected final String label;
+    protected final Node node;
+
+    public SingleNodeLabelMappingToURIsImpl(final String label, final String iri){
+        this.label=label;
+        this.node = NodeFactory.createURI(iri);
+    }
+
+    @Override
+    public Node map(final String label) {
+        if (label.equals(this.label)) {
+            return this.node;
+        }
+        else {
+            throw new UnSupportedNodeLabelException("The given node label (" + label + ") is not a supported label in the image of this node label mapping.");
+        }
+    }
+
+    public String unmap(final Node node) {
+        if (!isPossibleResult(node))
+            throw new UnSupportedNodeLabelException("The given RDF term (" + node.toString() + ") is not an URI node or not in the image of this node label mapping.");
+        return this.label;
+    }
+
+    @Override
+    public boolean isPossibleResult(final Node node) {
+        return node.isURI() && node.getURI().equals(this.node.getURI());
+    }
+
+}

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SingleNodeLabelMappingToURIsImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SingleNodeLabelMappingToURIsImpl.java
@@ -32,7 +32,7 @@ public class SingleNodeLabelMappingToURIsImpl implements NodeLabelMapping {
 
     @Override
     public boolean isPossibleResult(final Node node) {
-        return node.isURI() && node.getURI().equals(this.node.getURI());
+        return node.equals( this.node );
     }
 
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/exceptions/UnSupportedNodeLabelException.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/exceptions/UnSupportedNodeLabelException.java
@@ -1,0 +1,8 @@
+package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl.exceptions;
+
+public class UnSupportedNodeLabelException extends IllegalArgumentException{
+
+    public UnSupportedNodeLabelException(final String message){
+        super(message);
+    }
+}

--- a/src/main/java/se/liu/ida/hefquin/vocabulary/LPG2RDF.java
+++ b/src/main/java/se/liu/ida/hefquin/vocabulary/LPG2RDF.java
@@ -24,6 +24,10 @@ public class LPG2RDF {
     public static final Resource NodeLabelMapping = resource("NodeLabelMapping");
     public static final Resource IRIBasedNodeLabelMapping = resource("IRIBasedNodeLabelMapping");
     public static final Resource LiteralBasedNodeLabelMapping = resource("LiteralBasedNodeLabelMapping");
+    public static final Resource RegexIRIBasedNodeLabelMapping = resource("RegexIRIBasedNodeLabelMapping");
+    public static final Resource SingleLiteralBasedNodeLabelMapping = resource("SingleLiteralBasedNodeLabelMapping");
+    public static final Resource SingleIRIBasedNodeLabelMapping = resource("SingleIRIBasedNodeLabelMapping");
+    public static final Resource CombinedNodeLabelMapping = resource("CombinedNodeLabelMapping");
     public static final Resource EdgeLabelMapping = resource("EdgeLabelMapping");
     public static final Resource IRIBasedEdgeLabelMapping = resource("IRIBasedEdgeLabelMapping");
     public static final Resource RegexBasedEdgeLabelMapping = resource("RegexBasedEdgeLabelMapping");
@@ -38,6 +42,7 @@ public class LPG2RDF {
     public static final Property labelPredicate = property("labelPredicate");
     public static final Property nodeMapping = property("nodeMapping");
     public static final Property nodeLabelMapping = property("nodeLabelMapping");
+    public static final Property nodeLabelMappings = property("nodeLabelMappings");
     public static final Property edgeLabelMapping = property("edgeLabelMapping");
     public static final Property edgeLabelMappings = property("edgeLabelMappings");
     public static final Property propertyNameMapping = property("propertyNameMapping");
@@ -47,5 +52,6 @@ public class LPG2RDF {
     public static final Property regex = property("regex");
     public static final Property label = property("label");
     public static final Property iri = property("iri");
+    public static final Property literal = property("literal");
 
 }

--- a/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/CombinedNodeLabelMappingImplTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/CombinedNodeLabelMappingImplTest.java
@@ -1,0 +1,116 @@
+package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.junit.Test;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl.exceptions.UnSupportedNodeLabelException;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class CombinedNodeLabelMappingImplTest {
+
+    protected final List<NodeLabelMapping> nodeLabelMappings = new ArrayList<NodeLabelMapping>(Arrays.asList(
+            new SingleNodeLabelMappingToURIsImpl("0","http://singleExample.org/zero"),
+            new SingleNodeLabelMappingToLiteralsImpl("3","three"),
+            new RegexBasedNodeLabelMappingToURIsImpl("^[0-9]+", "https://example2.org/test/"),
+            new NodeLabelMappingToURIsImpl("https://example.org/label/")
+    ));
+
+    protected final NodeLabelMapping nodeLabelMapping = new CombinedNodeLabelMappingImpl(nodeLabelMappings);
+
+    @Test
+    public void mapSingleNodeLabel() {
+        Node resultNode = nodeLabelMapping.map("0");
+        assertNotNull(resultNode);
+        assertTrue(resultNode.isURI());
+        assertEquals(resultNode.getURI(),"http://singleExample.org/zero");
+
+        resultNode = nodeLabelMapping.map("3");
+        assertNotNull(resultNode);
+        assertTrue(resultNode.isLiteral());
+        assertEquals(resultNode.getLiteral().toString(), "three");
+
+        resultNode = nodeLabelMapping.map("100");
+        assertNotNull(resultNode);
+        assertTrue(resultNode.isURI());
+        assertEquals(resultNode.getURI(),"https://example2.org/test/100");
+
+        resultNode = nodeLabelMapping.map("DIRECTED");
+        assertNotNull(resultNode);
+        assertTrue(resultNode.isURI());
+        assertEquals(resultNode.getURI(),"https://example.org/label/DIRECTED");
+    }
+
+    @Test
+    public void unmapSingleURINodeLabel(){
+        Node node = NodeFactory.createURI("http://singleExample.org/zero");
+        String resultString = nodeLabelMapping.unmap(node);
+        assertNotNull(resultString);
+        assertEquals(resultString, "0");
+
+        node = NodeFactory.createLiteral("three");
+        resultString = nodeLabelMapping.unmap(node);
+        assertNotNull(resultString);
+        assertEquals(resultString, "3");
+
+        node = NodeFactory.createURI("https://example2.org/test/100");
+        resultString = nodeLabelMapping.unmap(node);
+        assertNotNull(resultString);
+        assertEquals(resultString, "100");
+
+        node = NodeFactory.createURI("https://example.org/label/DIRECTED");
+        resultString = nodeLabelMapping.unmap(node);
+        assertNotNull(resultString);
+        assertEquals(resultString, "DIRECTED");
+    }
+
+    @Test
+    public void nodeLabelIsPossibleResult(){
+
+        Node node = NodeFactory.createURI("http://singleExample.org/zero");
+        boolean IRIIsPossible = nodeLabelMapping.isPossibleResult(node);
+        assertTrue(IRIIsPossible);
+
+        node = NodeFactory.createLiteral("three");
+        IRIIsPossible = nodeLabelMapping.isPossibleResult(node);
+        assertTrue(IRIIsPossible);
+
+        node = NodeFactory.createURI("https://example2.org/test/100");
+        IRIIsPossible = nodeLabelMapping.isPossibleResult(node);
+        assertTrue(IRIIsPossible);
+
+        node = NodeFactory.createURI("https://example.org/label/DIRECTED");
+        IRIIsPossible = nodeLabelMapping.isPossibleResult(node);
+        assertTrue(IRIIsPossible);
+
+        node = NodeFactory.createURI("https://invalid.url.org/label/DIRECTED");
+        IRIIsPossible = nodeLabelMapping.isPossibleResult(node);
+        assertFalse(IRIIsPossible);
+    }
+
+
+
+    /*
+     * In this test case, a node with an invalid URI is provided as an argument to the CombinedNodeLabelMappingImpl.
+     */
+    @Test(expected = UnSupportedNodeLabelException.class)
+    public void unmapNodeLabelWithInvalidURI(){
+        final Node node = NodeFactory.createURI("https://invalid.url.org/label/DIRECTED");
+        nodeLabelMapping.unmap(node);
+    }
+
+    /*
+     * In this test case, an unsupported Literal node is provided as an argument to the CombinedNodeLabelMappingImpl.
+     */
+    @Test(expected = UnSupportedNodeLabelException.class)
+    public void unmapNodeLabelWithInvalidLiteral(){
+        final Node node = NodeFactory.createLiteral("test");
+        nodeLabelMapping.unmap(node);
+    }
+
+
+}

--- a/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/LPG2RDFConfigurationReaderTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/LPG2RDFConfigurationReaderTest.java
@@ -80,6 +80,306 @@ public class LPG2RDFConfigurationReaderTest {
     }
 
     @Test
+    public void LPG2RDFConfigWithIRIBasedNodeMappingAndRegexIRIBasedNodeLabelMapping() {
+        final String turtle =
+                "PREFIX lr:     <http://www.example.org/se/liu/ida/hefquin/lpg2rdf#>\n"
+                        + "PREFIX ex:     <http://example.org/>\n"
+                        + "PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>\n"
+                        + "\n"
+                        + "ex:LPGtoRDFConfig\n"
+                        + "   a  lr:LPGtoRDFConfiguration ;\n"
+                        + "   lr:labelPredicate  \"http://www.w3.org/2000/01/rdf-schema#label\"^^xsd:anyURI ;\n"
+                        + "   lr:nodeMapping  ex:IRINodeMapping ;\n"
+                        + "   lr:nodeLabelMapping ex:RegexIRINodeLabelMapping ;\n"
+                        + "   lr:edgeLabelMapping ex:IRIEdgeLabelMapping ;\n"
+                        + "   lr:propertyNameMapping ex:IRIPropertyNameMapping ."
+                        + "\n"
+                        + "ex:RegexIRINodeLabelMapping\n"
+                        + "   a  lr:RegexIRIBasedNodeLabelMapping ;\n"
+                        + "   lr:regex  \"[0-9]+\" ;\n"
+                        + "   lr:prefixOfIRIs  \"https://test.org/test/\"^^xsd:anyURI ."
+                        + "\n"
+                        + "ex:IRIEdgeLabelMapping\n"
+                        + "   a  lr:IRIBasedEdgeLabelMapping ;\n"
+                        + "   lr:prefixOfIRIs  \"https://example.org/relationship/\"^^xsd:anyURI ."
+                        + "\n"
+                        + "ex:IRIPropertyNameMapping\n"
+                        + "   a  lr:IRIBasedPropertyNameMapping ;\n"
+                        + "   lr:prefixOfIRIs  \"https://example.org/property/\"^^xsd:anyURI ."
+                        + "\n"
+                        + "ex:IRINodeMapping\n"
+                        + "   a  lr:IRIBasedNodeMapping ;\n"
+                        + "   lr:prefixOfIRIs  \"https://example.org/node/\"^^xsd:anyURI .";
+
+        final Model lpg2rdf = ModelFactory.createDefaultModel();
+
+        final RDFParserBuilder b = RDFParser.fromString(turtle);
+        b.lang( Lang.TURTLE );
+        b.parse(lpg2rdf);
+
+        final LPG2RDFConfiguration lpg2RDFConfiguration = LPG2RDFConfigurationReader.readFromModel(lpg2rdf);
+        assert(lpg2RDFConfiguration.getLabel().isURI());
+        assert(lpg2RDFConfiguration.getLabel().getURI().equals("http://www.w3.org/2000/01/rdf-schema#label"));
+        final LPGNode node = new LPGNode("0", null, null);
+        final Node resultNode = lpg2RDFConfiguration.mapNode(node);
+        assertNotNull(resultNode);
+        assertTrue(resultNode.isURI());
+        assertEquals(resultNode.getURI(), "https://example.org/node/0");
+
+        final String label = "0";
+        final Node resultNodeLabel = lpg2RDFConfiguration.mapNodeLabel(label);
+        assertNotNull(resultNodeLabel);
+        assertTrue(resultNodeLabel.isURI());
+        assertEquals(resultNodeLabel.getURI(), "https://test.org/test/0");
+
+        final Node resultEdgeLabel = lpg2RDFConfiguration.mapEdgeLabel(label);
+        assertNotNull(resultEdgeLabel);
+        assertTrue(resultEdgeLabel.isURI());
+        assertEquals(resultEdgeLabel.getURI(), "https://example.org/relationship/0");
+
+        final String propertyName = "0";
+        final Node resultPropertyName = lpg2RDFConfiguration.mapProperty(propertyName);
+        assertNotNull(resultPropertyName);
+        assertTrue(resultPropertyName.isURI());
+        assertEquals(resultPropertyName.getURI(), "https://example.org/property/0");
+    }
+
+    @Test
+    public void LPG2RDFConfigWithIRIBasedNodeMappingAndSingleIRIBasedNodeLabelMapping() {
+        final String turtle =
+                "PREFIX lr:     <http://www.example.org/se/liu/ida/hefquin/lpg2rdf#>\n"
+                        + "PREFIX ex:     <http://example.org/>\n"
+                        + "PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>\n"
+                        + "\n"
+                        + "ex:LPGtoRDFConfig\n"
+                        + "   a  lr:LPGtoRDFConfiguration ;\n"
+                        + "   lr:labelPredicate  \"http://www.w3.org/2000/01/rdf-schema#label\"^^xsd:anyURI ;\n"
+                        + "   lr:nodeMapping  ex:IRINodeMapping ;\n"
+                        + "   lr:nodeLabelMapping ex:SingleIRINodeLabelMapping ;\n"
+                        + "   lr:edgeLabelMapping ex:IRIEdgeLabelMapping ;\n"
+                        + "   lr:propertyNameMapping ex:IRIPropertyNameMapping ."
+                        + "\n"
+                        + "ex:SingleIRINodeLabelMapping\n"
+                        + "   a  lr:SingleIRIBasedNodeLabelMapping ;\n"
+                        + "   lr:label \"DIRECTED\" ;\n"
+                        + "   lr:iri \"http://singleExample.org/directorOf\"^^xsd:anyURI ."
+                        + "\n"
+                        + "ex:IRIEdgeLabelMapping\n"
+                        + "   a  lr:IRIBasedEdgeLabelMapping ;\n"
+                        + "   lr:prefixOfIRIs  \"https://example.org/relationship/\"^^xsd:anyURI ."
+                        + "\n"
+                        + "ex:IRIPropertyNameMapping\n"
+                        + "   a  lr:IRIBasedPropertyNameMapping ;\n"
+                        + "   lr:prefixOfIRIs  \"https://example.org/property/\"^^xsd:anyURI ."
+                        + "\n"
+                        + "ex:IRINodeMapping\n"
+                        + "   a  lr:IRIBasedNodeMapping ;\n"
+                        + "   lr:prefixOfIRIs  \"https://example.org/node/\"^^xsd:anyURI .";
+
+        final Model lpg2rdf = ModelFactory.createDefaultModel();
+
+        final RDFParserBuilder b = RDFParser.fromString(turtle);
+        b.lang( Lang.TURTLE );
+        b.parse(lpg2rdf);
+
+        final LPG2RDFConfiguration lpg2RDFConfiguration = LPG2RDFConfigurationReader.readFromModel(lpg2rdf);
+        assert(lpg2RDFConfiguration.getLabel().isURI());
+        assert(lpg2RDFConfiguration.getLabel().getURI().equals("http://www.w3.org/2000/01/rdf-schema#label"));
+        final LPGNode node = new LPGNode("0", null, null);
+        final Node resultNode = lpg2RDFConfiguration.mapNode(node);
+        assertNotNull(resultNode);
+        assertTrue(resultNode.isURI());
+        assertEquals(resultNode.getURI(), "https://example.org/node/0");
+
+        final String label = "DIRECTED";
+        final Node resultNodeLabel = lpg2RDFConfiguration.mapNodeLabel(label);
+        assertNotNull(resultNodeLabel);
+        assertTrue(resultNodeLabel.isURI());
+        assertEquals(resultNodeLabel.getURI(), "http://singleExample.org/directorOf");
+
+        final String edgeLabel = "0";
+        final Node resultEdgeLabel = lpg2RDFConfiguration.mapEdgeLabel(edgeLabel);
+        assertNotNull(resultEdgeLabel);
+        assertTrue(resultEdgeLabel.isURI());
+        assertEquals(resultEdgeLabel.getURI(), "https://example.org/relationship/0");
+
+        final String propertyName = "0";
+        final Node resultPropertyName = lpg2RDFConfiguration.mapProperty(propertyName);
+        assertNotNull(resultPropertyName);
+        assertTrue(resultPropertyName.isURI());
+        assertEquals(resultPropertyName.getURI(), "https://example.org/property/0");
+    }
+
+    @Test
+    public void LPG2RDFConfigWithIRIBasedNodeMappingAndSingleLiteralBasedNodeLabelMapping() {
+        final String turtle =
+                "PREFIX lr:     <http://www.example.org/se/liu/ida/hefquin/lpg2rdf#>\n"
+                        + "PREFIX ex:     <http://example.org/>\n"
+                        + "PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>\n"
+                        + "\n"
+                        + "ex:LPGtoRDFConfig\n"
+                        + "   a  lr:LPGtoRDFConfiguration ;\n"
+                        + "   lr:labelPredicate  \"http://www.w3.org/2000/01/rdf-schema#label\"^^xsd:anyURI ;\n"
+                        + "   lr:nodeMapping  ex:IRINodeMapping ;\n"
+                        + "   lr:nodeLabelMapping ex:SingleLiteralNodeLabelMapping ;\n"
+                        + "   lr:edgeLabelMapping ex:IRIEdgeLabelMapping ;\n"
+                        + "   lr:propertyNameMapping ex:IRIPropertyNameMapping ."
+                        + "\n"
+                        + "ex:SingleLiteralNodeLabelMapping\n"
+                        + "   a  lr:SingleLiteralBasedNodeLabelMapping ;\n"
+                        + "   lr:label \"DIRECTED\" ;\n"
+                        + "   lr:literal \"directorOf\" ."
+                        + "\n"
+                        + "ex:IRIEdgeLabelMapping\n"
+                        + "   a  lr:IRIBasedEdgeLabelMapping ;\n"
+                        + "   lr:prefixOfIRIs  \"https://example.org/relationship/\"^^xsd:anyURI ."
+                        + "\n"
+                        + "ex:IRIPropertyNameMapping\n"
+                        + "   a  lr:IRIBasedPropertyNameMapping ;\n"
+                        + "   lr:prefixOfIRIs  \"https://example.org/property/\"^^xsd:anyURI ."
+                        + "\n"
+                        + "ex:IRINodeMapping\n"
+                        + "   a  lr:IRIBasedNodeMapping ;\n"
+                        + "   lr:prefixOfIRIs  \"https://example.org/node/\"^^xsd:anyURI .";
+
+        final Model lpg2rdf = ModelFactory.createDefaultModel();
+
+        final RDFParserBuilder b = RDFParser.fromString(turtle);
+        b.lang( Lang.TURTLE );
+        b.parse(lpg2rdf);
+
+        final LPG2RDFConfiguration lpg2RDFConfiguration = LPG2RDFConfigurationReader.readFromModel(lpg2rdf);
+        assert(lpg2RDFConfiguration.getLabel().isURI());
+        assert(lpg2RDFConfiguration.getLabel().getURI().equals("http://www.w3.org/2000/01/rdf-schema#label"));
+        final LPGNode node = new LPGNode("0", null, null);
+        final Node resultNode = lpg2RDFConfiguration.mapNode(node);
+        assertNotNull(resultNode);
+        assertTrue(resultNode.isURI());
+        assertEquals(resultNode.getURI(), "https://example.org/node/0");
+
+        final String label = "DIRECTED";
+        final Node resultNodeLabel = lpg2RDFConfiguration.mapNodeLabel(label);
+        assertNotNull(resultNodeLabel);
+        assertTrue(resultNodeLabel.isLiteral());
+        assertEquals(resultNodeLabel.getLiteral().toString(), "directorOf");
+
+        final String edgeLabel = "0";
+        final Node resultEdgeLabel = lpg2RDFConfiguration.mapEdgeLabel(edgeLabel);
+        assertNotNull(resultEdgeLabel);
+        assertTrue(resultEdgeLabel.isURI());
+        assertEquals(resultEdgeLabel.getURI(), "https://example.org/relationship/0");
+
+        final String propertyName = "0";
+        final Node resultPropertyName = lpg2RDFConfiguration.mapProperty(propertyName);
+        assertNotNull(resultPropertyName);
+        assertTrue(resultPropertyName.isURI());
+        assertEquals(resultPropertyName.getURI(), "https://example.org/property/0");
+    }
+
+    @Test
+    public void LPG2RDFConfigWithIRIBasedNodeMappingAndCombinedNodeLabelMapping() {
+        final String turtle =
+                "PREFIX lr:     <http://www.example.org/se/liu/ida/hefquin/lpg2rdf#>\n"
+                        + "PREFIX ex:     <http://example.org/>\n"
+                        + "PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>\n"
+                        + "\n"
+                        + "ex:LPGtoRDFConfig\n"
+                        + "   a  lr:LPGtoRDFConfiguration ;\n"
+                        + "   lr:labelPredicate  \"http://www.w3.org/2000/01/rdf-schema#label\"^^xsd:anyURI ;\n"
+                        + "   lr:nodeMapping  ex:IRINodeMapping ;\n"
+                        + "   lr:nodeLabelMapping ex:CombinedNodeLabelMapping ;\n"
+                        + "   lr:edgeLabelMapping ex:IRIEdgeLabelMapping ;\n"
+                        + "   lr:propertyNameMapping ex:IRIPropertyNameMapping ."
+                        + "\n"
+                        + "ex:IRINodeLabelMapping\n"
+                        + "   a  lr:IRIBasedNodeLabelMapping ;\n"
+                        + "   lr:prefixOfIRIs  \"https://example.org/label/\"^^xsd:anyURI ."
+                        + "\n"
+                        + "ex:RegexIRINodeLabelMapping\n"
+                        + "   a  lr:RegexIRIBasedNodeLabelMapping ;\n"
+                        + "   lr:regex  \"^[0-9]+\" ;\n"
+                        + "   lr:prefixOfIRIs  \"https://test.org/test/\"^^xsd:anyURI ."
+                        + "\n"
+                        + "ex:SingleIRINodeLabelMapping\n"
+                        + "   a  lr:SingleIRIBasedNodeLabelMapping ;\n"
+                        + "   lr:label \"DIRECTED\" ;\n"
+                        + "   lr:iri \"http://singleExample.org/directorOf\"^^xsd:anyURI ."
+                        + "\n"
+                        + "ex:SingleLiteralNodeLabelMapping\n"
+                        + "   a  lr:SingleLiteralBasedNodeLabelMapping ;\n"
+                        + "   lr:label \"ACTED\" ;\n"
+                        + "   lr:literal \"actorOf\" ."
+                        + "\n"
+                        + "ex:CombinedNodeLabelMapping\n"
+                        + "   a  lr:CombinedNodeLabelMapping ;\n"
+                        + "   lr:nodeLabelMappings (ex:SingleIRINodeLabelMapping ex:SingleLiteralNodeLabelMapping ex:RegexIRINodeLabelMapping ex:IRINodeLabelMapping) ."
+                        + "\n"
+                        + "ex:IRIEdgeLabelMapping\n"
+                        + "   a  lr:IRIBasedEdgeLabelMapping ;\n"
+                        + "   lr:prefixOfIRIs  \"https://example.org/relationship/\"^^xsd:anyURI ."
+                        + "\n"
+                        + "ex:IRIPropertyNameMapping\n"
+                        + "   a  lr:IRIBasedPropertyNameMapping ;\n"
+                        + "   lr:prefixOfIRIs  \"https://example.org/property/\"^^xsd:anyURI ."
+                        + "\n"
+                        + "ex:IRINodeMapping\n"
+                        + "   a  lr:IRIBasedNodeMapping ;\n"
+                        + "   lr:prefixOfIRIs  \"https://example.org/node/\"^^xsd:anyURI .";
+
+        final Model lpg2rdf = ModelFactory.createDefaultModel();
+
+        final RDFParserBuilder b = RDFParser.fromString(turtle);
+        b.lang( Lang.TURTLE );
+        b.parse(lpg2rdf);
+
+        final LPG2RDFConfiguration lpg2RDFConfiguration = LPG2RDFConfigurationReader.readFromModel(lpg2rdf);
+        assert(lpg2RDFConfiguration.getLabel().isURI());
+        assert(lpg2RDFConfiguration.getLabel().getURI().equals("http://www.w3.org/2000/01/rdf-schema#label"));
+        final LPGNode node = new LPGNode("0", null, null);
+        final Node resultNode = lpg2RDFConfiguration.mapNode(node);
+        assertNotNull(resultNode);
+        assertTrue(resultNode.isURI());
+        assertEquals(resultNode.getURI(), "https://example.org/node/0");
+
+
+        String nodeLabel = "DIRECTED";
+        Node resultNodeLabel = lpg2RDFConfiguration.mapNodeLabel(nodeLabel);
+        assertNotNull(resultNodeLabel);
+        assertTrue(resultNodeLabel.isURI());
+        assertEquals(resultNodeLabel.getURI(), "http://singleExample.org/directorOf");
+
+        nodeLabel = "ACTED";
+        resultNodeLabel = lpg2RDFConfiguration.mapNodeLabel(nodeLabel);
+        assertNotNull(resultNodeLabel);
+        assertTrue(resultNodeLabel.isLiteral());
+        assertEquals(resultNodeLabel.getLiteral().toString(), "actorOf");
+
+        nodeLabel = "0";
+        resultNodeLabel = lpg2RDFConfiguration.mapNodeLabel(nodeLabel);
+        assertNotNull(resultNodeLabel);
+        assertTrue(resultNodeLabel.isURI());
+        assertEquals(resultNodeLabel.getURI(), "https://test.org/test/0");
+
+        nodeLabel = "ACTED_IN";
+        resultNodeLabel = lpg2RDFConfiguration.mapNodeLabel(nodeLabel);
+        assertNotNull(resultNodeLabel);
+        assertTrue(resultNodeLabel.isURI());
+        assertEquals(resultNodeLabel.getURI(), "https://example.org/label/ACTED_IN");
+
+        final String label = "0";
+        final Node resultEdgeLabel = lpg2RDFConfiguration.mapEdgeLabel(label);
+        assertNotNull(resultEdgeLabel);
+        assertTrue(resultEdgeLabel.isURI());
+        assertEquals(resultEdgeLabel.getURI(), "https://example.org/relationship/0");
+
+        final String propertyName = "0";
+        final Node resultPropertyName = lpg2RDFConfiguration.mapProperty(propertyName);
+        assertNotNull(resultPropertyName);
+        assertTrue(resultPropertyName.isURI());
+        assertEquals(resultPropertyName.getURI(), "https://example.org/property/0");
+    }
+
+    @Test
     public void LPG2RDFConfigWithIRIBasedNodeMappingAndIRIBasedNodeLabelMappingAndRegexBasedEdgeLabelMapping() {
         final String turtle =
                 "PREFIX lr:     <http://www.example.org/se/liu/ida/hefquin/lpg2rdf#>\n"
@@ -143,6 +443,7 @@ public class LPG2RDFConfigurationReaderTest {
         assertTrue(resultPropertyName.isURI());
         assertEquals(resultPropertyName.getURI(), "https://example.org/property/0");
     }
+
     @Test
     public void LPG2RDFConfigWithIRIBasedNodeMappingAndIRIBasedNodeLabelMappingAndSingleEdgeLabelMapping() {
         final String turtle =
@@ -897,6 +1198,7 @@ public class LPG2RDFConfigurationReaderTest {
         LPG2RDFConfigurationReader.readFromModel(lpg2rdf);
     }
 
+
     /*
      * In this test case, prefixOfIRIs of EdgeLabelMapping is not a URI.
      */
@@ -1252,6 +1554,67 @@ public class LPG2RDFConfigurationReaderTest {
                         + "\n"
                         + "ex:BNodeMapping\n"
                         + "   a  lr:BNodeBasedNodeMapping .";
+
+        final Model lpg2rdf = ModelFactory.createDefaultModel();
+
+        final RDFParserBuilder b = RDFParser.fromString(turtle);
+        b.lang( Lang.TURTLE );
+        b.parse(lpg2rdf);
+
+        LPG2RDFConfigurationReader.readFromModel(lpg2rdf);
+    }
+
+    /*
+     * In this test case, there is an instance of CombinedNodeLabelMapping inside the nodeLabelMappings list of another CombinedNodeLabelMapping.
+     */
+    @Test(expected = IllegalArgumentException.class)
+    public void LPG2RDFConfigWithIRIBasedNodeMappingAndNestedCombinedNodeLabelMapping() {
+        final String turtle =
+                "PREFIX lr:     <http://www.example.org/se/liu/ida/hefquin/lpg2rdf#>\n"
+                        + "PREFIX ex:     <http://example.org/>\n"
+                        + "PREFIX xsd:     <http://www.w3.org/2001/XMLSchema#>\n"
+                        + "\n"
+                        + "ex:LPGtoRDFConfig\n"
+                        + "   a  lr:LPGtoRDFConfiguration ;\n"
+                        + "   lr:labelPredicate  \"http://www.w3.org/2000/01/rdf-schema#label\"^^xsd:anyURI ;\n"
+                        + "   lr:nodeMapping  ex:IRINodeMapping ;\n"
+                        + "   lr:nodeLabelMapping ex:CombinedNodeLabelMapping ;\n"
+                        + "   lr:edgeLabelMapping ex:IRIEdgeLabelMapping ;\n"
+                        + "   lr:propertyNameMapping ex:IRIPropertyNameMapping ."
+                        + "\n"
+                        + "ex:IRINodeLabelMapping\n"
+                        + "   a  lr:IRIBasedNodeLabelMapping ;\n"
+                        + "   lr:prefixOfIRIs  \"https://example.org/label/\"^^xsd:anyURI ."
+                        + "\n"
+                        + "ex:RegexNodeLabelMapping\n"
+                        + "   a  lr:RegexIRIBasedNodeLabelMapping ;\n"
+                        + "   lr:regex  \"^[0-9]+\" ;\n"
+                        + "   lr:prefixOfIRIs  \"https://test.org/test/\"^^xsd:anyURI ."
+                        + "\n"
+                        + "ex:SingleIRINodeLabelMapping\n"
+                        + "   a  lr:SingleIRIBasedNodeLabelMapping ;\n"
+                        + "   lr:label \"DIRECTED\" ;\n"
+                        + "   lr:iri \"http://singleExample.org/directorOf\"^^xsd:anyURI ."
+                        + "\n"
+                        + "ex:CombinedNodeLabelMapping\n"
+                        + "   a  lr:CombinedNodeLabelMapping ;\n"
+                        + "   lr:nodeLabelMappings (ex:InnerCombinedNodeLabelMapping) ."
+                        + "\n"
+                        + "ex:InnerCombinedNodeLabelMapping\n"
+                        + "   a  lr:NodeLabelMapping ;\n"
+                        + "   lr:nodeLabelMappings (ex:SingleIRINodeLabelMapping ex:RegexNodeLabelMapping ex:IRINodeLabelMapping) ."
+                        + "\n"
+                        + "ex:IRIEdgeLabelMapping\n"
+                        + "   a  lr:IRIBasedEdgeLabelMapping ;\n"
+                        + "   lr:prefixOfIRIs  \"https://example.org/relationship/\"^^xsd:anyURI ."
+                        + "\n"
+                        + "ex:IRIPropertyNameMapping\n"
+                        + "   a  lr:IRIBasedPropertyNameMapping ;\n"
+                        + "   lr:prefixOfIRIs  \"https://example.org/property/\"^^xsd:anyURI ."
+                        + "\n"
+                        + "ex:IRINodeMapping\n"
+                        + "   a  lr:IRIBasedNodeMapping ;\n"
+                        + "   lr:prefixOfIRIs  \"https://example.org/node/\"^^xsd:anyURI .";
 
         final Model lpg2rdf = ModelFactory.createDefaultModel();
 

--- a/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/RegexBasedNodeLabelMappingToURIsImplTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/RegexBasedNodeLabelMappingToURIsImplTest.java
@@ -1,0 +1,58 @@
+package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.junit.Test;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl.exceptions.UnSupportedNodeLabelException;
+
+import static org.junit.Assert.*;
+
+public class RegexBasedNodeLabelMappingToURIsImplTest {
+    protected final String NODELABEL = "https://example2.org/test/";
+    protected final String regex = "^[0-9]+";
+
+    protected final NodeLabelMapping nodeLabelMapping = new RegexBasedNodeLabelMappingToURIsImpl(regex, NODELABEL);
+
+    @Test
+    public void mapNodeLabel() {
+        final String label = "0";
+        final Node resultNode = nodeLabelMapping.map(label);
+        assertNotNull(resultNode);
+        assertTrue(resultNode.isURI());
+        assertEquals(resultNode.getURI(), NODELABEL + "0");
+    }
+
+    @Test
+    public void unmapURINodeLabel(){
+        final Node node = NodeFactory.createURI(NODELABEL + "0");
+        final String resultString = nodeLabelMapping.unmap(node);
+        assertNotNull(resultString);
+        assertEquals(resultString, "0");
+    }
+
+    @Test
+    public void nodeLabelIsPossibleResult(){
+        final Node IRINode = NodeFactory.createURI(NODELABEL + "0");
+        final boolean IRIIsPossible = nodeLabelMapping.isPossibleResult(IRINode);
+        assertTrue(IRIIsPossible);
+    }
+
+
+    /*
+     * In this test case, a node with an invalid URI is provided as an argument to the RegexBasedNodeLabelMappingToURIsImpl.
+     */
+    @Test(expected = UnSupportedNodeLabelException.class)
+    public void unmapNodeLabelWithInvalidURI(){
+        final Node node = NodeFactory.createURI("https://example.org/3");
+        nodeLabelMapping.unmap(node);
+    }
+
+    /*
+     * In this test case, a label which is not match with provided regex in the RegexBasedNodeLabelMappingToURIsImpl.
+     */
+    @Test(expected = UnSupportedNodeLabelException.class)
+    public void mapNodeLabelWithUnmatchedLabel(){
+        final String label = "test";
+        nodeLabelMapping.map(label);
+    }
+}

--- a/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SingleNodeLabelMappingToLiteralsImplTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SingleNodeLabelMappingToLiteralsImplTest.java
@@ -1,0 +1,62 @@
+package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.junit.Test;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl.exceptions.UnSupportedNodeLabelException;
+
+import static org.junit.Assert.*;
+
+public class SingleNodeLabelMappingToLiteralsImplTest {
+
+    protected final String label="DIRECTED";
+    protected final String literal="directorOf";
+    protected final NodeLabelMapping nodeLabelMapping = new SingleNodeLabelMappingToLiteralsImpl(label,literal);
+
+    @Test
+    public void mapSingleLiteralNodeLabel() {
+        final Node resultNode = nodeLabelMapping.map("DIRECTED");
+        assertNotNull(resultNode);
+        assertTrue(resultNode.isLiteral());
+        assertEquals(resultNode.getLiteral().toString(), "directorOf");
+    }
+
+    @Test
+    public void unmapSingleLiteralNodeLabel(){
+        final Node node = NodeFactory.createLiteral("directorOf");
+        final String resultString = nodeLabelMapping.unmap(node);
+        assertNotNull(resultString);
+        assertEquals(resultString, "DIRECTED");
+    }
+
+    @Test
+    public void singleLiteralNodeLabelIsPossibleResult(){
+        final Node literalNode = NodeFactory.createLiteral("directorOf");
+        final Node IRINode = NodeFactory.createURI("http://singleExample.org/directorOf");
+        final boolean literalIsPossible = nodeLabelMapping.isPossibleResult(literalNode);
+        final boolean IRIIsPossible = nodeLabelMapping.isPossibleResult(IRINode);
+        assertTrue(literalIsPossible);
+        assertFalse(IRIIsPossible);
+    }
+
+
+
+    /*
+     * In this test case, a non-Literal node is provided as an argument to the SingleNodeLabelMappingToURIsImpl.
+    */
+    @Test(expected = UnSupportedNodeLabelException.class)
+    public void unmapNodeLabelWithInvalidURI(){
+        final Node node = NodeFactory.createURI("https://example.org/3");
+        nodeLabelMapping.unmap(node);
+    }
+
+    /*
+     * In this test case, a label which is not equal with the given label in SingleNodeLabelMappingToURIsImpl.
+     */
+    @Test(expected = UnSupportedNodeLabelException.class)
+    public void mapNodeLabelWithUnmatchedLabel(){
+        final String label = "test";
+        nodeLabelMapping.map(label);
+    }
+
+}

--- a/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SingleNodeLabelMappingToURIsImplTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/wrappers/lpgwrapper/impl/SingleNodeLabelMappingToURIsImplTest.java
@@ -1,0 +1,59 @@
+package se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.junit.Test;
+import se.liu.ida.hefquin.engine.wrappers.lpgwrapper.impl.exceptions.UnSupportedNodeLabelException;
+
+import static org.junit.Assert.*;
+
+public class SingleNodeLabelMappingToURIsImplTest {
+
+    protected final String label="DIRECTED";
+    protected final String iri="http://singleExample.org/directorOf";
+    protected final NodeLabelMapping nodeLabelMapping = new SingleNodeLabelMappingToURIsImpl(label,iri);
+
+    @Test
+    public void mapSingleURINodeLabel() {
+        final Node resultNode = nodeLabelMapping.map("DIRECTED");
+        assertNotNull(resultNode);
+        assertTrue(resultNode.isURI());
+        assertEquals(resultNode.getURI(),"http://singleExample.org/directorOf");
+    }
+
+    @Test
+    public void unmapSingleURINodeLabel(){
+        final Node node = NodeFactory.createURI("http://singleExample.org/directorOf");
+        final String resultString = nodeLabelMapping.unmap(node);
+        assertNotNull(resultString);
+        assertEquals(resultString, "DIRECTED");
+    }
+
+    @Test
+    public void singleURINodeLabelIsPossibleResult(){
+        final Node IRINode = NodeFactory.createURI("http://singleExample.org/directorOf");
+        final boolean IRIIsPossible = nodeLabelMapping.isPossibleResult(IRINode);
+        assertTrue(IRIIsPossible);
+    }
+
+
+
+    /*
+     * In this test case, a node with an invalid URI is provided as an argument to the SingleNodeLabelMappingToURIsImpl.
+     */
+    @Test(expected = UnSupportedNodeLabelException.class)
+    public void unmapNodeLabelWithInvalidURI(){
+        final Node node = NodeFactory.createURI("https://example.org/3");
+        nodeLabelMapping.unmap(node);
+    }
+
+    /*
+     * In this test case, a label which is not equal with the given label in SingleNodeLabelMappingToURIsImpl.
+     */
+    @Test(expected = UnSupportedNodeLabelException.class)
+    public void mapNodeLabelWithUnmatchedLabel(){
+        final String label = "test";
+        nodeLabelMapping.map(label);
+    }
+
+}


### PR DESCRIPTION
Add SingleLiteralNodeLabelMapping, SingleIRINodeLabelMapping, RegexIRINodeLabelMapping, and CombinedNodeLabelMapping classes and their tests.