### PR TITLE
first version of README.txt for release packages (issue #413)

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -1,0 +1,65 @@
+## What is HeFQUIN?
+
+HeFQUIN is a query‑federation engine for heterogeneous graph‑data sources (e.g., federated knowledge graphs).
+
+Project home and documentation: https://liusemweb.github.io/HeFQUIN/
+
+
+## Key resources
+
+* Feature overview: https://liusemweb.github.io/HeFQUIN/doc/features.html
+* User docs: https://liusemweb.github.io/HeFQUIN/doc/
+* Run using Docker: https://liusemweb.github.io/HeFQUIN/doc/docker.html
+* Run using CLI: https://liusemweb.github.io/HeFQUIN/doc/programs.html
+* Developer docs: https://liusemweb.github.io/HeFQUIN/devdoc/
+* Research publications: https://liusemweb.github.io/HeFQUIN/research/
+* GitHub releases page: https://github.com/LiUSemWeb/HeFQUIN/releases/
+
+
+## Quick start (Docker)
+
+docker pull ghcr.io/LiUSemWeb/hefquin:latest
+docker run \
+    -p 8080:8080 \
+    -v MyFedConf.ttl:/usr/local/tomcat/webapps/ROOT/DefaultFedConf.ttl \
+    hefquin:latest
+
+Visit http://localhost:8080/ and send SPARQL queries to http://localhost:8080/sparql.
+
+Example (with curl):
+
+curl -X POST http://localhost:8080/sparql \
+    --data-binary @ExampleQuery.rq \
+    -H 'Content-Type: application/sparql-query'
+
+
+## Quick start (CLI):
+
+bin/hefquin --federationDescription=MyFedConf.ttl \
+    --query=ExampleQuery.rq
+
+See https://liusemweb.github.io/HeFQUIN/doc/programs.html for full CLI options.
+
+
+## Add HeFQUIN to your build:
+
+Include using Maven:
+
+<dependency>
+    <groupId>se.liu.research.hefquin</groupId>
+    <artifactId>hefquin-engine</artifactId>
+    <version>x.y.z</version> <!-- replace this by the version number of the HeFQUIN release to be used -->
+</dependency> 
+
+Include using Gradle:
+
+implementation("se.liu.research.hefquin:hefquin-engine:x.y.z")
+
+
+## Need help or contribute?
+
+Issues & discussions: https://github.com/LiUSemWeb/HeFQUIN/
+Contributor guidelines: https://liusemweb.github.io/HeFQUIN/devdoc/
+
+
+Licensed under the Apache 2.0 License.


### PR DESCRIPTION
This is a first version a of a `README.txt` that can be provided as part of release packages. It uses plain text, provides links to relevant resources, and includes quick start guidelines.

*Note:* This file should probably not be merged into the repo but instead only be included in the releases packages themselves, right? I'm only adding it here so that we discuss and add comments in-place. 