### PR TITLE
Adds a module for CLI arguments for plan printing

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/cli/RunQueryWithoutSrcSel.java
+++ b/src/main/java/se/liu/ida/hefquin/cli/RunQueryWithoutSrcSel.java
@@ -17,6 +17,7 @@ import arq.cmdline.ModResultsOut;
 import arq.cmdline.ModTime;
 import se.liu.ida.hefquin.cli.modules.ModEngineConfig;
 import se.liu.ida.hefquin.cli.modules.ModFederation;
+import se.liu.ida.hefquin.cli.modules.ModPlanPrinting;
 import se.liu.ida.hefquin.cli.modules.ModQuery;
 import se.liu.ida.hefquin.engine.HeFQUINEngine;
 import se.liu.ida.hefquin.engine.HeFQUINEngineDefaultComponents;
@@ -30,13 +31,11 @@ public class RunQueryWithoutSrcSel extends CmdARQ
 	protected final ModTime          modTime =          new ModTime();
 	protected final ModQuery         modQuery =         new ModQuery();
 	protected final ModFederation    modFederation =    new ModFederation();
+	protected final ModPlanPrinting  modPlanPrinting =  new ModPlanPrinting();
 	protected final ModResultsOut    modResults =       new ModResultsOut();
 	protected final ModEngineConfig  modEngineConfig =  new ModEngineConfig();
 
 	protected final ArgDecl argSuppressResultPrintout = new ArgDecl(ArgDecl.NoValue, "suppressResultPrintout");
-	protected final ArgDecl argPrintSourceAssignment  = new ArgDecl(ArgDecl.NoValue, "printSourceAssignment");
-	protected final ArgDecl argPrintLogicalPlan   = new ArgDecl(ArgDecl.NoValue, "printLogicalPlan");
-	protected final ArgDecl argPrintPhysicalPlan  = new ArgDecl(ArgDecl.NoValue, "printPhysicalPlan");
 	protected final ArgDecl argQueryProcStats = new ArgDecl(ArgDecl.NoValue, "printQueryProcStats");
 	protected final ArgDecl argOnelineTimeStats = new ArgDecl(ArgDecl.NoValue, "printQueryProcMeasurements");
 	protected final ArgDecl argFedAccessStats = new ArgDecl(ArgDecl.NoValue, "printFedAccessStats");
@@ -50,12 +49,10 @@ public class RunQueryWithoutSrcSel extends CmdARQ
 
 		addModule(modEngineConfig);
 		addModule(modTime);
+		addModule(modPlanPrinting);
 		addModule(modResults);
 
 		add(argSuppressResultPrintout, "--suppressResultPrintout", "Do not print out the query result");
-		add(argPrintSourceAssignment, "--printSourceAssignment", "Print out the source assignment used as input to the query optimization");
-		add(argPrintLogicalPlan, "--printLogicalPlan", "Print out the logical plan produced by the logical query optimization");
-		add(argPrintPhysicalPlan, "--printPhysicalPlan", "Print out the physical plan produced by the physical query optimization and used for the query execution");
 		add(argQueryProcStats, "--printQueryProcStats", "Print out statistics about the query execution process");
 		add(argOnelineTimeStats, "--printQueryProcMeasurements", "Print out measurements about the query processing time in one line that can be used for a CSV file");
 		add(argFedAccessStats, "--printFedAccessStats", "Print out statistics of the federation access manager");
@@ -78,9 +75,9 @@ public class RunQueryWithoutSrcSel extends CmdARQ
 		                                                   execServiceForPlanTasks,
 		                                                   modFederation.getFederationCatalog(),
 		                                                   false, // isExperimentRun
-		                                                   contains(argPrintSourceAssignment),
-		                                                   contains(argPrintLogicalPlan),
-		                                                   contains(argPrintPhysicalPlan) );
+		                                                   modPlanPrinting.printSrcAssignment(),
+		                                                   modPlanPrinting.printLogicalPlan(),
+		                                                   modPlanPrinting.printPhysicalPlan() );
 		e.integrateIntoJena();
 
 		final Query query = getQuery();

--- a/src/main/java/se/liu/ida/hefquin/cli/modules/ModPlanPrinting.java
+++ b/src/main/java/se/liu/ida/hefquin/cli/modules/ModPlanPrinting.java
@@ -1,0 +1,38 @@
+package se.liu.ida.hefquin.cli.modules;
+
+import org.apache.jena.cmd.ArgDecl;
+import org.apache.jena.cmd.CmdArgModule;
+import org.apache.jena.cmd.CmdGeneral;
+import org.apache.jena.cmd.ModBase;
+
+public class ModPlanPrinting extends ModBase
+{
+	protected final ArgDecl argPrintSrcAssignment  = new ArgDecl(ArgDecl.NoValue, "printSourceAssignment");
+	protected final ArgDecl argPrintLogicalPlan    = new ArgDecl(ArgDecl.NoValue, "printLogicalPlan");
+	protected final ArgDecl argPrintPhysicalPlan   = new ArgDecl(ArgDecl.NoValue, "printPhysicalPlan");
+
+	protected boolean printSrcAssignment = false;
+	protected boolean printLogicalPlan = false;
+	protected boolean printPhysicalPlan = false;
+
+	@Override
+	public void registerWith( final CmdGeneral cmdLine ) {
+		cmdLine.getUsage().startCategory("Query Plan Printing");
+		cmdLine.add(argPrintSrcAssignment, "--printSourceAssignment", "Print out the source assignment used as input to the query optimization");
+		cmdLine.add(argPrintLogicalPlan, "--printLogicalPlan", "Print out the logical plan produced by the logical query optimization");
+		cmdLine.add(argPrintPhysicalPlan, "--printPhysicalPlan", "Print out the physical plan produced by the physical query optimization and used for the query execution");
+	}
+
+	@Override
+	public void processArgs( final CmdArgModule cmdLine ) {
+		printSrcAssignment = cmdLine.contains(argPrintSrcAssignment);
+		printLogicalPlan = cmdLine.contains(argPrintLogicalPlan);
+		printPhysicalPlan = cmdLine.contains(argPrintPhysicalPlan);
+	}
+
+	public boolean printSrcAssignment() { return printSrcAssignment; }
+
+	public boolean printLogicalPlan() { return printLogicalPlan; }
+
+	public boolean printPhysicalPlan() { return printPhysicalPlan; }
+}


### PR DESCRIPTION
@huanyu-li this one is for you. It adds a dedicated module of CLI arguments related to the printing of plans and moves the current arguments for plan printing into this module. This new module can now serve as a basis for additional arguments that you might add during the hackathon.