### PR TITLE
CLI Argument to skip the query execution

### DIFF
--- a/src/main/java/se/liu/ida/hefquin/cli/RunQueryWithoutSrcSel.java
+++ b/src/main/java/se/liu/ida/hefquin/cli/RunQueryWithoutSrcSel.java
@@ -36,6 +36,7 @@ public class RunQueryWithoutSrcSel extends CmdARQ
 	protected final ModEngineConfig  modEngineConfig =  new ModEngineConfig();
 
 	protected final ArgDecl argSuppressResultPrintout = new ArgDecl(ArgDecl.NoValue, "suppressResultPrintout");
+	protected final ArgDecl argSkipExecution = new ArgDecl(ArgDecl.NoValue, "skipExecution");
 	protected final ArgDecl argQueryProcStats = new ArgDecl(ArgDecl.NoValue, "printQueryProcStats");
 	protected final ArgDecl argOnelineTimeStats = new ArgDecl(ArgDecl.NoValue, "printQueryProcMeasurements");
 	protected final ArgDecl argFedAccessStats = new ArgDecl(ArgDecl.NoValue, "printFedAccessStats");
@@ -53,6 +54,7 @@ public class RunQueryWithoutSrcSel extends CmdARQ
 		addModule(modResults);
 
 		add(argSuppressResultPrintout, "--suppressResultPrintout", "Do not print out the query result");
+		add(argSkipExecution, "--skipExecution", "Do not execute the query (but create the execution plan)");
 		add(argQueryProcStats, "--printQueryProcStats", "Print out statistics about the query execution process");
 		add(argOnelineTimeStats, "--printQueryProcMeasurements", "Print out measurements about the query processing time in one line that can be used for a CSV file");
 		add(argFedAccessStats, "--printFedAccessStats", "Print out statistics of the federation access manager");
@@ -75,6 +77,7 @@ public class RunQueryWithoutSrcSel extends CmdARQ
 		                                                   execServiceForPlanTasks,
 		                                                   modFederation.getFederationCatalog(),
 		                                                   false, // isExperimentRun
+		                                                   contains(argSkipExecution),
 		                                                   modPlanPrinting.printSrcAssignment(),
 		                                                   modPlanPrinting.printLogicalPlan(),
 		                                                   modPlanPrinting.printPhysicalPlan() );

--- a/src/main/java/se/liu/ida/hefquin/cli/modules/ModEngineConfig.java
+++ b/src/main/java/se/liu/ida/hefquin/cli/modules/ModEngineConfig.java
@@ -52,6 +52,7 @@ public class ModEngineConfig extends ModBase
 	                                final ExecutorService execServiceForPlanTasks,
 	                                final FederationCatalog cat,
 	                                final boolean isExperimentRun,
+	                                final boolean skipExecution,
 	                                final boolean printSourceAssignment,
 	                                final boolean printLogicalPlan,
 	                                final boolean printPhysicalPlan ) {
@@ -60,6 +61,7 @@ public class ModEngineConfig extends ModBase
 			@Override public ExecutorService getExecutorServiceForPlanTasks() { return execServiceForPlanTasks; }
 			@Override public FederationCatalog getFederationCatalog() { return cat; }
 			@Override public boolean isExperimentRun() { return isExperimentRun; }
+			@Override public boolean skipExecution() { return skipExecution; }
 			@Override public boolean withPrintingOfSourceAssignment() { return printSourceAssignment; }
 			@Override public boolean withPrintingOfLogicalPlan() { return printLogicalPlan; }
 			@Override public boolean withPrintingOfPhysicalPlan() { return printPhysicalPlan; }

--- a/src/main/java/se/liu/ida/hefquin/engine/HeFQUINEngineConfigReader.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/HeFQUINEngineConfigReader.java
@@ -99,6 +99,7 @@ public class HeFQUINEngineConfigReader
 		ExecutorService getExecutorServiceForPlanTasks();
 		FederationCatalog getFederationCatalog();
 		boolean isExperimentRun();
+		boolean skipExecution();
 		boolean withPrintingOfSourceAssignment();
 		boolean withPrintingOfLogicalPlan();
 		boolean withPrintingOfPhysicalPlan();
@@ -439,6 +440,9 @@ public class HeFQUINEngineConfigReader
 		public boolean isExperimentRun() { return ctx.isExperimentRun(); }
 
 		@Override
+		public boolean skipExecution() { return ctx.skipExecution(); }
+
+		@Override
 		public boolean withPrintingOfSourceAssignment() { return ctx.withPrintingOfSourceAssignment(); }
 
 		@Override
@@ -505,6 +509,11 @@ public class HeFQUINEngineConfigReader
 		}
 
 		@Override
