### PR TITLE
add workflow to publish docker image 

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,10 +15,19 @@ jobs:
     steps:
     # Checkout the repository
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v3
       with:
-        fetch-depth: 0
-        fetch-tags: true
+        fetch-depth: 0  # This ensures a full history is fetched, not just a shallow clone
+
+    # Fetch all tags
+    - name: Fetch all tags
+      run: |
+        git fetch --prune --unshallow --tags
+        echo "Exit code for fetch: $?"
+        
+        # List all the tags to confirm they are fetched
+        echo "Listing all tags:"
+        git tag --list
 
     # Set up Docker Buildx for cross-platform builds (optional but recommended)
     - name: Set up Docker Buildx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,39 @@
+name: Build and Publish Docker image to GHCR
+
+on:
+  workflow_dispatch: # allows manual triggers via the GitHub UI
+  release:
+    types: [published]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    # Checkout the repository
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Set up Docker Buildx for cross-platform builds (optional but recommended)
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    # Log in to the GitHub Container Registry
+    - name: Log in to GHCR
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    # Build and tag the Docker image
+    - name: Build Docker image
+      run: |
+        cd hefquin-docker/
+        docker build -t ghcr.io/liusemweb/hefquin:latest .
+        # TODO: Identify tags from commit and loop through these tags and add to the image
+        # docker tag ghcr.io/liusemweb/hefquin:latest ghcr.io/liusemweb/hefquin:v1.0.0
+    
+    # Push the Docker image to GitHub Container Registry (GHCR)
+    - name: Push Docker image to GHCR
+      run: |
+        docker push ghcr.io/liusemweb/hefquin:latest --all-tags

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,6 +2,9 @@ name: Build and Publish Docker image to GHCR
 
 on:
   workflow_dispatch: # allows manual triggers via the GitHub UI
+  push:
+    branches:
+      - 364-publish-docker-image
   release:
     types:
       - published

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -49,8 +49,8 @@ jobs:
     - name: Tag and push Docker image
       run: |
         # Get the tags for the current commit and add to image
-        tags=$(git tag --points-at HEAD)
         git tag --list
+        git log --oneline --decorate
         # Loop tags
         tags=$(git tag --points-at HEAD)
         for tag in $tags; do

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,10 +37,16 @@ jobs:
         # Get the tags for the current commit and add to image
         echo "Find tags"
         tags=$(git tag --points-at HEAD)
-        for tag in $tags; do
-          echo "Adding tag: " $tag
-          docker tag ghcr.io/liusemweb/hefquin:latest ghcr.io/liusemweb/hefquin:$tag
-        done
+        # Check if there are any tags
+        if [ -z "$tags" ]; then
+          echo "No tags found for the current commit."
+        else
+          # Loop through the tags line by line
+          echo "$tags" | while read -r tag; do
+            echo "Adding tag: $tag"
+            docker tag ghcr.io/liusemweb/hefquin:latest ghcr.io/liusemweb/hefquin:$tag
+         done
+fi
 
     # Push the Docker image to GitHub Container Registry (GHCR)
     - name: Push Docker image to GHCR

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -45,8 +45,8 @@ jobs:
           echo "$tags" | while read -r tag; do
             echo "Adding tag: $tag"
             docker tag ghcr.io/liusemweb/hefquin:latest ghcr.io/liusemweb/hefquin:$tag
-         done
-fi
+          done
+        fi
 
     # Push the Docker image to GitHub Container Registry (GHCR)
     - name: Push Docker image to GHCR

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,4 +38,4 @@ jobs:
     # Push the Docker image to GitHub Container Registry (GHCR)
     - name: Push Docker image to GHCR
       run: |
-        docker push ghcr.io/liusemweb/hefquin:latest --all-tags
+        docker push ghcr.io/liusemweb/hefquin --all-tags

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,6 +34,8 @@ jobs:
       run: |
         cd hefquin-docker/
         git fetch --tags
+        git log --oneline --decorate
+        git show
         docker build -t ghcr.io/liusemweb/hefquin:latest .
         # Get the tags for the current commit and add to image
         echo "Find tags"
