### PR TITLE
400 prevent query engine from crashing on cardinality query exceptions

### DIFF
--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/DataRetrievalResponse.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/DataRetrievalResponse.java
@@ -1,5 +1,6 @@
 package se.liu.ida.hefquin.engine.federation.access;
 
+import java.time.Duration;
 import java.util.Date;
 
 import se.liu.ida.hefquin.engine.federation.FederationMember;
@@ -26,4 +27,41 @@ public interface DataRetrievalResponse
 	 * Returns the time at which the retrieval of this response was completed.
 	 */
 	Date getRetrievalEndTime();
+
+	/**
+	 * Returns the total duration between request start and request end.
+	 */
+	default Duration getRequestDuration() {
+		return Duration.between( getRequestStartTime().toInstant(), getRetrievalEndTime().toInstant() );
+	}
+
+	/**
+	 * Indicates whether the response is based on a fallback (default) value due to
+	 * an error.
+	 */
+	default boolean isFallbackResponse() {
+		return false;
+	};
+
+	/**
+	 * Indicates whether an error occurred during data retrieval.
+	 */
+	default boolean isError() {
+		return getErrorStatusCode() != null;
+	};
+
+	/**
+	 * Returns the HTTP status code if the response resulted in an error, or empty
+	 * otherwise.
+	 */
+	default Integer getErrorStatusCode() {
+		return null;
+	};
+
+	/**
+	 * Returns a short description of the error if available, or empty otherwise.
+	 */
+	default String getErrorDescription() {
+		return null;
+	};
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/FederationAccessManagerBase1.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/FederationAccessManagerBase1.java
@@ -1,24 +1,19 @@
 package se.liu.ida.hefquin.engine.federation.access.impl;
 
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
-import java.util.stream.Stream;
-
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryFactory;
 import org.apache.jena.sparql.core.Var;
-import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
 import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.aggregate.AggregatorFactory;
 import se.liu.ida.hefquin.base.data.SolutionMapping;

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/reqproc/SPARQLRequestProcessorImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/reqproc/SPARQLRequestProcessorImpl.java
@@ -14,7 +14,6 @@ import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.rdfconnection.RDFConnection;
 import org.apache.jena.rdfconnection.RDFConnectionRemote;
-import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
 import org.apache.jena.sparql.exec.http.QueryExecutionHTTPBuilder;
 
 import se.liu.ida.hefquin.base.data.SolutionMapping;

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/reqproc/SPARQLRequestProcessorImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/reqproc/SPARQLRequestProcessorImpl.java
@@ -14,6 +14,7 @@ import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
 import org.apache.jena.rdfconnection.RDFConnection;
 import org.apache.jena.rdfconnection.RDFConnectionRemote;
+import org.apache.jena.sparql.engine.http.QueryExceptionHTTP;
 import org.apache.jena.sparql.exec.http.QueryExecutionHTTPBuilder;
 
 import se.liu.ida.hefquin.base.data.SolutionMapping;
@@ -79,7 +80,12 @@ public class SPARQLRequestProcessorImpl implements SPARQLRequestProcessor
 			throw new FederationAccessException("Initiating the remote execution of a query at the SPARQL endpoint at '" + fm.getInterface().getURL() + "' caused an exception.", e, req, fm);
 		}
 
-		final ResultSet result = qe.execSelect();
+		final ResultSet result;
+		try {
+			result = qe.execSelect();
+		} catch( Exception e ){
+			throw new FederationAccessException( e, req, fm );
+		}
 
 		final Date requestStartTime = new Date();
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/response/CachedCardinalityResponseImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/response/CachedCardinalityResponseImpl.java
@@ -6,7 +6,7 @@ import se.liu.ida.hefquin.engine.federation.FederationMember;
 import se.liu.ida.hefquin.engine.federation.access.CardinalityResponse;
 import se.liu.ida.hefquin.engine.federation.access.DataRetrievalRequest;
 
