### PR TITLE
remove property project.version, use default instead

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,6 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <maven.compiler.source>17</maven.compiler.source>
     <maven.compiler.target>17</maven.compiler.target>
-    <project.version>0.0.4-SNAPSHOT</project.version>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
This resolves #368

The version can now be updated correctly across all `pom.xml` files using:
```bash
mvn versions:set -DnewVersion=x.y.z -DgenerateBackupPoms=false
```