### PR TITLE
Upgrade to Jena 4.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,12 +38,12 @@
 		<groupId>org.apache.jena</groupId>
 		<artifactId>apache-jena-libs</artifactId>
 		<type>pom</type>
-		<version>4.1.0</version>
+		<version>4.10.0</version>
 	</dependency>
 	<dependency>
 		<groupId>org.apache.jena</groupId>
 		<artifactId>jena-cmds</artifactId>
-		<version>4.1.0</version>
+		<version>4.10.0</version>
 	</dependency>
 <!--
 	<dependency>

--- a/src/main/java/se/liu/ida/hefquin/engine/data/utils/JenaResultSetUtils.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/data/utils/JenaResultSetUtils.java
@@ -32,7 +32,7 @@ public class JenaResultSetUtils
 
 		@Override
 		public void output( final IndentedWriter out, final SerializationContext sCxt ) {
-			out.println( debug() );
+			out.print("QueryIterator (HeFQUIN SolutionMappings -> Jena Bindings)");
 		}
 
 		@Override

--- a/src/main/java/se/liu/ida/hefquin/engine/federation/access/BRTPFInterface.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/federation/access/BRTPFInterface.java
@@ -1,8 +1,6 @@
 package se.liu.ida.hefquin.engine.federation.access;
 