+		public boolean skipExecution() {
+			return qprocCtx.skipExecution();
+		}
+
+		@Override
 		public boolean withPrintingOfSourceAssignment() { return printSourceAssignment; }
 
 		@Override
@@ -528,6 +537,9 @@ public class HeFQUINEngineConfigReader
 
 			@Override
 			public boolean isExperimentRun() { return ctx.isExperimentRun(); }
+
+			@Override
+			public boolean skipExecution() { return ctx.skipExecution(); }
 		};
 	}
 

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/QueryProcContext.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/QueryProcContext.java
@@ -18,4 +18,11 @@ public interface QueryProcContext
 	 * of an experiment, in which case additional statistics need to be produced.
 	 */
 	boolean isExperimentRun();
+
+	/**
+	 * Returns <code>true</code> if the user requested to skip the actual
+	 * query execution. In this case, the query processor can stop after
+	 * query planning.
+	 */
+	boolean skipExecution();
 }

--- a/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/compiler/QueryPlanCompilerBase.java
+++ b/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/compiler/QueryPlanCompilerBase.java
@@ -22,6 +22,7 @@ public abstract class QueryPlanCompilerBase implements QueryPlanCompiler
 			@Override public FederationCatalog getFederationCatalog() { return ctxt.getFederationCatalog(); }
 			@Override public FederationAccessManager getFederationAccessMgr() { return ctxt.getFederationAccessMgr(); }
 			@Override public boolean isExperimentRun() { return ctxt.isExperimentRun(); }
+			@Override public boolean skipExecution() { return ctxt.skipExecution(); }
 			@Override public ExecutorService getExecutorServiceForPlanTasks() { return ctxt.getExecutorServiceForPlanTasks(); }
 		};
 	}

--- a/src/test/java/se/liu/ida/hefquin/engine/HeFQUINEngineConfigReaderTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/HeFQUINEngineConfigReaderTest.java
@@ -294,7 +294,11 @@ public class HeFQUINEngineConfigReaderTest
 			public boolean isExperimentRun() { throw new UnsupportedOperationException(); }
 
 			@Override
+			public boolean skipExecution() { throw new UnsupportedOperationException(); }
+
+			@Override
 			public boolean withPrintingOfSourceAssignment() { throw new UnsupportedOperationException(); }
+
 			@Override
 			public boolean withPrintingOfLogicalPlan() { throw new UnsupportedOperationException(); }
 
@@ -331,6 +335,11 @@ public class HeFQUINEngineConfigReaderTest
 				public boolean isExperimentRun() {
 					throw new UnsupportedOperationException();
 				}
+
+				@Override
+				public boolean skipExecution() {
+					throw new UnsupportedOperationException();
+				}
 			};
 
 			@Override
@@ -349,6 +358,9 @@ public class HeFQUINEngineConfigReaderTest
 
 			@Override
 			public boolean isExperimentRun() { throw new UnsupportedOperationException(); }
+
+			@Override
+			public boolean skipExecution() { throw new UnsupportedOperationException(); }
 
 			@Override
 			public boolean withPrintingOfSourceAssignment() { throw new UnsupportedOperationException(); }

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/iterbased/TestUtils.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/iterbased/TestUtils.java
@@ -23,6 +23,7 @@ public class TestUtils extends EngineTestBase
 			@Override public FederationAccessManager getFederationAccessMgr() { return fedAccessMgr; }
 			@Override public ExecutorService getExecutorServiceForPlanTasks() { return null; }
 			@Override public boolean isExperimentRun() { return false; }
+			@Override public boolean skipExecution() { return false; }
 		};
 	}
 

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoinTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoinTest.java
@@ -192,6 +192,7 @@ public class ExecOpParallelMultiwayLeftJoinTest extends TestsForTPAddAlgorithms<
 			@Override public FederationAccessManager getFederationAccessMgr() { return fedAccessMgr; }
 			@Override public ExecutorService getExecutorServiceForPlanTasks() { return getExecutorServiceForTest(); }
 			@Override public boolean isExperimentRun() { return false; }
