### PR TITLE
add --no-module-directories to pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,9 @@
             <configuration>
               <outputDirectory>target/reports/${project.version}</outputDirectory>
               <failOnError>false</failOnError>
+              <additionalOptions>
+                <additionalOption>--no-module-directories</additionalOption>
+              </additionalOptions>
             </configuration>
           </execution>
           <execution>


### PR DESCRIPTION
This option simplifies the structure of the generated javadoc and makes it possible to to support search functionality when embedding the javadocs in an iframe.