-public class CachedCardinalityResponseImpl implements CardinalityResponse
+public class CachedCardinalityResponseImpl extends DataRetrievalResponseBase implements CardinalityResponse
 {
 	protected final FederationMember fm;
 	protected final DataRetrievalRequest request;
@@ -19,6 +19,8 @@ public class CachedCardinalityResponseImpl implements CardinalityResponse
 	                                      final int cardinality,
 	                                      final Date requestStartTime,
 	                                      final Date requestEndTime ) {
+		super( fm, request, requestStartTime, requestEndTime );
+
 		assert fm != null;
 		assert request != null;
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/response/CardinalityResponseImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/response/CardinalityResponseImpl.java
@@ -1,5 +1,6 @@
 package se.liu.ida.hefquin.engine.federation.access.impl.response;
 
+import java.time.Duration;
 import java.util.Date;
 
 import se.liu.ida.hefquin.engine.federation.FederationMember;
@@ -13,6 +14,14 @@ public class CardinalityResponseImpl implements CardinalityResponse
 	protected final DataRetrievalRequest request;
 	protected final int cardinality;
 
+    /**
+     * Constructs a cardinality response that wraps the given data retrieval response and associates it
+     * with a request and a cardinality value.
+     *
+     * @param wrappedResponse the wrapped data retrieval response (must not be null)
+     * @param request         the original data retrieval request (must not be null)
+     * @param cardinality     the cardinality of the request
+     */
 	public CardinalityResponseImpl( final DataRetrievalResponse wrappedResponse,
 	                                final DataRetrievalRequest request,
 	                                final int cardinality ) {
@@ -49,8 +58,27 @@ public class CardinalityResponseImpl implements CardinalityResponse
 	}
 
 	@Override
+	public Duration getRequestDuration() {
+		return wrappedResponse.getRequestDuration();
+	}
+
 	public int getCardinality() {
 		return cardinality;
 	}
+
+	@Override
+	public boolean isError() {
+		return wrappedResponse.getErrorStatusCode() != null;
+	};
+
+	@Override
+	public Integer getErrorStatusCode() {
+		return wrappedResponse.getErrorStatusCode();
+	};
+
+	@Override
+	public String getErrorDescription() {
+		return wrappedResponse.getErrorDescription();
+	};
 
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/response/CardinalityResponseImplWithoutCardinality.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/response/CardinalityResponseImplWithoutCardinality.java
@@ -1,53 +1,17 @@
 package se.liu.ida.hefquin.engine.federation.access.impl.response;
 
-import java.util.Date;
-
-import se.liu.ida.hefquin.engine.federation.FederationMember;
-import se.liu.ida.hefquin.engine.federation.access.CardinalityResponse;
 import se.liu.ida.hefquin.engine.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.engine.federation.access.DataRetrievalResponse;
 
-public class CardinalityResponseImplWithoutCardinality implements CardinalityResponse
+public class CardinalityResponseImplWithoutCardinality extends CardinalityResponseImpl
 {
-	protected final DataRetrievalResponse wrappedResponse;
-	protected final DataRetrievalRequest request;
-
 	public CardinalityResponseImplWithoutCardinality( final DataRetrievalResponse wrappedResponse,
 	                                                  final DataRetrievalRequest request ) {
-		assert wrappedResponse != null;
-		assert request != null;
-
-		this.wrappedResponse = wrappedResponse;
-		this.request = request;
-	}
-
-	public DataRetrievalResponse getWrappedResponse() {
-		return wrappedResponse;
+		super( wrappedResponse, request, Integer.MAX_VALUE );
 	}
 
 	@Override
-	public FederationMember getFederationMember() {
-		return wrappedResponse.getFederationMember();
+	public boolean isFallbackResponse() {
+		return true;
 	}
-
-	@Override
-	public DataRetrievalRequest getRequest() {
-		return request;
-	}
-
-	@Override
-	public Date getRequestStartTime() {
-		return wrappedResponse.getRequestStartTime();
-	}
-
-	@Override
-	public Date getRetrievalEndTime() {
-		return wrappedResponse.getRetrievalEndTime();
-	}
-
-	@Override
-	public int getCardinality() {
-		return Integer.MAX_VALUE;
-	}
-
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/response/DataRetrievalResponseBase.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/response/DataRetrievalResponseBase.java
@@ -12,20 +12,74 @@ public abstract class DataRetrievalResponseBase implements DataRetrievalResponse
 	private final DataRetrievalRequest request;
 	private final Date requestStartTime;
 	private final Date retrievalEndTime;
+	protected final Integer errorStatusCode;
+	protected final String errorDescription;
 
 	/**
-	 * Initializes the retrievalEndTime to the time when this object is created.
+	 * Constructs a response with the given federation member, request, and request start time. The retrieval end time
+	 * is automatically set to the current time at the moment of construction. This constructor assumes no error
+	 * occurred.
+	 *
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 */
 	protected DataRetrievalResponseBase( final FederationMember fm,
 	                                     final DataRetrievalRequest request,
 	                                     final Date requestStartTime ) {
-		this( fm, request, requestStartTime, new Date() );
+		this( fm, request, requestStartTime, null, null );
 	}
 
+	/**
+	 * Constructs a response with the given federation member, request, request start time, and request end time. This
+	 * constructor assumes no error occurred.
+	 *
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
+	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
+	 */
 	protected DataRetrievalResponseBase( final FederationMember fm,
 	                                     final DataRetrievalRequest request,
 	                                     final Date requestStartTime,
 	                                     final Date retrievalEndTime ) {
+		this( fm, request, requestStartTime, retrievalEndTime, null, null );
+	}
+
+	/**
+	 * Constructs a response with the given federation member, request, request start time, and error details. The
+	 * retrieval end time is automatically set to the current time at the moment of construction.
+	 *
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
+	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
+	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
+	 */
+	protected DataRetrievalResponseBase( final FederationMember fm,
+	                                     final DataRetrievalRequest request,
+	                                     final Date requestStartTime,
+	                                     final Integer errorStatusCode,
+	                                     final String errorDescription ) {
+		this( fm, request, requestStartTime, new Date(), errorStatusCode, errorDescription );
+	}
+
+	/**
+	 * Constructs a response with fully specified timing and error information.
+	 *
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
+	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
+	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
+	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
+	 */
+	protected DataRetrievalResponseBase( final FederationMember fm,
+	                                     final DataRetrievalRequest request,
+	                                     final Date requestStartTime,
+	                                     final Date retrievalEndTime,
+	                                     final Integer errorStatusCode,
+	                                     final String errorDescription ) {
 		assert fm != null;
 		assert request != null;
 		assert requestStartTime != null;
@@ -35,6 +89,8 @@ public abstract class DataRetrievalResponseBase implements DataRetrievalResponse
 		this.request = request;
 		this.requestStartTime = requestStartTime;
 		this.retrievalEndTime = retrievalEndTime;
+		this.errorStatusCode = errorStatusCode;
+		this.errorDescription = errorDescription;
 	}
 
 	@Override
@@ -57,4 +113,13 @@ public abstract class DataRetrievalResponseBase implements DataRetrievalResponse
 		return retrievalEndTime;
 	}
 
+	@Override
+	public Integer getErrorStatusCode() {
+		return errorStatusCode;
+	}
+
+	@Override
+	public String getErrorDescription() {
+		return errorDescription;
+	}
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/response/JSONResponseImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/response/JSONResponseImpl.java
@@ -8,24 +8,92 @@ import se.liu.ida.hefquin.engine.federation.FederationMember;
 import se.liu.ida.hefquin.engine.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.engine.federation.access.JSONResponse;
 
-public class JSONResponseImpl extends DataRetrievalResponseBase implements JSONResponse {
+public class JSONResponseImpl extends DataRetrievalResponseBase implements JSONResponse
+{
+	protected final JsonObject jsonObj;
 
-    protected final JsonObject jsonObj;
+	/**
+	 * Constructs a response with the given JSON object, federation member, request, and request start time. The
+	 * retireval end time is automatically set to the current time at the moment of construction. This constructor
+	 * assumes no error occurred.
+	 *
+	 * @param obj              the JSON object contained in this response (must not be {@code null})
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the data retrieval request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
+	 */
+	public JSONResponseImpl( final JsonObject obj,
+	                         final FederationMember fm,
+	                         final DataRetrievalRequest request,
+	                         final Date requestStartTime ) {
+		super( fm, request, requestStartTime );
+		this.jsonObj = obj;
+	}
 
-    public JSONResponseImpl(final JsonObject obj, final FederationMember fm, 
-            final DataRetrievalRequest request, final Date requestStartTime) {
-        super(fm, request, requestStartTime);
-        this.jsonObj = obj;
-    }
+	/**
+	 * Constructs a response with the given JSON object, federation member, request, request start time, and retrieval
+	 * end time. This constructor assumes no error occurred.
+	 *
+	 * @param obj              the JSON object contained in this response (must not be {@code null})
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the data retrieval request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
+	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
+	 */
+	public JSONResponseImpl( final JsonObject obj,
+	                         final FederationMember fm,
+	                         final DataRetrievalRequest request,
+	                         final Date requestStartTime,
+	                         final Date retrievalEndTime ) {
+		super( fm, request, requestStartTime, retrievalEndTime );
+		this.jsonObj = obj;
+	}
 
-    public JSONResponseImpl(final JsonObject obj, final FederationMember fm, 
-            final DataRetrievalRequest request, final Date requestStartTime, 
-            final Date requestEndTime) {
-        super(fm, request, requestStartTime, requestEndTime);
-        this.jsonObj = obj;
-    }
+	/**
+	 * Constructs a response with the given JSON object, federation member, request, request start time, and error
+	 * details. The retrieval end time is automatically set to the current time at the moment of construction.
+	 *
+	 * @param obj              the JSON object contained in this response (must not be {@code null})
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
+	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
+	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
+	 */
+	public JSONResponseImpl( final JsonObject obj,
+	                         final FederationMember fm,
+	                         final DataRetrievalRequest request,
+	                         final Date requestStartTime,
+	                         final Integer errorStatusCode,
+	                         final String errorDescription ) {
+		super( fm, request, requestStartTime, errorStatusCode, errorDescription );
+		this.jsonObj = obj;
+	}
 
-    public JsonObject getJsonObject() {
-        return jsonObj;
-    }
+	/**
+	 * Constructs a response with the given JSON object, federation member, request, request start time, retrieval end
+	 * time, and error details.
+	 *
+	 * @param obj              the JSON object contained in this response (must not be {@code null})
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
+	 * @param requestEndTime   the time at which the request was completed (must not be {@code null})
+	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
+	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
+	 */
+	public JSONResponseImpl( final JsonObject obj,
+	                         final FederationMember fm,
+	                         final DataRetrievalRequest request,
+	                         final Date requestStartTime,
+	                         final Date requestEndTime,
+	                         final Integer errorStatusCode,
+	                         final String errorDescription ) {
+		super( fm, request, requestStartTime, requestEndTime, errorStatusCode, errorDescription );
+		this.jsonObj = obj;
+	}
+
+	public JsonObject getJsonObject() {
+		return jsonObj;
+	}
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/response/RecordsResponseImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/response/RecordsResponseImpl.java
@@ -8,29 +8,101 @@ import se.liu.ida.hefquin.engine.wrappers.lpg.data.TableRecord;
 import java.util.Date;
 import java.util.List;
 
-public class RecordsResponseImpl extends DataRetrievalResponseBase implements RecordsResponse {
+public class RecordsResponseImpl extends DataRetrievalResponseBase implements RecordsResponse
+{
+	protected final List<TableRecord> response;
 
-    protected final List<TableRecord> response;
+	/**
+	 * Constructs a response with the given records, federation member, request, and request start time. The retrieval
+	 * end time is automatically set to the current time at the moment of construction. This constructor assumes no
+	 * error occurred.
+	 *
+	 * @param response         the list of records contained in this response (must not be {@code null})
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the data retrieval request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
+	 */
+	public RecordsResponseImpl( final List<TableRecord> response,
+	                            final FederationMember fm,
+	                            final DataRetrievalRequest request,
+	                            final Date requestStartTime ) {
+		super( fm, request, requestStartTime );
 
-    public RecordsResponseImpl(final List<TableRecord> response, final FederationMember fm,
-                               final DataRetrievalRequest request, final Date requestStartTime) {
-        super(fm, request, requestStartTime);
+		assert response != null;
+		this.response = response;
+	}
 
-        assert response != null;
-        this.response = response;
-    }
+	/**
+	 * Constructs a response with the given records, federation member, request, request start time, and retrieval end
+	 * time. This constructor assumes no error occurred.
+	 *
+	 * @param response         the list of records contained in this response (must not be {@code null})
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the data retrieval request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
+	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
+	 */
+	public RecordsResponseImpl( final List<TableRecord> response,
+	                            final FederationMember fm,
+	                            final DataRetrievalRequest request,
+	                            final Date requestStartTime,
+	                            final Date retrievalEndTime ) {
+		super( fm, request, requestStartTime, retrievalEndTime );
 
-    public RecordsResponseImpl(final List<TableRecord> response, final FederationMember fm,
-                               final DataRetrievalRequest request, final Date requestStartTime,
-                               final Date retrievalEndTime) {
-        super(fm, request, requestStartTime, retrievalEndTime);
+		assert response != null;
+		this.response = response;
+	}
 
-        assert response != null;
-        this.response = response;
-    }
+	/**
+	 * Constructs a response with the given records, federation member, request, request start time, and error details..
+	 * The retrieval end time is automatically set to the current time at the moment of construction.
+	 *
+	 * @param response         the list of records contained in this response (must not be {@code null})
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the data retrieval request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
+	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
+	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
+	 */
+	public RecordsResponseImpl( final List<TableRecord> response,
+	                            final FederationMember fm,
+	                            final DataRetrievalRequest request,
+	                            final Date requestStartTime,
+	                            final Integer errorStatusCode,
+	                            final String errorDescription ) {
+		super( fm, request, requestStartTime, errorStatusCode, errorDescription );
 
-    @Override
-    public List<TableRecord> getResponse() {
-        return response;
-    }
+		assert response != null;
+		this.response = response;
+	}
+
+	/**
+	 * Constructs a response with the given records, federation member, request, request start time, retrieval end time,
+	 * and error details.
+	 *
+	 * @param response         the list of records contained in this response (must not be {@code null})
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the data retrieval request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
+	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
+	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
+	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
+	 */
+	public RecordsResponseImpl( final List<TableRecord> response,
+	                            final FederationMember fm,
+	                            final DataRetrievalRequest request,
+	                            final Date requestStartTime,
+	                            final Date retrievalEndTime,
+	                            final Integer errorStatusCode,
+	                            final String errorDescription ) {
+		super( fm, request, requestStartTime, retrievalEndTime, errorStatusCode, errorDescription );
+
+		assert response != null;
+		this.response = response;
+	}
+
+	@Override
+	public List<TableRecord> getResponse() {
+		return response;
+	}
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/response/SolMapsResponseImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/response/SolMapsResponseImpl.java
@@ -15,24 +15,88 @@ public class SolMapsResponseImpl
 	protected final List<SolutionMapping> solMaps;
 
 	/**
-	 * Initializes the retrievalEndTime to the time when this object is created.
+	 * Constructs a response with the given solution mappings, federation member, request, and request start time. The
+	 * retrieval end time is automatically set to the current time at the moment of construction. This constructor
+	 * assumes no error occurred.
+	 *
+	 * @param solMaps          the list of solution mappings contained in this response (must not be {@code null})
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the data request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 */
 	public SolMapsResponseImpl( final List<SolutionMapping> solMaps,
 	                            final FederationMember fm,
 	                            final DataRetrievalRequest request,
 	                            final Date requestStartTime ) {
-		super(fm, request, requestStartTime);
+		super( fm, request, requestStartTime );
 
 		assert solMaps != null;
 		this.solMaps = solMaps;
 	}
 
+	/**
+	 * Constructs a response with the given solution mappings, federation member, request, request start time, and
+	 * retrieval end time. This constructor assumes no error occurred.
+	 *
+	 * @param solMaps          the list of solution mappings contained in this response (must not be {@code null})
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the data retrieval request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
+	 * @param retrievalEndTime the time at which the request retrieval completed (must not be {@code null})
+	 */
 	public SolMapsResponseImpl( final List<SolutionMapping> solMaps,
 	                            final FederationMember fm,
 	                            final DataRetrievalRequest request,
 	                            final Date requestStartTime,
 	                            final Date retrievalEndTime ) {
-		super(fm, request, requestStartTime, retrievalEndTime);
+		super( fm, request, requestStartTime, retrievalEndTime );
+
+		assert solMaps != null;
+		this.solMaps = solMaps;
+	}
+
+	/**
+	 * Constructs a response with the given solution mappings, federation member, request, request start time, and error
+	 * details. The retrieval end time is automatically set to the current time at the moment of construction.
+	 *
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the data retrieval request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
+	 * @param retrievalEndTime the time at which the request retrieval completed (must not be {@code null})
+	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
+	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
+	 */
+	public SolMapsResponseImpl( final List<SolutionMapping> solMaps,
+	                            final FederationMember fm,
+	                            final DataRetrievalRequest request,
+	                            final Date requestStartTime,
+	                            final Integer errorStatusCode,
+	                            final String errorDescription ) {
+		super( fm, request, requestStartTime, errorStatusCode, errorDescription );
+
+		assert solMaps != null;
+		this.solMaps = solMaps;
+	}
+
+	/**
+	 * Constructs a response with the given solution mappings, federation member, request, request start time, retrieval
+	 * end time, and error details.
+	 *
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the data retrieval request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
+	 * @param retrievalEndTime the time at which the request retrieval completed (must not be {@code null})
+	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
+	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
+	 */
+	public SolMapsResponseImpl( final List<SolutionMapping> solMaps,
+	                            final FederationMember fm,
+	                            final DataRetrievalRequest request,
+	                            final Date requestStartTime,
+	                            final Date retrievalEndTime,
+	                            final Integer errorStatusCode,
+	                            final String errorDescription ) {
+		super( fm, request, requestStartTime, retrievalEndTime, errorStatusCode, errorDescription );
 
 		assert solMaps != null;
 		this.solMaps = solMaps;
@@ -47,5 +111,4 @@ public class SolMapsResponseImpl
 	public int getSize() {
 		return solMaps.size();
 	}
-
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/response/StringResponseImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/response/StringResponseImpl.java
@@ -6,33 +6,101 @@ import se.liu.ida.hefquin.engine.federation.access.StringResponse;
 
 import java.util.Date;
 
-public class StringResponseImpl extends DataRetrievalResponseBase implements StringResponse {
+public class StringResponseImpl extends DataRetrievalResponseBase implements StringResponse
+{
+	protected final String response;
 
-    protected final String response;
+	/**
+	 * Constructs a response with a string response, federation member, request, and request start time. The retrieval
+	 * end time is automatically set to the current time at the moment of construction. This constructor assumes no
+	 * error occurred.
+	 *
+	 * @param response         the response string (must not be {@code null})
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the data retrieval request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
+	 */
+	public StringResponseImpl( final String response,
+	                           final FederationMember fm,
+	                           final DataRetrievalRequest request,
+	                           final Date requestStartTime ) {
+		super( fm, request, requestStartTime );
 
-    public StringResponseImpl( final String response,
-                                  final FederationMember fm,
-                                  final DataRetrievalRequest request,
-                                  final Date requestStartTime) {
-        super(fm, request, requestStartTime);
+		assert response != null;
+		this.response = response;
+	}
 
-        assert response != null;
-        this.response = response;
-    }
+	/**
+	 * Constructs a response with a string response, federation member, request, request start time, and retrieval end
+	 * time. This constructor assumes no error occurred.
+	 *
+	 * @param response         the response string (must not be {@code null})
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the data retrieval request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
+	 */
+	public StringResponseImpl( final String response,
+	                           final FederationMember fm,
+	                           final DataRetrievalRequest request,
+	                           final Date requestStartTime,
+	                           final Date retrievalEndTime ) {
+		super( fm, request, requestStartTime, retrievalEndTime );
 
-    public StringResponseImpl( final String response,
-                                  final FederationMember fm,
-                                  final DataRetrievalRequest request,
-                                  final Date requestStartTime,
-                                  final Date retrievalEndTime) {
-        super(fm, request, requestStartTime, retrievalEndTime);
+		assert response != null;
+		this.response = response;
+	}
 
-        assert response != null;
-        this.response = response;
-    }
+	/**
+	 * Constructs a response with a string response, federation member, request, request start time, and error details.
+	 * The retrieval end time is automatically set to the current time at the moment of construction.
+	 *
+	 * @param response         the response string (must not be {@code null})
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the data retrieval request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
+	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
+	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
+	 */
+	public StringResponseImpl( final String response,
+	                           final FederationMember fm,
+	                           final DataRetrievalRequest request,
+	                           final Date requestStartTime,
+	                           final Integer errorStatusCode,
+	                           final String errorDescription ) {
+		super( fm, request, requestStartTime, errorStatusCode, errorDescription );
 
-    @Override
-    public String getResponse() {
-        return this.response;
-    }
+		assert response != null;
+		this.response = response;
+	}
+
+	/**
+	 * Constructs a response with a string response, federation member, request, and request start time. The retrieval
+	 * end time is automatically set to the current time at the moment of construction. This constructor assumes no
+	 * error occurred.
+	 *
+	 * @param response         the response string (must not be {@code null})
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the data retrieval request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
+	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
+	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
+	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
+	 */
+	public StringResponseImpl( final String response,
+	                           final FederationMember fm,
+	                           final DataRetrievalRequest request,
+	                           final Date requestStartTime,
+	                           final Date retrievalEndTime,
+	                           final Integer errorStatusCode,
+	                           final String errorDescription ) {
+		super( fm, request, requestStartTime, retrievalEndTime, errorStatusCode, errorDescription );
+
+		assert response != null;
+		this.response = response;
+	}
+
+	@Override
+	public String getResponse() {
+		return this.response;
+	}
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/response/TPFResponseImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/response/TPFResponseImpl.java
@@ -9,9 +9,7 @@ import se.liu.ida.hefquin.engine.federation.FederationMember;
 import se.liu.ida.hefquin.engine.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.engine.federation.access.TPFResponse;
 
-public class TPFResponseImpl
-                    extends DataRetrievalResponseBase
-                    implements TPFResponse
+public class TPFResponseImpl extends DataRetrievalResponseBase implements TPFResponse
 {
 	protected final List<Triple> matchingTriples;
 	protected final List<Triple> metadataTriples;
@@ -19,7 +17,16 @@ public class TPFResponseImpl
 	protected final String nextPageURL;
 
 	/**
-	 * Initializes the retrievalEndTime to the time when this object is created.
+	 * Constructs a response with the given matching triples, metadata triples, next page URL, federation member,
+	 * request, and request start time. The retrieval end time is automatically set to the current time at the moment of
+	 * construction. This constructor assumes no error occurred.
+	 *
+	 * @param matchingTriples  the list of triples matching the request pattern (must not be null)
+	 * @param metadataTriples  the list of metadata triples (must not be null)
+	 * @param nextPageURL      the URL for the next page of results, or {@code null} if there is none
+	 * @param fm               the federation member from which the data was retrieved
+	 * @param request          the original data retrieval request
+	 * @param requestStartTime the timestamp when the request started
 	 */
 	public TPFResponseImpl( final List<Triple> matchingTriples,
 	                        final List<Triple> metadataTriples,
@@ -27,25 +34,7 @@ public class TPFResponseImpl
 	                        final FederationMember fm,
 	                        final DataRetrievalRequest request,
 	                        final Date requestStartTime ) {
-		super(fm, request, requestStartTime);
-
-		assert matchingTriples != null;
-		assert metadataTriples != null;
-
-		this.matchingTriples = matchingTriples;
-		this.metadataTriples = metadataTriples;
-		this.nextPageURL = nextPageURL; // may be null
-		this.cardEstimate = null;
-	}
-
-	public TPFResponseImpl( final List<Triple> matchingTriples,
-	                        final List<Triple> metadataTriples,
-	                        final String nextPageURL,
-	                        final FederationMember fm,
-	                        final DataRetrievalRequest request,
-	                        final Date requestStartTime,
-	                        final Date retrievalEndTime ) {
-		super(fm, request, requestStartTime, retrievalEndTime);
+		super( fm, request, requestStartTime );
 
 		assert matchingTriples != null;
 		assert metadataTriples != null;
@@ -57,7 +46,47 @@ public class TPFResponseImpl
 	}
 
 	/**
-	 * Initializes the retrievalEndTime to the time when this object is created.
+	 * Constructs a response with the given matching triples, metadata triples, next page URL, federation member,
+	 * request, request start time, and retrieval end time. This constructor assumes no error occurred.
+	 *
+	 * @param matchingTriples  the list of triples matching the request pattern (must not be null)
+	 * @param metadataTriples  the list of metadata triples (must not be null)
+	 * @param nextPageURL      the URL for the next page of results, or {@code null} if there is none
+	 * @param fm               the federation member from which the data was retrieved
+	 * @param request          the original data retrieval request
+	 * @param requestStartTime the timestamp when the request started
+	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
+	 */
+	public TPFResponseImpl( final List<Triple> matchingTriples,
+	                        final List<Triple> metadataTriples,
+	                        final String nextPageURL,
+	                        final FederationMember fm,
+	                        final DataRetrievalRequest request,
+	                        final Date requestStartTime,
+	                        final Date retrievalEndTime ) {
+		super( fm, request, requestStartTime, retrievalEndTime );
+
+		assert matchingTriples != null;
+		assert metadataTriples != null;
+
+		this.matchingTriples = matchingTriples;
+		this.metadataTriples = metadataTriples;
+		this.nextPageURL = nextPageURL; // may be null
+		this.cardEstimate = null;
+	}
+
+	/**
+	 * Constructs a response with the given matching triples, metadata triples, next page URL, triple count, federation
+	 * member, request, and request start time. The retrieval end time is automatically set to the current time at the moment of
+	 * construction. This constructor assumes no error occurred.
+	 *
+	 * @param matchingTriples  the list of triples matching the request pattern (must not be null)
+	 * @param metadataTriples  the list of metadata triples (must not be null)
+	 * @param nextPageURL      the URL for the next page of results, or {@code null} if there is none
+	 * @param tripleCount      the triple count
+	 * @param fm               the federation member from which the data was retrieved
+	 * @param request          the original data retrieval request
+	 * @param requestStartTime the timestamp when the request started
 	 */
 	public TPFResponseImpl( final List<Triple> matchingTriples,
 	                        final List<Triple> metadataTriples,
@@ -66,7 +95,7 @@ public class TPFResponseImpl
 	                        final FederationMember fm,
 	                        final DataRetrievalRequest request,
 	                        final Date requestStartTime ) {
-		super(fm, request, requestStartTime);
+		super( fm, request, requestStartTime );
 
 		assert matchingTriples != null;
 		assert metadataTriples != null;
@@ -75,9 +104,22 @@ public class TPFResponseImpl
 		this.matchingTriples = matchingTriples;
 		this.metadataTriples = metadataTriples;
 		this.nextPageURL = nextPageURL; // may be null
-		this.cardEstimate = Integer.valueOf(tripleCount);
+		this.cardEstimate = Integer.valueOf( tripleCount );
 	}
 
+	/**
+	 * Constructs a response with the given matching triples, metadata triples, next page URL, triple count, federation
+	 * member, request, request start time, and retrieval end time. This constructor assumes no error occurred.
+	 *
+	 * @param matchingTriples  the list of triples matching the request pattern (must not be null)
+	 * @param metadataTriples  the list of metadata triples (must not be null)
+	 * @param nextPageURL      the URL for the next page of results, or {@code null} if there is none
+	 * @param tripleCount      the triple count
+	 * @param fm               the federation member from which the data was retrieved
+	 * @param request          the original data retrieval request
+	 * @param requestStartTime the timestamp when the request started
+	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
+	 */
 	public TPFResponseImpl( final List<Triple> matchingTriples,
 	                        final List<Triple> metadataTriples,
 	                        final String nextPageURL,
@@ -86,7 +128,7 @@ public class TPFResponseImpl
 	                        final DataRetrievalRequest request,
 	                        final Date requestStartTime,
 	                        final Date retrievalEndTime ) {
-		super(fm, request, requestStartTime, retrievalEndTime);
+		super( fm, request, requestStartTime, retrievalEndTime );
 
 		assert matchingTriples != null;
 		assert metadataTriples != null;
@@ -95,7 +137,147 @@ public class TPFResponseImpl
 		this.matchingTriples = matchingTriples;
 		this.metadataTriples = metadataTriples;
 		this.nextPageURL = nextPageURL; // may be null
-		this.cardEstimate = Integer.valueOf(tripleCount);
+		this.cardEstimate = Integer.valueOf( tripleCount );
+	}
+
+	/**
+	 * Constructs a response with the given matching triples, metadata triples, next page URL, federation member,
+	 * request, request start time, and error details. The retrieval end time is automatically set to the current time
+	 * at the moment of construction.
+	 *
+	 * @param matchingTriples  the list of triples matching the request pattern (must not be null)
+	 * @param metadataTriples  the list of metadata triples (must not be null)
+	 * @param nextPageURL      the URL for the next page of results, or {@code null} if there is none
+	 * @param fm               the federation member from which the data was retrieved
+	 * @param request          the original data retrieval request
+	 * @param requestStartTime the timestamp when the request started
+	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
+	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
+	 */
+	public TPFResponseImpl( final List<Triple> matchingTriples,
+	                        final List<Triple> metadataTriples,
+	                        final String nextPageURL,
+	                        final FederationMember fm,
+	                        final DataRetrievalRequest request,
+	                        final Date requestStartTime,
+	                        final int errorStatusCode,
+	                        final String errorDescription ) {
+		super( fm, request, requestStartTime, errorStatusCode, errorDescription );
+
+		assert matchingTriples != null;
+		assert metadataTriples != null;
+
+		this.matchingTriples = matchingTriples;
+		this.metadataTriples = metadataTriples;
+		this.nextPageURL = nextPageURL; // may be null
+		this.cardEstimate = null;
+	}
+
+	/**
+	 * Constructs a response with the given matching triples, metadata triples, next page URL, federation member,
+	 * request, request start time, retrieval end time, and error details.
+	 *
+	 * @param matchingTriples  the list of triples matching the request pattern (must not be null)
+	 * @param metadataTriples  the list of metadata triples (must not be null)
+	 * @param nextPageURL      the URL for the next page of results, or {@code null} if there is none
+	 * @param fm               the federation member from which the data was retrieved
+	 * @param request          the original data retrieval request
+	 * @param requestStartTime the timestamp when the request started
+	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
+	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
+	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
+	 */
+	public TPFResponseImpl( final List<Triple> matchingTriples,
+	                        final List<Triple> metadataTriples,
+	                        final String nextPageURL,
+	                        final FederationMember fm,
+	                        final DataRetrievalRequest request,
+	                        final Date requestStartTime,
+	                        final Date retrievalEndTime,
+	                        final Integer errorStatusCode,
+	                        final String errorDescription ) {
+		super( fm, request, requestStartTime, retrievalEndTime, errorStatusCode, errorDescription );
+
+		assert matchingTriples != null;
+		assert metadataTriples != null;
+
+		this.matchingTriples = matchingTriples;
+		this.metadataTriples = metadataTriples;
+		this.nextPageURL = nextPageURL; // may be null
+		this.cardEstimate = null;
+	}
+
+	/**
+	 * Constructs a response with the given matching triples, metadata triples, next page URL, triple count, federation
+	 * member, request, request start time, and error details. The retrieval end time is automatically set to the
+	 * current time at the moment of construction.
+	 *
+	 * @param matchingTriples  the list of triples matching the request pattern (must not be null)
+	 * @param metadataTriples  the list of metadata triples (must not be null)
+	 * @param nextPageURL      the URL for the next page of results, or {@code null} if there is none
+	 * @param tripleCount      the triple count
+	 * @param fm               the federation member from which the data was retrieved
+	 * @param request          the original data retrieval request
+	 * @param requestStartTime the timestamp when the request started
+	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
+	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
+	 */
+	public TPFResponseImpl( final List<Triple> matchingTriples,
+	                        final List<Triple> metadataTriples,
+	                        final String nextPageURL,
+	                        final int tripleCount,
+	                        final FederationMember fm,
+	                        final DataRetrievalRequest request,
+	                        final Date requestStartTime,
+	                        final Integer errorStatusCode,
+	                        final String errorDescription ) {
+		super( fm, request, requestStartTime, errorStatusCode, errorDescription );
+
+		assert matchingTriples != null;
+		assert metadataTriples != null;
+		assert tripleCount >= 0;
+
+		this.matchingTriples = matchingTriples;
+		this.metadataTriples = metadataTriples;
+		this.nextPageURL = nextPageURL; // may be null
+		this.cardEstimate = Integer.valueOf( tripleCount );
+	}
+
+	/**
+	 * Constructs a response with the given matching triples, metadata triples, next page URL, triple count, federation
+	 * member, request, request start time, retrieval end time, and error details.
+	 *
+	 * @param matchingTriples  the list of triples matching the request pattern (must not be null)
+	 * @param metadataTriples  the list of metadata triples (must not be null)
+	 * @param nextPageURL      the URL for the next page of results, or {@code null} if there is none
+	 * @param tripleCount      the triple count
+	 * @param fm               the federation member from which the data was retrieved
+	 * @param request          the original data retrieval request
+	 * @param requestStartTime the timestamp when the request started
+	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
+	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
+	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
+	 */
+	public TPFResponseImpl( final List<Triple> matchingTriples,
+	                        final List<Triple> metadataTriples,
+	                        final String nextPageURL,
+	                        final int tripleCount,
+	                        final FederationMember fm,
+	                        final DataRetrievalRequest request,
+	                        final Date requestStartTime,
+	                        final Date retrievalEndTime,
+	                        final Integer errorStatusCode,
+	                        final String errorDescription ) {
+		super( fm, request, requestStartTime, retrievalEndTime, errorStatusCode, errorDescription );
+
+		assert matchingTriples != null;
+		assert metadataTriples != null;
+		assert tripleCount >= 0;
+
+		this.matchingTriples = matchingTriples;
+		this.metadataTriples = metadataTriples;
+		this.nextPageURL = nextPageURL; // may be null
+		this.cardEstimate = Integer.valueOf( tripleCount );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/response/TriplesResponseImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/impl/response/TriplesResponseImpl.java
@@ -8,31 +8,94 @@ import se.liu.ida.hefquin.engine.federation.FederationMember;
 import se.liu.ida.hefquin.engine.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.engine.federation.access.TriplesResponse;
 
-public class TriplesResponseImpl
-                            extends DataRetrievalResponseBase
-                            implements TriplesResponse
+public class TriplesResponseImpl extends DataRetrievalResponseBase implements TriplesResponse
 {
 	protected final List<Triple> triples;
 
 	/**
-	 * Initializes the retrievalEndTime to the time when this object is created.
+	 * Constructs a response with the given triples, federation member, request, and request start time. The retrieval
+	 * end time is automatically set to the current time at the moment of construction. This constructor assumes no
+	 * error occurred.
+	 *
+	 * @param triples          the list of triples contained in this response (must not be {@code null})
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the data retrieval request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 */
 	public TriplesResponseImpl( final List<Triple> triples,
 	                            final FederationMember fm,
 	                            final DataRetrievalRequest request,
 	                            final Date requestStartTime ) {
-		super(fm, request, requestStartTime);
+		super( fm, request, requestStartTime );
 
 		assert triples != null;
 		this.triples = triples;
 	}
 
+	/**
+	 * Constructs a response with the given triples. federation member, request, request start time, and the retrieval
+	 * end time. This constructor assumes no error occurred.
+	 *
+	 * @param triples          the list of triples contained in this response (must not be {@code null})
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
+	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
+	 */
 	public TriplesResponseImpl( final List<Triple> triples,
 	                            final FederationMember fm,
 	                            final DataRetrievalRequest request,
 	                            final Date requestStartTime,
 	                            final Date retrievalEndTime ) {
-		super(fm, request, requestStartTime, retrievalEndTime);
+		super( fm, request, requestStartTime, retrievalEndTime );
+
+		assert triples != null;
+		this.triples = triples;
+	}
+
+	/**
+	 * Constructs a response with the given triples, federation member, request, request start time, and error details.
+	 * The retrieval end time is automatically set to the current time at the moment of construction.
+	 *
+	 * @param triples          the list of triples contained in this response (must not be {@code null})
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
+	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
+	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
+	 */
+	public TriplesResponseImpl( final List<Triple> triples,
+	                            final FederationMember fm,
+	                            final DataRetrievalRequest request,
+	                            final Date requestStartTime,
+								final Integer errorStatusCode,
+								final String errorDescription ) {
+		super( fm, request, requestStartTime, errorStatusCode, errorDescription );
+
+		assert triples != null;
+		this.triples = triples;
+	}
+
+	/**
+	 * Constructs a response with the given triples, federation member, request, request start time, retrieval end time,
+	 * and error details.
+	 *
+	 * @param triples          the list of triples contained in this response (must not be {@code null})
+	 * @param fm               the federation member from which this response originates (must not be {@code null})
+	 * @param request          the request associated with this response (must not be {@code null})
+	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
+	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
+	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
+	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
+	 */
+	public TriplesResponseImpl( final List<Triple> triples,
+	                            final FederationMember fm,
+	                            final DataRetrievalRequest request,
+	                            final Date requestStartTime,
+	                            final Date retrievalEndTime,
+								final Integer errorStatusCode,
+								final String errorDescription ) {
+		super( fm, request, requestStartTime, retrievalEndTime, errorStatusCode, errorDescription );
 
 		assert triples != null;
 		this.triples = triples;

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/federation/access/impl/FederationAccessManagerHTTPErrorTests.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/federation/access/impl/FederationAccessManagerHTTPErrorTests.java
@@ -1,0 +1,373 @@
+package se.liu.ida.hefquin.engine.federation.access.impl;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.client.HttpResponseException;
+import org.apache.jena.datatypes.xsd.XSDDatatype;
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.Var;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import se.liu.ida.hefquin.base.data.SolutionMapping;
+import se.liu.ida.hefquin.base.data.Triple;
+import se.liu.ida.hefquin.base.data.VocabularyMapping;
+import se.liu.ida.hefquin.base.data.impl.TripleImpl;
+import se.liu.ida.hefquin.base.data.utils.SolutionMappingUtils;
+import se.liu.ida.hefquin.base.query.TriplePattern;
+import se.liu.ida.hefquin.base.query.impl.TriplePatternImpl;
+import se.liu.ida.hefquin.engine.EngineTestBase;
+import se.liu.ida.hefquin.engine.federation.BRTPFServer;
+import se.liu.ida.hefquin.engine.federation.FederationMember;
+import se.liu.ida.hefquin.engine.federation.Neo4jServer;
+import se.liu.ida.hefquin.engine.federation.SPARQLEndpoint;
+import se.liu.ida.hefquin.engine.federation.TPFServer;
+import se.liu.ida.hefquin.engine.federation.access.*;
+import se.liu.ida.hefquin.engine.federation.access.impl.iface.BRTPFInterfaceImpl;
+import se.liu.ida.hefquin.engine.federation.access.impl.iface.TPFInterfaceImpl;
+import se.liu.ida.hefquin.engine.federation.access.impl.req.BRTPFRequestImpl;
+import se.liu.ida.hefquin.engine.federation.access.impl.req.SPARQLRequestImpl;
+import se.liu.ida.hefquin.engine.federation.access.impl.req.TPFRequestImpl;
+import se.liu.ida.hefquin.engine.federation.access.impl.reqproc.BRTPFRequestProcessor;
+import se.liu.ida.hefquin.engine.federation.access.impl.reqproc.BRTPFRequestProcessorImpl;
+import se.liu.ida.hefquin.engine.federation.access.impl.reqproc.Neo4jRequestProcessor;
+import se.liu.ida.hefquin.engine.federation.access.impl.reqproc.SPARQLRequestProcessor;
+import se.liu.ida.hefquin.engine.federation.access.impl.reqproc.SPARQLRequestProcessorImpl;
+import se.liu.ida.hefquin.engine.federation.access.impl.reqproc.TPFRequestProcessor;
+import se.liu.ida.hefquin.engine.federation.access.impl.reqproc.TPFRequestProcessorImpl;
+import se.liu.ida.hefquin.engine.federation.access.impl.response.SolMapsResponseImpl;
+import se.liu.ida.hefquin.engine.federation.access.impl.response.TPFResponseImpl;
+
+public class FederationAccessManagerHTTPErrorTests extends EngineTestBase
+{
+	protected static ExecutorService execServiceForFedAccess;
+	final TriplePattern tp = new TriplePatternImpl( NodeFactory.createVariable( "s" ),
+	                                                NodeFactory.createVariable( "p" ),
+	                                                NodeFactory.createVariable( "o" ) );
+	final SPARQLRequest sparqlReq = new SPARQLRequestImpl( tp );
+	final TPFRequest tpfReq = new TPFRequestImpl( tp );
+	final BRTPFRequest brtpfReq = new BRTPFRequestImpl( tp, Collections.emptySet() );
+
+	@BeforeClass
+	public static void createExecService() {
+		final int numberOfThreads = 10;
+		execServiceForFedAccess = Executors.newFixedThreadPool( numberOfThreads );
+	}
+
+	@AfterClass
+	public static void tearDownExecService() {
+		execServiceForFedAccess.shutdownNow();
+		try {
+			execServiceForFedAccess.awaitTermination( 500L, TimeUnit.MILLISECONDS );
+		} catch ( final InterruptedException ex ) {
+			System.err.println( "Terminating the thread pool was interrupted." );
+			ex.printStackTrace();
+		}
+	}
+
+	// SPARQL request tests
+
+	@Test
+	public void sparqlCardinalityNoErrorTest() throws FederationAccessException, IOException, InterruptedException, ExecutionException {
+		final SPARQLEndpoint fm = new SPARQLEndpointForTest();
+		final FederationAccessManager fedAccessMgr = createFedAccessMgrForTests();
+		final int card1 = fedAccessMgr.issueCardinalityRequest( sparqlReq, fm ).get().getCardinality();
+		final int card2 = fedAccessMgr.issueRequest( sparqlReq, fm ).get().getSize();
+		assertEquals( card1, card2 );
+	}
+
+	@Test
+	public void sparqlCardinalityHTTPExceptionTest() throws FederationAccessException, IOException, InterruptedException, ExecutionException {
+		final SPARQLEndpoint fm = new SPARQLEndpointForTest();
+		for( final int errorCode : new int[]{ 400, 403, 404, 408, 415, 428, 500, 502, 503, 504 }){
+			final FederationAccessManager fedAccessMgr = createFedAccessMgrForTests( errorCode );
+			final int cardinality = fedAccessMgr.issueCardinalityRequest( sparqlReq, fm ).get().getCardinality();
+			assertEquals( Integer.MAX_VALUE, cardinality );
+		}
+	}
+
+	@Test
+	public void tpfCardinalityNoErrorTest() throws FederationAccessException, IOException, InterruptedException, ExecutionException {
+		final TPFServer fm = new TPFServerForTest();
+		final FederationAccessManager fedAccessMgr = createFedAccessMgrForTests();
+		final int card1 = fedAccessMgr.issueCardinalityRequest( tpfReq, fm ).get().getCardinality();
+		final int card2 = fedAccessMgr.issueRequest( tpfReq, fm ).get().getSize();
+		assertEquals( card1, card2 );
+	}
+
+	@Test
+	public void tpfCardinalityHTTPExceptionTest() throws FederationAccessException, IOException, InterruptedException, ExecutionException {
+		final TPFServer fm = new TPFServerForTest();
+		for( final int errorCode : new int[]{ 400, 403, 404, 408, 415, 428, 500, 502, 503, 504 }){
+			final FederationAccessManager fedAccessMgr = createFedAccessMgrForTests( errorCode );
+			final int cardinality = fedAccessMgr.issueCardinalityRequest( tpfReq, fm ).get().getCardinality();
+			assertEquals( Integer.MAX_VALUE, cardinality );
+		}
+	}
+
+	@Test
+	public void tpfWithBrtpfServerCardinalityNoErrorTest() throws FederationAccessException, IOException, InterruptedException, ExecutionException {
+		final BRTPFServer fm = new BRTPFServerForTest();
+		final FederationAccessManager fedAccessMgr = createFedAccessMgrForTests();
+		final int card1 = fedAccessMgr.issueCardinalityRequest( tpfReq, fm ).get().getCardinality();
+		final int card2 = fedAccessMgr.issueRequest( tpfReq, fm ).get().getSize();
+		assertEquals( card1, card2 );
+	}
+
+	@Test
+	public void tpfWithBrtpfServerCardinalityHTTPExceptionTest() throws FederationAccessException, IOException, InterruptedException, ExecutionException {
+		final BRTPFServer fm = new BRTPFServerForTest();
+		for( final int errorCode : new int[]{ 400, 403, 404, 408, 415, 428, 500, 502, 503, 504 }){
+			final FederationAccessManager fedAccessMgr = createFedAccessMgrForTests( errorCode );
+			final int cardinality = fedAccessMgr.issueCardinalityRequest( tpfReq, fm ).get().getCardinality();
+			assertEquals( Integer.MAX_VALUE, cardinality );
+		}
+	}
+
+	@Test
+	public void brtpfCardinalityNoErrorTest() throws FederationAccessException, IOException, InterruptedException, ExecutionException {
+		final BRTPFServer fm = new BRTPFServerForTest();
+		final FederationAccessManager fedAccessMgr = createFedAccessMgrForTests();
+		final int card1 = fedAccessMgr.issueCardinalityRequest( brtpfReq, fm ).get().getCardinality();
+		final int card2 = fedAccessMgr.issueRequest( brtpfReq, fm ).get().getSize();
+		assertEquals( card1, card2 );
+	}
+
+	@Test
+	public void brtpfCardinalityHTTPExceptionTest() throws FederationAccessException, IOException, InterruptedException, ExecutionException {
+		final BRTPFServer fm = new BRTPFServerForTest();
+		for( final int errorCode : new int[]{ 400, 403, 404, 408, 415, 428, 500, 502, 503, 504 }){
+			final FederationAccessManager fedAccessMgr = createFedAccessMgrForTests( errorCode );
+			final int cardinality = fedAccessMgr.issueCardinalityRequest( brtpfReq, fm ).get().getCardinality();
+			assertEquals( Integer.MAX_VALUE, cardinality );
+		}
+	}
+
+	// ------------ helper code ------------
+
+	public static FederationAccessManager createFedAccessMgrForTests() throws IOException {
+		return createFedAccessMgrForTests( -1 );
+	}
+
+	public static FederationAccessManager createFedAccessMgrForTests( final int errorCode ) throws IOException {
+		final SPARQLRequestProcessor reqProc = new MySPARQLRequestProcessor( errorCode );
+		final TPFRequestProcessor reqProcTPF = new MyTPFRequestProcessor( errorCode );
+		final BRTPFRequestProcessor reqProcBRTPF = new MyBRTPFRequestProcessor( errorCode );
+		final Neo4jRequestProcessor reqProcNeo4j = new Neo4jRequestProcessor() {
+			@Override
+			public RecordsResponse performRequest( Neo4jRequest req, Neo4jServer fm ) {
+				return null;
+			}
+		};
+
+		return new AsyncFederationAccessManagerImpl( execServiceForFedAccess,
+		                                             reqProc,
+		                                             reqProcTPF,
+		                                             reqProcBRTPF,
+		                                             reqProcNeo4j );
+	}
+
+	protected static class MyTPFServerForTest implements TPFServer
+	{
+		protected final TPFInterface iface;
+		protected final long errorCode;
+
+		public MyTPFServerForTest( final int errorCode ) {
+			this.errorCode = errorCode;
+			iface = new TPFInterfaceImpl( "http://example.org/tpf", "subject", "predicate", "object" );
+		}
+
+		@Override
+		public VocabularyMapping getVocabularyMapping() {
+			return null;
+		}
+
+		@Override
+		public TPFInterface getInterface() {
+			return iface;
+		}
+	}
+
+	protected static class MyBRTPFServerForTest implements BRTPFServer
+	{
+		protected final long errorCode;
+		protected final BRTPFInterface iface;
+
+		public MyBRTPFServerForTest( final int errorCode ) {
+			this.errorCode = errorCode;
+			iface = new BRTPFInterfaceImpl( "http://example.org/brtpf", "subject", "predicate", "object", "values" );
+		}
+
+		@Override
+		public VocabularyMapping getVocabularyMapping() {
+			return null;
+		}
+
+		@Override
+		public BRTPFInterface getInterface() {
+			return iface;
+		}
+	}
+
+	protected static class MySPARQLRequestProcessor extends SPARQLRequestProcessorImpl
+	{
+		protected final int errorCode;
+
+		public MySPARQLRequestProcessor( final int errorCode ) {
+			this.errorCode = errorCode;
+		}
+
+		@Override
+		public SolMapsResponse performRequest( SPARQLRequest req, SPARQLEndpoint fm ) throws FederationAccessException {
+			final FederationAccessException e = getException( req, fm, errorCode );
+			if( e != null) throw e;
+
+			final List<SolutionMapping> solMaps = new ArrayList<>();
+			// vars
+			final Var s = Var.alloc( "s" );
+			final Var o = Var.alloc( "o" );
+			final Var p = Var.alloc( "p" );
+			for( final Triple triple : getTriples()){
+				solMaps.add( SolutionMappingUtils.createSolutionMapping( s, triple.asJenaTriple().getSubject(),
+				                                                         p, triple.asJenaTriple().getPredicate(),
+				                                                         o, triple.asJenaTriple().getObject() ) );
+			}
+
+			final List<SolutionMapping> result = new ArrayList<>();
+
+			final Var var = Var.alloc( "__hefquinCountVar" );
+			if ( req.getExpectedVariables().getPossibleVariables().contains( var ) ) {
+				// add cardinality solution mapping
+				final Node countLiteral = NodeFactory.createLiteralByValue( solMaps.size(), XSDDatatype.XSDinteger );
+				final SolutionMapping solMap = SolutionMappingUtils.createSolutionMapping( var, countLiteral );
+				result.add( solMap );
+			} else {
+				// or all solution mappings
+				result.addAll(solMaps);
+			}
+			return new SolMapsResponseImpl( result, fm, req, new Date() );
+		}
+	}
+
+	protected static class MyTPFRequestProcessor extends TPFRequestProcessorImpl
+	{
+		protected final int errorCode;
+
+		public MyTPFRequestProcessor( final int errorCode ) {
+			this.errorCode = errorCode;
+		}
+
+		@Override
+		public TPFResponse performRequest( TPFRequest req, TPFServer fm ) throws FederationAccessException {
+			final FederationAccessException e = getException( req, fm, errorCode );
+			if( e != null) throw e;
+
+			final TPFResponse r = new TPFResponseImpl( getTriples(),
+			                                           Collections.emptyList(),
+			                                           null,
+			                                           fm,
+			                                           req,
+			                                           new Date() ) {
+				@Override
+				public Integer getCardinalityEstimate() {
+					return matchingTriples.size();
+				};
+			};
+			return r;
+		}
+
+		@Override
+		public TPFResponse performRequest( TPFRequest req, BRTPFServer fm ) throws FederationAccessException {
+			final FederationAccessException e = getException( req, fm, errorCode );
+			if( e != null) throw e;
+
+			final TPFResponse r = new TPFResponseImpl( getTriples(),
+			                                           Collections.emptyList(),
+			                                           null,
+			                                           fm,
+			                                           req,
+			                                           new Date() ) {
+				@Override
+				public Integer getCardinalityEstimate() {
+					return matchingTriples.size();
+				};
+			};
+			return r;
+		}
+	}
+
+	protected static class MyBRTPFRequestProcessor extends BRTPFRequestProcessorImpl
+	{
+		protected final int errorCode;
+
+		public MyBRTPFRequestProcessor( final int errorCode ) {
+			this.errorCode = errorCode;
+		}
+
+		@Override
+		public TPFResponse performRequest( BRTPFRequest req, BRTPFServer fm ) throws FederationAccessException {
+			final FederationAccessException e = getException( req, fm, errorCode );
+			if( e != null) throw e;
+
+			final TPFResponse r = new TPFResponseImpl( Collections.emptyList(), Collections.emptyList(), null, fm, req,
+					new Date() ) {
+				@Override
+				public Integer getCardinalityEstimate() {
+					return matchingTriples.size();
+				};
+			};
+			return r;
+		}
+	}
+
+	protected static List<Triple> getTriples() {
+		// values
+		final Node sVal = NodeFactory.createURI( "http://example.org/s" );
+		final Node pVal = NodeFactory.createURI( "http://example.org/p" );
+		final Node o1Val = NodeFactory.createURI( "http://example.org/o1" );
+		final Node o2Val = NodeFactory.createURI( "http://example.org/o2" );
+		final Node o3Val = NodeFactory.createURI( "http://example.org/o3" );
+
+		final List<Triple> triples = new ArrayList<>();
+		triples.add( new TripleImpl( sVal, pVal, o1Val ) );
+		triples.add( new TripleImpl( sVal, pVal, o2Val ) );
+		triples.add( new TripleImpl( sVal, pVal, o3Val ) );
+		return triples;
+	}
+
+	protected static FederationAccessException getException( final DataRetrievalRequest req,
+	                                                         final FederationMember fm,
+	                                                         final int errorCode ){
+		final HttpResponseException e;
+		switch ( errorCode ) {
+			case 400 -> e = new HttpResponseException( 400, "Bad Request" );
+			case 403 -> e = new HttpResponseException( 403, "Forbidden" );
+			case 404 -> e = new HttpResponseException( 404, "Not Found" );
+			case 408 -> e = new HttpResponseException( 408, "Request Timeout" );
+			case 415 -> e = new HttpResponseException( 415, "Unsupported Media Type" );
+			case 428 -> e = new HttpResponseException( 429, "Too Many Requests" );
+			case 500 -> e = new HttpResponseException( 500, "Internal Server Error" );
+			case 502 -> e = new HttpResponseException( 502, "Bad Gateway" );
+			case 503 -> e = new HttpResponseException( 503, "Service Unavailable" );
+			case 504 -> e = new HttpResponseException( 504, "Gateway Timeout" );
+			default -> e = null;
+		}
+		
+		if ( e != null )
+			return new FederationAccessException( e, req, fm );
+		
+		return null;
+	}
+}


### PR DESCRIPTION
## Summary of Changes

This pull request includes the following updates:
- The unchecked exception that may be thrown by `QueryExecution.execSelect()` in `SPARQLRequestProcessorImpl` is now caught and wrapped in a `FederationException` to ensure consistent error handling.
- In `FederationAccessManagerBase1`, `FederationExceptions` raised during calls to `issueCardinalityRequest(...)` are now caught, and `Integer.MAX_VALUE` is returned as a fallback cardinality value.

## Additional Notes
- Since this fix is independent of the specific `FederationAccessManager` implementations, cardinality results continue to be cacheable as usual.