-import org.apache.jena.sparql.engine.http.HttpQuery;
-
 public interface BRTPFInterface extends TPFInterface
 {
-	HttpQuery createHttpRequest(BRTPFRequest req);
+	String createRequestURL(BRTPFRequest req);
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/federation/access/TPFInterface.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/federation/access/TPFInterface.java
@@ -1,8 +1,6 @@
 package se.liu.ida.hefquin.engine.federation.access;
 
-import org.apache.jena.sparql.engine.http.HttpQuery;
-
 public interface TPFInterface extends TriplesRetrievalInterface
 {
-	HttpQuery createHttpRequest(TPFRequest req);
+	String createRequestURL(TPFRequest req);
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/iface/BRTPFInterfaceImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/iface/BRTPFInterfaceImpl.java
@@ -2,7 +2,7 @@ package se.liu.ida.hefquin.engine.federation.access.impl.iface;
 
 import java.util.Set;
 
-import org.apache.jena.sparql.engine.http.HttpQuery;
+import org.apache.jena.sparql.exec.http.Params;
 import org.apache.jena.sparql.serializer.SerializationContext;
 
 import se.liu.ida.hefquin.engine.data.SolutionMapping;
@@ -44,28 +44,23 @@ public class BRTPFInterfaceImpl extends TPFInterfaceImpl implements BRTPFInterfa
 	}
 
 	@Override
-	public HttpQuery createHttpRequest( final BRTPFRequest req ) {
-		final HttpQuery httpReq;
-
+	public String createRequestURL( final BRTPFRequest req ) {
 		final String pageURL = req.getPageURL();
 		if ( pageURL != null ) {
-			httpReq = createHttpRequest( pageURL );
-		}
-		else {
-			httpReq = createHttpRequest( req.getTriplePattern().asJenaTriple() );
-
-			final Set<SolutionMapping> solmaps = req.getSolutionMappings();
-			if ( solmaps != null && ! solmaps.isEmpty() ) {
-				final String values = SolutionMappingUtils.createValuesClause(solmaps, scxt);
-				httpReq.addParam( httpQueryArgumentForBindings, values );
-			}
+			return pageURL;
 		}
 
-		setHeaders(httpReq);
-		return httpReq;
+		final Params params = createParams( req.getTriplePattern().asJenaTriple() );
+
+		final Set<SolutionMapping> solmaps = req.getSolutionMappings();
+		if ( solmaps != null && ! solmaps.isEmpty() ) {
+			final String values = SolutionMappingUtils.createValuesClause(solmaps, scxt);
+			params.add( httpQueryArgumentForBindings, values );
+		}
+
+		return baseURLWithFinalSeparator + params.httpString();
 	}
-  
-  
+
 	@Override
 	public String toString() {
 		return "BRTPFInterface server at " + baseURL;

--- a/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/iface/TPFInterfaceImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/iface/TPFInterfaceImpl.java
@@ -3,10 +3,9 @@ package se.liu.ida.hefquin.engine.federation.access.impl.iface;
 import org.apache.jena.atlas.io.StringWriterI;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
-import org.apache.jena.riot.WebContent;
 import org.apache.jena.riot.out.NodeFormatter;
 import org.apache.jena.riot.out.NodeFormatterNT;
-import org.apache.jena.sparql.engine.http.HttpQuery;
+import org.apache.jena.sparql.exec.http.Params;
 
 import se.liu.ida.hefquin.engine.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.engine.federation.access.TPFInterface;
@@ -18,6 +17,7 @@ public class TPFInterfaceImpl implements TPFInterface
 	protected static final NodeFormatter nodeFormatter = new NodeFormatterNT();
 
 	public final String baseURL;
+	public final String baseURLWithFinalSeparator;
 	public final String httpQueryArgumentForSubject;
 	public final String httpQueryArgumentForPredicate;
 	public final String httpQueryArgumentForObject;
@@ -35,6 +35,13 @@ public class TPFInterfaceImpl implements TPFInterface
 		this.httpQueryArgumentForSubject    = httpQueryArgumentForSubject;
 		this.httpQueryArgumentForPredicate  = httpQueryArgumentForPredicate;
 		this.httpQueryArgumentForObject     = httpQueryArgumentForObject;
+
+		if ( baseURL.endsWith("?") || baseURL.endsWith("&") )
+			baseURLWithFinalSeparator = baseURL;
+		else if ( baseURL.contains("?") )
+			baseURLWithFinalSeparator = baseURL + "&";
+		else
+			baseURLWithFinalSeparator = baseURL + "?";
 	}
 
 	@Override
@@ -63,31 +70,24 @@ public class TPFInterfaceImpl implements TPFInterface
 	}
 
 	@Override
-	public HttpQuery createHttpRequest( final TPFRequest req ) {
-		final HttpQuery httpReq;
-
+	public String createRequestURL( final TPFRequest req ) {
 		final String pageURL = req.getPageURL();
 		if ( pageURL != null ) {
-			httpReq = createHttpRequest( pageURL );
-		} else {
-			httpReq = createHttpRequest( req.getQueryPattern().asJenaTriple() );
+			return pageURL;
 		}
 
-		setHeaders(httpReq);
-		return httpReq;
+		final Params params = createParams( req.getQueryPattern().asJenaTriple() );
+
+		return baseURLWithFinalSeparator + params.httpString();
 	}
 
-	protected HttpQuery createHttpRequest( final String pageURL ) {
-		return new HttpQuery(pageURL);
-	}
-
-	protected HttpQuery createHttpRequest( final Triple tp ) {
-		final HttpQuery httpReq = new HttpQuery(baseURL);
+	protected Params createParams( final Triple tp ) {
+		final Params params = Params.create();
 
 		final Node s = tp.getSubject();
 		if ( s != null && s.isConcrete() ) {
 			if ( s.isURI() ) {
-				httpReq.addParam( httpQueryArgumentForSubject, s.getURI() );
+				params.add( httpQueryArgumentForSubject, s.getURI() );
 			}
 			else {
 				throw new IllegalArgumentException("The triple pattern of the given request has an illegal subject (" + s.getClass().getName() + ").");
@@ -97,46 +97,41 @@ public class TPFInterfaceImpl implements TPFInterface
 			// variables need to be included in the request;
 			// otherwise brTPF servers do not know what to do
 			// with the variables in the 'values' parameter
-			httpReq.addParam( httpQueryArgumentForSubject, "?" + s.getName() );
+			params.add( httpQueryArgumentForSubject, "?" + s.getName() );
 		}
 
 		final Node p = tp.getPredicate();
 		if ( p != null && p.isConcrete() ) {
 			if ( p.isURI() ) {
-				httpReq.addParam( httpQueryArgumentForPredicate, p.getURI() );
+				params.add( httpQueryArgumentForPredicate, p.getURI() );
 			}
 			else {
 				throw new IllegalArgumentException("The triple pattern of the given request has an illegal predicate (" + s.getClass().getName() + ").");
 			}
 		}
 		else if ( p != null && p.isVariable() ) {
-			httpReq.addParam( httpQueryArgumentForPredicate, "?" + p.getName() );
+			params.add( httpQueryArgumentForPredicate, "?" + p.getName() );
 		}
 
 		final Node o = tp.getObject();
 		if ( o != null && o.isConcrete() ) {
 			if ( o.isURI() ) {
-				httpReq.addParam( httpQueryArgumentForObject, o.getURI() );
+				params.add( httpQueryArgumentForObject, o.getURI() );
 			}
 			else if ( o.isLiteral() ) {
 				final StringWriterI w = new StringWriterI();
 				nodeFormatter.formatLiteral(w, o);
-				httpReq.addParam( httpQueryArgumentForObject, w.toString() );
+				params.add( httpQueryArgumentForObject, w.toString() );
 			}
 			else {
 				throw new IllegalArgumentException("The triple pattern of the given request has an illegal object (" + s.getClass().getName() + ").");
 			}
 		}
 		else if ( o != null && o.isVariable() ) {
-			httpReq.addParam( httpQueryArgumentForObject, "?" + o.getName() );
+			params.add( httpQueryArgumentForObject, "?" + o.getName() );
 		}
 
-		return httpReq;
-	}
-
-	protected void setHeaders( final HttpQuery httpReq ) {
-		httpReq.setAllowCompression(true);
-		httpReq.setAccept(WebContent.defaultRDFAcceptHeader);
+		return params;
 	}
 
 	@Override

--- a/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/reqproc/BRTPFRequestProcessorImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/reqproc/BRTPFRequestProcessorImpl.java
@@ -1,7 +1,5 @@
 package se.liu.ida.hefquin.engine.federation.access.impl.reqproc;
 
-import org.apache.jena.sparql.engine.http.HttpQuery;
-
 import se.liu.ida.hefquin.engine.federation.BRTPFServer;
 import se.liu.ida.hefquin.engine.federation.access.BRTPFRequest;
 import se.liu.ida.hefquin.engine.federation.access.FederationAccessException;
@@ -11,8 +9,8 @@ import se.liu.ida.hefquin.engine.query.TriplePattern;
 
 public class BRTPFRequestProcessorImpl extends TPFRequestProcessorBase implements BRTPFRequestProcessor
 {
-	public BRTPFRequestProcessorImpl( final int connectionTimeout, final int readTimeout ) {
-		super(connectionTimeout, readTimeout);
+	public BRTPFRequestProcessorImpl( final int connectionTimeout ) {
+		super(connectionTimeout);
 	}
 
 	public BRTPFRequestProcessorImpl() {
@@ -21,12 +19,12 @@ public class BRTPFRequestProcessorImpl extends TPFRequestProcessorBase implement
 
 	@Override
 	public TPFResponse performRequest( final BRTPFRequest req, final BRTPFServer fm ) throws FederationAccessException {
-		final HttpQuery q = fm.getInterface().createHttpRequest(req);
+		final String requestURL = fm.getInterface().createRequestURL(req);
 		final TriplePattern tp = req.getTriplePattern();
 
 		final TPFResponseBuilder b;
 		try {
-			b = performRequest(q, tp);
+			b = performRequest(requestURL, tp);
 		}
 		catch ( final Exception ex ) {
 			throw new FederationAccessException("Performing a brTPF request caused an exception.", ex, req, fm);

--- a/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/reqproc/TPFRequestProcessorImpl.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/reqproc/TPFRequestProcessorImpl.java
@@ -8,11 +8,12 @@ import se.liu.ida.hefquin.engine.federation.access.TPFInterface;
 import se.liu.ida.hefquin.engine.federation.access.TPFRequest;
 import se.liu.ida.hefquin.engine.federation.access.TPFResponse;
 import se.liu.ida.hefquin.engine.federation.access.impl.response.TPFResponseBuilder;
+import se.liu.ida.hefquin.engine.query.TriplePattern;
 
 public class TPFRequestProcessorImpl extends TPFRequestProcessorBase implements TPFRequestProcessor
 {
-	public TPFRequestProcessorImpl( final int connectionTimeout, final int readTimeout ) {
-		super(connectionTimeout, readTimeout);
+	public TPFRequestProcessorImpl( final long connectionTimeout ) {
+		super(connectionTimeout);
 	}
 
 	public TPFRequestProcessorImpl() {
@@ -21,18 +22,21 @@ public class TPFRequestProcessorImpl extends TPFRequestProcessorBase implements 
 
 	@Override
 	public TPFResponse performRequest( final TPFRequest req, final TPFServer fm ) throws FederationAccessException {
-		return performRequest(req, fm.getInterface(), fm);
+		return performRequest( req, fm.getInterface(), fm );
 	}
 
 	@Override
 	public TPFResponse performRequest( final TPFRequest req, final BRTPFServer fm ) throws FederationAccessException {
-		return performRequest(req, fm.getInterface(), fm);
+		return performRequest( req, fm.getInterface(), fm );
 	}
 
 	protected TPFResponse performRequest( final TPFRequest req, final TPFInterface iface, final FederationMember fm ) throws FederationAccessException {
+		final String requestURL = iface.createRequestURL(req);
+		final TriplePattern tp = req.getQueryPattern();
+
 		final TPFResponseBuilder b;
 		try {
-			b = performRequest( iface.createHttpRequest(req), req.getQueryPattern() );
+			b = performRequest(requestURL, tp);
 		}
 		catch ( final Exception ex ) {
 			throw new FederationAccessException("Performing a TPF request caused an exception.", ex, req, fm);


### PR DESCRIPTION
This PR upgrades the code base to version 4.10 of Jena. The main change that was necessary was to rewrite all the code that was based on Jena's HttpQuery class (which, in turn, was based on the Apache HttpClient library). The newly written code uses Jena's new HTTP-related helper functionality, which is based on the HttpClient API that was introduced in Java 11.

Note that, after doing a `git pull`, you may need to have your IDE update the Maven-related stuff for the HeFQUIN project in your IDE. For Eclipse, I had to right-click on the project, select the menu items "Maven" -> "Update project ..." in the pop-up menu, and then simply click "Ok" in the dialog that shows up.