### PR TITLE
Support prefixes during plan printing

### DIFF
--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/impl/BGPImpl.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/impl/BGPImpl.java
@@ -2,13 +2,16 @@ package se.liu.ida.hefquin.base.query.impl;
 
 import java.util.*;
 
+import org.apache.jena.atlas.io.IndentedLineBuffer;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.ARQConstants;
 import org.apache.jena.sparql.core.BasicPattern;
 import org.apache.jena.sparql.core.PathBlock;
 import org.apache.jena.sparql.core.TriplePath;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.serializer.FormatterElement;
+import org.apache.jena.sparql.serializer.SerializationContext;
 import org.apache.jena.sparql.syntax.Element;
 import org.apache.jena.sparql.syntax.ElementGroup;
 import org.apache.jena.sparql.syntax.ElementPathBlock;
@@ -367,12 +370,15 @@ public class BGPImpl implements BGP
 
 	@Override
 	public String toStringForPlanPrinters() {
-		final ElementTriplesBlock elmt = new ElementTriplesBlock();
-		for ( final TriplePattern tp : tps ) {
-			elmt.addTriple( tp.asJenaTriple() );
+		// convert into an Element object and use
+		// pretty printing via FormatterElement
+		final ElementTriplesBlock block = new ElementTriplesBlock();
+		for ( final TriplePattern t : tps ) {
+			block.addTriple( t.asJenaTriple() );
 		}
-
-		return "{ " + FormatterElement.asString(elmt) + " }";
+		final IndentedLineBuffer buf = new IndentedLineBuffer();
+		final SerializationContext sCxt = new SerializationContext( ARQConstants.getGlobalPrefixMap() );
+		FormatterElement.format( buf, sCxt, block );
+		return "{ " + buf.asString() + " }";
 	}
-
 }

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/impl/GenericSPARQLGraphPatternImpl1.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/impl/GenericSPARQLGraphPatternImpl1.java
@@ -5,8 +5,10 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.jena.atlas.io.IndentedLineBuffer;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.ARQConstants;
 import org.apache.jena.sparql.algebra.Algebra;
 import org.apache.jena.sparql.algebra.Op;
 import org.apache.jena.sparql.algebra.OpVars;
@@ -16,6 +18,7 @@ import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.ExprTransformSubstitute;
 import org.apache.jena.sparql.expr.NodeValue;
 import org.apache.jena.sparql.serializer.FormatterElement;
+import org.apache.jena.sparql.serializer.SerializationContext;
 import org.apache.jena.sparql.syntax.Element;
 import org.apache.jena.sparql.syntax.ElementBind;
 import org.apache.jena.sparql.syntax.ElementFilter;
@@ -32,6 +35,7 @@ import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
 import se.liu.ida.hefquin.base.query.SPARQLGroupPattern;
 import se.liu.ida.hefquin.base.query.TriplePattern;
 import se.liu.ida.hefquin.base.query.VariableByBlankNodeSubstitutionException;