@@ -42,8 +44,9 @@ jobs:
         if [ -z "$tags" ]; then
           echo "No tags found for the current commit."
         else
-          # Loop through the tags line by line
-          echo "$tags" | while read -r tag; do
+          # Loop tags
+          tags=$(git tag --points-at HEAD)
+          for tag in $tags; do
             echo "Adding tag: $tag"
             docker tag ghcr.io/liusemweb/hefquin:latest ghcr.io/liusemweb/hefquin:$tag
           done

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,8 +2,10 @@ name: Build and Publish Docker image to GHCR
 
 on:
   workflow_dispatch: # allows manual triggers via the GitHub UI
-  release:
-    types: [push]
+  push:
+    branches:
+      - 364-publish-docker-image
+      - main
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,9 +2,6 @@ name: Build and Publish Docker image to GHCR
 
 on:
   workflow_dispatch: # allows manual triggers via the GitHub UI
-  push:
-    branches:
-      - 364-publish-docker-image
   release:
     types:
       - published

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,7 +15,10 @@ jobs:
     steps:
     # Checkout the repository
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
 
     # Set up Docker Buildx for cross-platform builds (optional but recommended)
     - name: Set up Docker Buildx
@@ -33,12 +36,9 @@ jobs:
     - name: Build Docker image
       run: |
         cd hefquin-docker/
-        git fetch --tags
-        git log --oneline --decorate
-        git show
         docker build -t ghcr.io/liusemweb/hefquin:latest .
         # Get the tags for the current commit and add to image
-        echo "Find tags"
+        echo "Adding tags"
         tags=$(git tag --points-at HEAD)
         # Check if there are any tags
         if [ -z "$tags" ]; then

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Build Docker image
       run: |
         cd hefquin-docker/
-        docker build -t ghcr.io/liusemweb/hefquin:latest .
+        docker build -t ghcr.io/liusemweb/hefquin:dev .
         # TODO: Identify tags from commit and loop through these tags and add to the image
         # docker tag ghcr.io/liusemweb/hefquin:latest ghcr.io/liusemweb/hefquin:v1.0.0
     

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,6 +17,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
       with:
+        ref: main
         fetch-depth: 0  # This ensures a full history is fetched
 
     # Fetch all tags
@@ -27,6 +28,16 @@ jobs:
         # Verify that the tags are fetched
         echo "Listing all tags:"
         git tag --list
+    
+    - name: Tags
+      run: |
+        # Get the tags for the current commit and add to image
+        git tag --list
+        git log --oneline --decorate
+        tags=$(git tag --points-at HEAD)
+        for tag in $tags; do
+          echo "Adding tag: $tag"
+        done
 
     # Set up Docker Buildx for cross-platform builds (optional but recommended)
     - name: Set up Docker Buildx

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,9 @@ name: Build and Publish Docker image to GHCR
 
 on:
   workflow_dispatch: # allows manual triggers via the GitHub UI
-  push:
-    branches:
-      - 364-publish-docker-image
-      - main
+  release:
+    types:
+      - published
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,7 +3,7 @@ name: Build and Publish Docker image to GHCR
 on:
   workflow_dispatch: # allows manual triggers via the GitHub UI
   release:
-    types: [published]
+    types: [push]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,6 +34,7 @@ jobs:
         # Get the tags for the current commit and add to image
         tags=$(git tag --points-at HEAD)
         for tag in $tags; do
+          echo "Adding tag: " $tag
           docker tag ghcr.io/liusemweb/hefquin:latest ghcr.io/liusemweb/hefquin:$tag
         done
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,10 +31,13 @@ jobs:
     - name: Build Docker image
       run: |
         cd hefquin-docker/
-        docker build -t ghcr.io/liusemweb/hefquin:dev .
-        # TODO: Identify tags from commit and loop through these tags and add to the image
-        # docker tag ghcr.io/liusemweb/hefquin:latest ghcr.io/liusemweb/hefquin:v1.0.0
-    
+        docker build -t ghcr.io/liusemweb/hefquin:latest .
+        # Get the tags for the current commit and add to image
+        tags=$(git tag --points-at HEAD)
+        for tag in $tags; do
+          docker tag ghcr.io/liusemweb/hefquin:latest ghcr.io/liusemweb/hefquin:$tag
+        done
+
     # Push the Docker image to GitHub Container Registry (GHCR)
     - name: Push Docker image to GHCR
       run: |

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,13 +19,12 @@ jobs:
       with:
         fetch-depth: 0  # This ensures a full history is fetched, not just a shallow clone
 
