### PR TITLE
update namespace used in federation descriptions

### DIFF
--- a/ExampleFederation.ttl
+++ b/ExampleFederation.ttl
@@ -1,6 +1,6 @@
 PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
-PREFIX fd:     <http://www.example.org/se/liu/ida/hefquin/fd#>
+PREFIX fd:     <http://w3id.org/hefquin/feddesc#>
 PREFIX ex:     <http://example.org/>
 
 ex:dbpediaSPARQL

--- a/hefquin-service/src/main/resources/DefaultFedConf.ttl
+++ b/hefquin-service/src/main/resources/DefaultFedConf.ttl
@@ -1,6 +1,6 @@
 PREFIX rdf:    <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
 PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
-PREFIX fd:     <http://www.example.org/se/liu/ida/hefquin/fd#>
+PREFIX fd:     <http://w3id.org/hefquin/feddesc#>
 PREFIX ex:     <http://example.org/>
 
 ex:dbpediaSPARQL

--- a/hefquin-service/src/test/java/se/liu/ida/hefquin/service/InspectServletTest.java
+++ b/hefquin-service/src/test/java/se/liu/ida/hefquin/service/InspectServletTest.java
@@ -9,7 +9,6 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 
-import org.apache.http.HttpEntity;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -250,8 +249,8 @@ public class InspectServletTest {
 			final String result = EntityUtils.toString( response.getEntity() );
 			final JsonObject o = JsonParser.parseString( result ).getAsJsonObject();
 			assertEquals(
-				"java.util.NoSuchElementException: no federation member with URI <http://invalid/federation/member>",
-				o.getAsJsonArray( "exceptions" ).get( 0 )
+				"\"java.util.NoSuchElementException: no federation member with URI <http://invalid/federation/member>\"",
+				o.getAsJsonArray("exceptions").get(0).toString()
 			);
 		}
 	}

--- a/hefquin-service/src/test/resources/TestFedConf.ttl
+++ b/hefquin-service/src/test/resources/TestFedConf.ttl
@@ -1,4 +1,4 @@
-PREFIX fd:     <http://www.example.org/se/liu/ida/hefquin/fd#>
+PREFIX fd:     <http://w3id.org/hefquin/feddesc#>
 PREFIX ex:     <http://example.org/>
 
 ex:dbpediaSPARQL


### PR DESCRIPTION
This PR updates the namespace used for the federation description vocabulary in the `hefquin-service` resource files and the federation description example file (`ExampleFederation.ttl`).

Resolves issue #436 