+import se.liu.ida.hefquin.base.query.utils.QueryPatternUtils;
 import se.liu.ida.hefquin.jenaext.sparql.algebra.OpUtils;
 
 /**
@@ -204,7 +208,12 @@ public class GenericSPARQLGraphPatternImpl1 implements SPARQLGraphPattern
 
 	@Override
 	public String toStringForPlanPrinters() {
-		return FormatterElement.asString(jenaPatternElement);
+		// convert into an Element object and use
+		// pretty printing via FormatterElement
+		final IndentedLineBuffer buf = new IndentedLineBuffer();
+		final SerializationContext sCxt = new SerializationContext( ARQConstants.getGlobalPrefixMap() );
+		FormatterElement.format( buf, sCxt, asJenaElement() );
+		return buf.asString();
 	}
 
 }

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/impl/GenericSPARQLGraphPatternImpl2.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/impl/GenericSPARQLGraphPatternImpl2.java
@@ -5,8 +5,10 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.jena.atlas.io.IndentedLineBuffer;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.ARQConstants;
 import org.apache.jena.sparql.algebra.Op;
 import org.apache.jena.sparql.algebra.OpAsQuery;
 import org.apache.jena.sparql.algebra.OpVars;
@@ -23,6 +25,7 @@ import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.graph.NodeTransform;
 import org.apache.jena.sparql.graph.NodeTransformLib;
 import org.apache.jena.sparql.serializer.FormatterElement;
+import org.apache.jena.sparql.serializer.SerializationContext;
 import org.apache.jena.sparql.syntax.Element;
 import org.apache.jena.sparql.syntax.syntaxtransform.NodeTransformSubst;
 
@@ -191,7 +194,12 @@ public class GenericSPARQLGraphPatternImpl2 implements SPARQLGraphPattern
 
 	@Override
 	public String toStringForPlanPrinters() {
-		return FormatterElement.asString( asJenaElement() );
+		// convert into an Element object and use
+		// pretty printing via FormatterElement
+		final IndentedLineBuffer buf = new IndentedLineBuffer();
+		final SerializationContext sCxt = new SerializationContext( ARQConstants.getGlobalPrefixMap() );
+		FormatterElement.format( buf, sCxt, asJenaElement() );
+		return buf.asString();
 	}
 
 }

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/impl/SPARQLGroupPatternImpl.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/impl/SPARQLGroupPatternImpl.java
@@ -7,7 +7,11 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 
+import org.apache.jena.atlas.io.IndentedLineBuffer;
+import org.apache.jena.sparql.ARQConstants;
 import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.serializer.FormatterElement;
+import org.apache.jena.sparql.serializer.SerializationContext;
 
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
@@ -16,6 +20,7 @@ import se.liu.ida.hefquin.base.query.SPARQLGroupPattern;
 import se.liu.ida.hefquin.base.query.TriplePattern;
 import se.liu.ida.hefquin.base.query.VariableByBlankNodeSubstitutionException;
 import se.liu.ida.hefquin.base.query.utils.ExpectedVariablesUtils;
+import se.liu.ida.hefquin.base.query.utils.QueryPatternUtils;
 
 public class SPARQLGroupPatternImpl implements SPARQLGroupPattern
 {
@@ -221,16 +226,11 @@ public class SPARQLGroupPatternImpl implements SPARQLGroupPattern
 
 	@Override
 	public String toStringForPlanPrinters() {
-		final StringBuilder b = new StringBuilder();
-		for ( final SPARQLGraphPattern p : subPatterns ) {
-			b.append( "{" );
-			b.append( System.lineSeparator() );
-			b.append( p.toStringForPlanPrinters() );
-			b.append( System.lineSeparator() );
-			b.append( "}" );
-		}
-
-		return b.toString();
+		// convert into an Element object and use
+		// pretty printing via FormatterElement
+		final IndentedLineBuffer buf = new IndentedLineBuffer();
+		final SerializationContext sCxt = new SerializationContext( ARQConstants.getGlobalPrefixMap() );
+		FormatterElement.format( buf, sCxt, QueryPatternUtils.convertToJenaElement(this) );
+		return buf.asString();
 	}
-
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/BaseForTextBasedPlanPrinters.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/BaseForTextBasedPlanPrinters.java
@@ -109,7 +109,7 @@ public class BaseForTextBasedPlanPrinters
 	                                                 final String indentString,
 	                                                 final PrintStream out ) {
 		final String gpAsString = gp.toStringForPlanPrinters();
-		final String gpAsString2 = gpAsString.replace( System.lineSeparator(), " ");
+		final String gpAsString2 = gpAsString.replaceAll( "\\s+", " ");
 		final String gpAsShortString;
 		if ( gpAsString2.length() > 88 )
 			gpAsShortString = gpAsString2.substring(0, 40) + "[...]" + gpAsString2.substring( gpAsString2.length()-40 );


### PR DESCRIPTION
This PR is a minor addition to the printing of plans. It uses `FormatterElement` for pretty printing and prefixing URI:s (when possible), to make the output a bit more compact. Prefixing is also applied when using `FmtUtils` (e.g., `FmtUtils.stringForTriple`), but for `FormatterElement.asString` the empty prefix mapping is always used.

By default, the prefix mapping in `ARQConstants` contains, e.g., `rdf`, `rdfs` `xsd`,  and `owl`, but the prefixes can be set manually. For example, we could set this programmatically based on the query:
```java
String queryFilename = "ExampleQuery.rq";
Query q = QueryFactory.read(queryFilename, null, Syntax.syntaxARQ);
ARQConstants.getGlobalPrefixMap().setNsPrefixes( q.getPrefixMapping() );
```
Perhaps this would be a nice default behavior when executing queries?

The PR also collapses all whitespace chars in the short version of the string for plan printers, rather than just the replacing the line breaks.