-    # Fetch all tags
-    - name: Fetch all tags
+    # Fetch all tags if the repository is shallow
+    - name: Fetch tags if needed
       run: |
-        git fetch --prune --unshallow --tags
-        echo "Exit code for fetch: $?"
-        
-        # List all the tags to confirm they are fetched
+        git fetch --prune --tags
+  
+        # Verify that the tags are fetched
         echo "Listing all tags:"
         git tag --list
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,6 +33,7 @@ jobs:
     - name: Build Docker image
       run: |
         cd hefquin-docker/
+        git fetch --tags
         docker build -t ghcr.io/liusemweb/hefquin:latest .
         # Get the tags for the current commit and add to image
         echo "Find tags"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,27 +18,12 @@ jobs:
       uses: actions/checkout@v3
       with:
         ref: main
-        fetch-depth: 0  # This ensures a full history is fetched
 
     # Fetch all tags
     - name: Fetch tags
       run: |
         git fetch --prune --tags
-  
-        # Verify that the tags are fetched
-        echo "Listing all tags:"
-        git tag --list
     
-    - name: Tags
-      run: |
-        # Get the tags for the current commit and add to image
-        git tag --list
-        git log --oneline --decorate
-        tags=$(git tag --points-at HEAD)
-        for tag in $tags; do
-          echo "Adding tag: $tag"
-        done
-
     # Set up Docker Buildx for cross-platform builds (optional but recommended)
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
@@ -60,8 +45,6 @@ jobs:
     - name: Tag and push Docker image
       run: |
         # Get the tags for the current commit and add to image
-        git tag --list
-        git log --oneline --decorate
         # Loop tags
         tags=$(git tag --points-at HEAD)
         for tag in $tags; do

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,10 +17,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
       with:
-        fetch-depth: 0  # This ensures a full history is fetched, not just a shallow clone
+        fetch-depth: 0  # This ensures a full history is fetched
 
-    # Fetch all tags if the repository is shallow
-    - name: Fetch tags if needed
+    # Fetch all tags
+    - name: Fetch tags
       run: |
         git fetch --prune --tags
   
@@ -45,20 +45,18 @@ jobs:
       run: |
         cd hefquin-docker/
         docker build -t ghcr.io/liusemweb/hefquin:latest .
+    
+    - name: Tag and push Docker image
+      run: |
         # Get the tags for the current commit and add to image
-        echo "Adding tags"
         tags=$(git tag --points-at HEAD)
-        # Check if there are any tags
-        if [ -z "$tags" ]; then
-          echo "No tags found for the current commit."
-        else
-          # Loop tags
-          tags=$(git tag --points-at HEAD)
-          for tag in $tags; do
-            echo "Adding tag: $tag"
-            docker tag ghcr.io/liusemweb/hefquin:latest ghcr.io/liusemweb/hefquin:$tag
-          done
-        fi
+        git tag --list
+        # Loop tags
+        tags=$(git tag --points-at HEAD)
+        for tag in $tags; do
+          echo "Adding tag: $tag"
+          docker tag ghcr.io/liusemweb/hefquin:latest ghcr.io/liusemweb/hefquin:$tag
+        done
 
     # Push the Docker image to GitHub Container Registry (GHCR)
     - name: Push Docker image to GHCR

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,6 +32,7 @@ jobs:
         cd hefquin-docker/
         docker build -t ghcr.io/liusemweb/hefquin:latest .
         # Get the tags for the current commit and add to image
+        echo "Find tags"
         tags=$(git tag --points-at HEAD)
         for tag in $tags; do
           echo "Adding tag: " $tag

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -3,7 +3,10 @@
 
 name: Java CI with Maven
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
This workflow is triggered when a release is published, and builds and publishes the corresponding docker image in `ghcr.io` with the tag `latest` as well as any tags provided for the release.