+			@Override public boolean skipExecution() { return false; }
 		};
 		final CollectingIntermediateResultElementSink sink = new CollectingIntermediateResultElementSink();
 

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestTPFWithTranslationTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestTPFWithTranslationTest.java
@@ -85,6 +85,7 @@ public class ExecOpRequestTPFWithTranslationTest extends ExecOpTestBase {
 			@Override public FederationAccessManager getFederationAccessMgr() { return fedAccessMgr; }
 			@Override public ExecutorService getExecutorServiceForPlanTasks() { return null; }
 			@Override public boolean isExperimentRun() { return false; }
+			@Override public boolean skipExecution() { return false; }
 		};
 	}
 	

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestTPFatTPFServerTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestTPFatTPFServerTest.java
@@ -78,6 +78,7 @@ public class ExecOpRequestTPFatTPFServerTest extends ExecOpTestBase
 			@Override public FederationAccessManager getFederationAccessMgr() { return fedAccessMgr; }
 			@Override public ExecutorService getExecutorServiceForPlanTasks() { return null; }
 			@Override public boolean isExperimentRun() { return false; }
+			@Override public boolean skipExecution() { return false; }
 		};
 
 		op.execute(sink, execCxt);
@@ -135,6 +136,7 @@ public class ExecOpRequestTPFatTPFServerTest extends ExecOpTestBase
 			@Override public FederationAccessManager getFederationAccessMgr() { return fedAccessMgr; }
 			@Override public ExecutorService getExecutorServiceForPlanTasks() { return null; }
 			@Override public boolean isExperimentRun() { return false; }
+			@Override public boolean skipExecution() { return false; }
 		};
 	}
 

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/TestsForTPAddAlgorithms.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/TestsForTPAddAlgorithms.java
@@ -521,6 +521,7 @@ public abstract class TestsForTPAddAlgorithms<MemberType extends FederationMembe
 			@Override public FederationAccessManager getFederationAccessMgr() { return fedAccessMgr; }
 			@Override public ExecutorService getExecutorServiceForPlanTasks() { return getExecutorServiceForTest(); }
 			@Override public boolean isExperimentRun() { return false; }
+			@Override public boolean skipExecution() { return false; }
 		};
 		final CollectingIntermediateResultElementSink sink = new CollectingIntermediateResultElementSink();
 

--- a/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/TestsForTPAddAlgorithmsWithTranslation.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/TestsForTPAddAlgorithmsWithTranslation.java
@@ -444,6 +444,7 @@ public abstract class TestsForTPAddAlgorithmsWithTranslation<MemberType extends 
 			@Override public FederationAccessManager getFederationAccessMgr() { return fedAccessMgr; }
 			@Override public ExecutorService getExecutorServiceForPlanTasks() { return null; }
 			@Override public boolean isExperimentRun() { return false; }
+			@Override public boolean skipExecution() { return false; }
 		};
 		final CollectingIntermediateResultElementSink sink = new CollectingIntermediateResultElementSink();
 

--- a/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/QueryProcessorImplTest.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/QueryProcessorImplTest.java
@@ -360,6 +360,7 @@ public class QueryProcessorImplTest extends EngineTestBase
 			@Override public FederationAccessManager getFederationAccessMgr() { return fedAccessMgr; }
 			@Override public ExecutorService getExecutorServiceForPlanTasks() { return execServiceForPlanTasks; }
 			@Override public boolean isExperimentRun() { return false; }
+			@Override public boolean skipExecution() { return false; }
 		};
 
 		final SourcePlanner sourcePlanner = new ServiceClauseBasedSourcePlannerImpl(ctxt);

--- a/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/srcsel/SourcePlannerImplTestBase.java
+++ b/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/srcsel/SourcePlannerImplTestBase.java
@@ -33,6 +33,7 @@ public abstract class SourcePlannerImplTestBase extends EngineTestBase
 			@Override public FederationAccessManager getFederationAccessMgr() { throw new UnsupportedOperationException(); }
 			@Override public ExecutorService getExecutorServiceForPlanTasks() { throw new UnsupportedOperationException(); }
 			@Override public boolean isExperimentRun() { throw new UnsupportedOperationException(); }
+			@Override public boolean skipExecution() { return false; }
 		};
 
 		final Query query = new GenericSPARQLGraphPatternImpl1( QueryFactory.create(queryString).getQueryPattern() );


### PR DESCRIPTION
@huanyu-li  Here is another one for you. This PR adds a CLI argument (`--skipExecution`) with which users of the CLI tool can print the query plans without actually executing the query.