### PR TITLE
Adds QueryPlanningInfo to logical plans

### DIFF
--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/info/QueryPlanProperty.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/info/QueryPlanProperty.java
@@ -1,0 +1,153 @@
+package se.liu.ida.hefquin.engine.queryplan.info;
+
+/**
+ * Represents a particular property of a query plan as determined and
+ * used during query planning. Typical examples of such properties are
+ * the (estimated) cardinality of the query result produced by the plan
+ * and the (estimated) number of requests that will be issued when running
+ * the plan.
+ * <p>
+ * In addition to its type (as captured by the {@link Type} class) and its
+ * value, each such property has a {@link Quality} score which indicates
+ * how certain the value is.
+ */
+public class QueryPlanProperty
+{
+	public static enum Quality {
+		PURE_GUESS(0),
+		MIN_OR_MAX_POSSIBLE(1),
+		ESTIMATE_BASED_ON_ESTIMATES(2),
+		ESTIMATE_BASED_ON_ACCURATES(3),
+		DIRECT_ESTIMATE(4),
+		ACCURATE(5);
+
+		final int pos;
+		Quality( final int pos ) { this.pos = pos; }
+
+		public boolean higherThan( final Quality other ) {
+			return pos > other.pos;
+		}
+	}
+
+	public static class Type {
+		public final String name;
+		public Type( final String name ) { this.name = name; }
+	}
+
+	/**
+	 * A property of this type specifies the (potentially estimated) number
+	 * of solution mappings that can be expected from the corresponding query
+	 * plan.
+	 */
+	public static Type CARDINALITY = new Type("cardinality");
+
+	/**
+	 * A property of this type specifies the (potentially estimated) maximum
+	 * number of solution mappings that can be expected from the corresponding
+	 * query plan.
+	 */
+	public static Type MAX_CARDINALITY = new Type("max cardinality");
+
+	/**
+	 * A property of this type specifies the (potentially estimated) minimum
+	 * number of solution mappings that can be expected from the corresponding
+	 * query plan.
+	 */
+	public static Type MIN_CARDINALITY = new Type("min cardinality");
+
+	/**
+	 * Creates a property of type {@link #CARDINALITY}.
+	 * @param value - the value to be used for the created property
+	 * @param quality - the quality of the given value
+	 * @return the created property
+	 */
+	public static QueryPlanProperty cardinality( final int value,
+	                                             final Quality quality ) {
+		return new QueryPlanProperty(CARDINALITY, value, quality);
+	}
+
+	/**
+	 * Creates a property of type {@link #MAX_CARDINALITY}.
+	 * @param value - the value to be used for the created property
+	 * @param quality - the quality of the given value
+	 * @return the created property
+	 */
+	public static QueryPlanProperty maxCardinality( final int value,
+	                                                final Quality quality ) {
+		return new QueryPlanProperty(MAX_CARDINALITY, value, quality);
+	}
+
+	/**
+	 * Creates a property of type {@link #MIN_CARDINALITY}.
+	 * @param value - the value to be used for the created property
+	 * @param quality - the quality of the given value
+	 * @return the created property
+	 */
+	public static QueryPlanProperty minCardinality( final int value,
+	                                                final Quality quality ) {
+		return new QueryPlanProperty(MIN_CARDINALITY, value, quality);
+	}
+
+	/**
+	 * Creates a copy of the given property (its type and its value) with
+	 * a reduced quality score.
+	 *
+	 * @param p - the property to be copied
+	 * @return the copy
+	 */
+	public static QueryPlanProperty copyWithReducedQuality( final QueryPlanProperty p ) {
+		final Quality reducedQuality = switch (p.quality) {
+			case ACCURATE:
+				yield Quality.ESTIMATE_BASED_ON_ACCURATES;
+			case DIRECT_ESTIMATE:
+				yield Quality.ESTIMATE_BASED_ON_ESTIMATES;
+			case ESTIMATE_BASED_ON_ACCURATES:
+				yield Quality.ESTIMATE_BASED_ON_ESTIMATES;
+			case ESTIMATE_BASED_ON_ESTIMATES:
+				yield Quality.ESTIMATE_BASED_ON_ESTIMATES;
+			case MIN_OR_MAX_POSSIBLE:
+				yield Quality.MIN_OR_MAX_POSSIBLE;
+			case PURE_GUESS:
+				yield Quality.PURE_GUESS;
+		};
+
+		return new QueryPlanProperty( p.type, p.value, reducedQuality );
+	}
+
+	protected final Type type;
+	protected final int value;
+	protected final Quality quality;
+
+	/**
+	 * Creates a new {@link QueryPlanProperty} with the given type, value,
+	 * and quality score.
+	 *
+	 * @param type - the type of the property to be created
+	 * @param value - the value of the property to be created
+	 * @param quality - the quality score of the property to be created
+	 */
+	public QueryPlanProperty( final Type type, final int value, final Quality quality ) {
+		this.type = type;
+		this.value = value;
+		this.quality = quality;
+	}
+
+	/**
+	 * Returns the type of this property.
+	 * @return the type of this property
+	 */
+	public Type getType() { return type; }
+
+	/**
+	 * Returns the value of this property.
+	 * @return the value of this property
+	 */
+	public int getValue() { return value; }
+
+	/**
+	 * Returns the quality score of this property.
+	 * @return the quality score of this property
+	 */
+	public Quality getQuality() { return quality; }
+
+}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/info/QueryPlanningInfo.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/info/QueryPlanningInfo.java
@@ -1,0 +1,63 @@
+package se.liu.ida.hefquin.engine.queryplan.info;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Every object of this class captures a collection of information about
+ * a particular query plan. These objects are meant to be populated and
+ * used during query planning.
+ */
+public class QueryPlanningInfo
+{
+	protected Map<QueryPlanProperty.Type, QueryPlanProperty> properties = new HashMap<>();
+
+	/**
+	 * Can be used to ask whether this collection of information is still empty.
+	 *
+	 * @return <code>true</code> if this collection of information
+	 *         is still empty, <code>false</code> otherwise
+	 */
+	public boolean isEmpty() {
+		return properties.isEmpty();
+	}
+
+	/**
+	 * Returns the query plan property of the given type. If the collected
+	 * information does not include such a property, then <code>null</code>
+	 * is returned.
+	 *
+	 * @param type - the type for which the property is requested
+	 * @return the requested property or <code>null</code>
+	 */
+	public QueryPlanProperty getProperty( final QueryPlanProperty.Type type ) {
+		return properties.get(type);
+	}
+
+	/**
+	 * Returns all collected query plan properties.
+	 *
+	 * @return an iterable of all collected properties
+	 */
+	public Iterable<QueryPlanProperty> getProperties() {
+		return properties.values();
+	}
+
+	/**
+	 * Adds the given property to the collected information, unless
+	 * there already is a property of the same type. If this object
+	 * already contains a property of the same type as the given
+	 * property, then an {@link IllegalArgumentException} is thrown.
+	 *
+	 * @param p - the property to be added
+	 */
+	public void addProperty( final QueryPlanProperty p ) {
+		final QueryPlanProperty.Type type = p.getType();
+
+		if ( properties.containsKey(type) )
+			throw new IllegalArgumentException("This QueryPlanningInfo object already contains a propety of type '" + type.name + "'.");
+
+		properties.put(type, p);
+	}
+
+}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlan.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlan.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryplan.logical;
 import java.util.NoSuchElementException;
 
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 
 public interface LogicalPlan
 {
@@ -32,4 +33,11 @@ public interface LogicalPlan
 	 * then a {@link NoSuchElementException} will be thrown.
 	 */
 	LogicalPlan getSubPlan( int i ) throws NoSuchElementException;
+
+	/**
+	 * Returns an object that captures query-planning-related
+	 * information about this plan. This object is meant to be
+	 * requested and populated by the query planner. 
+	 */
+	QueryPlanningInfo getQueryPlanningInfo();
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/BaseForLogicalPlan.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/BaseForLogicalPlan.java
@@ -1,0 +1,21 @@
+package se.liu.ida.hefquin.engine.queryplan.logical.impl;
+
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
+import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlan;
+
+/**
+ * A base class for implementations of {@link LogicalPlan}.
+ */
+public abstract class BaseForLogicalPlan implements LogicalPlan
+{
+	// to be created only when requested
+	private QueryPlanningInfo info = null;
+
+	@Override
+	public QueryPlanningInfo getQueryPlanningInfo() {
+		if ( info == null )
+			info = new QueryPlanningInfo();
+
+		return info;
+	}
+}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalPlanWithBinaryRootImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalPlanWithBinaryRootImpl.java
@@ -7,7 +7,8 @@ import se.liu.ida.hefquin.engine.queryplan.logical.BinaryLogicalOp;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanWithBinaryRoot;
 
-public class LogicalPlanWithBinaryRootImpl implements LogicalPlanWithBinaryRoot
+public class LogicalPlanWithBinaryRootImpl extends BaseForLogicalPlan
+                                           implements LogicalPlanWithBinaryRoot
 {
 	private final BinaryLogicalOp rootOp;
 	private final LogicalPlan subPlan1;

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalPlanWithNaryRootImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalPlanWithNaryRootImpl.java
@@ -10,7 +10,8 @@ import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanWithNaryRoot;
 import se.liu.ida.hefquin.engine.queryplan.logical.NaryLogicalOp;
 
-public class LogicalPlanWithNaryRootImpl implements LogicalPlanWithNaryRoot
+public class LogicalPlanWithNaryRootImpl extends BaseForLogicalPlan
+                                         implements LogicalPlanWithNaryRoot
 {
 	private final NaryLogicalOp rootOp;
 	private final List<LogicalPlan> subPlans;

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalPlanWithNullaryRootImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalPlanWithNullaryRootImpl.java
@@ -7,7 +7,8 @@ import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanWithNullaryRoot;
 import se.liu.ida.hefquin.engine.queryplan.logical.NullaryLogicalOp;
 
-public class LogicalPlanWithNullaryRootImpl implements LogicalPlanWithNullaryRoot
+public class LogicalPlanWithNullaryRootImpl extends BaseForLogicalPlan
+                                            implements LogicalPlanWithNullaryRoot
 {
 	private final NullaryLogicalOp rootOp;
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalPlanWithUnaryRootImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalPlanWithUnaryRootImpl.java
@@ -7,7 +7,8 @@ import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanWithUnaryRoot;
 import se.liu.ida.hefquin.engine.queryplan.logical.UnaryLogicalOp;
 
-public class LogicalPlanWithUnaryRootImpl implements LogicalPlanWithUnaryRoot
+public class LogicalPlanWithUnaryRootImpl extends BaseForLogicalPlan
+                                          implements LogicalPlanWithUnaryRoot
 {
 	private final UnaryLogicalOp rootOp;
 	private final LogicalPlan subPlan;

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/BaseForTextBasedPlanPrinters.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/BaseForTextBasedPlanPrinters.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryplan.utils;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
@@ -11,6 +12,8 @@ import org.apache.jena.sparql.expr.ExprList;
 import org.apache.jena.sparql.util.ExprUtils;
 
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanProperty;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanVisitor;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.*;
@@ -202,6 +205,7 @@ public class BaseForTextBasedPlanPrinters
 
 		protected String indentLevelString = null;
 		protected String indentLevelStringForOpDetail = null;
+		protected QueryPlanningInfo info = null;
 
 		protected Set<SPARQLGraphPattern> graphPatterns = new HashSet<>();
 		protected List<String> fullStringsForGraphPatterns = new ArrayList<>();
@@ -213,6 +217,41 @@ public class BaseForTextBasedPlanPrinters
 
 		public void setIndentLevelString( final String s ) { indentLevelString = s; }
 		public void setIndentLevelStringForOpDetail( final String s ) { indentLevelStringForOpDetail = s; }
+		public void setQueryPlanningInfo( final QueryPlanningInfo info ) { this.info = info; }
+
+		public void printQueryPlanningInfo( final String indentString ) {
+			out.append( indentString );
+			out.append( "  - query planning info: " );
+
+			if ( info == null || info.isEmpty() ) {
+				out.append( "none" + System.lineSeparator() );
+			}
+			else {
+				final Iterator<QueryPlanProperty> it = info.getProperties().iterator();
+				out.append( " " );
+				print( it.next() );
+				out.append( System.lineSeparator() );
+
+				while ( it.hasNext() ) {
+					out.append( indentString );
+					out.append( "                          " );
+					print( it.next() );
+					out.append( System.lineSeparator() );
+				}
+			}
+		}
+
+		protected void print( final QueryPlanProperty prop ) {
+			out.append( prop.getType().name + " = " + prop.getValue() );
+			switch ( prop.getQuality() ) {
+			case PURE_GUESS:                   out.append(" (pure guess)"); break;
+			case MIN_OR_MAX_POSSIBLE:          out.append(" (min or max possible)"); break;
+			case ESTIMATE_BASED_ON_ESTIMATES:  out.append(" (estimate based on estimates)"); break;
+			case ESTIMATE_BASED_ON_ACCURATES:  out.append(" (estimate based on accurates)"); break;
+			case DIRECT_ESTIMATE:              out.append(" (direct estimate)"); break;
+			case ACCURATE:                     out.append(" (accurate)"); break;
+			}
+		}
 
 		public void printFullStringsForGraphPatterns() {
 			if ( fullStringsForGraphPatterns.isEmpty() )

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedLogicalPlanPrinterImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedLogicalPlanPrinterImpl.java
@@ -49,6 +49,7 @@ public class TextBasedLogicalPlanPrinterImpl extends BaseForTextBasedPlanPrinter
 		final String indentLevelStringForOpDetail = getIndentLevelStringForDetail(planNumber, planLevel, numberOfSiblings, plan.numberOfSubPlans(), indentLevelString);
 		opPrinter.setIndentLevelStringForOpDetail(indentLevelStringForOpDetail);
 
+		opPrinter.setQueryPlanningInfo( plan.getQueryPlanningInfo() );
 		plan.getRootOperator().visit(opPrinter);
 
 		for ( int i = 0; i < plan.numberOfSubPlans(); ++i ) {
@@ -76,6 +77,8 @@ public class TextBasedLogicalPlanPrinterImpl extends BaseForTextBasedPlanPrinter
 				out.append( System.lineSeparator() );
 			}
 
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
+
 			out.append( indentLevelStringForOpDetail + singleBase );
 			out.append( System.lineSeparator() );
 		}
@@ -89,6 +92,8 @@ public class TextBasedLogicalPlanPrinterImpl extends BaseForTextBasedPlanPrinter
 			                  indentLevelStringForOpDetail + singleBase,
 			                  out );
 
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
+
 			out.append( indentLevelStringForOpDetail + singleBase );
 			out.append( System.lineSeparator() );
 		}
@@ -100,6 +105,8 @@ public class TextBasedLogicalPlanPrinterImpl extends BaseForTextBasedPlanPrinter
 			out.append( indentLevelStringForOpDetail + singleBase + "  - vocab.mapping (" + op.getVocabularyMapping().hashCode() +  ") " );
 			out.append( System.lineSeparator() );
 
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
+
 			out.append( indentLevelStringForOpDetail + singleBase );
 			out.append( System.lineSeparator() );
 		}
@@ -110,6 +117,9 @@ public class TextBasedLogicalPlanPrinterImpl extends BaseForTextBasedPlanPrinter
 			out.append( System.lineSeparator() );
 			printFederationMember( op.getFederationMember(), indentLevelStringForOpDetail + singleBase, out );
 			printSPARQLGraphPattern( op.getPattern(), indentLevelStringForOpDetail + singleBase );
+
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
+
 			out.append( indentLevelStringForOpDetail + singleBase );
 			out.append( System.lineSeparator() );
 		}
@@ -120,6 +130,9 @@ public class TextBasedLogicalPlanPrinterImpl extends BaseForTextBasedPlanPrinter
 			out.append( System.lineSeparator() );
 			printFederationMember( op.getFederationMember(), indentLevelStringForOpDetail + singleBase, out );
 			printSPARQLGraphPattern( op.getPattern(), indentLevelStringForOpDetail + singleBase );
+
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
+
 			out.append( indentLevelStringForOpDetail + singleBase );
 			out.append( System.lineSeparator() );
 		}
@@ -128,6 +141,8 @@ public class TextBasedLogicalPlanPrinterImpl extends BaseForTextBasedPlanPrinter
 		public void visit( final LogicalOpJoin op ) {
 			printLogicalOperatorBase( op, indentLevelString, out, np );
 			out.append( System.lineSeparator() );
+
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
 		}
 
 		@Override
@@ -136,6 +151,8 @@ public class TextBasedLogicalPlanPrinterImpl extends BaseForTextBasedPlanPrinter
 			out.append( System.lineSeparator() );
 			out.append( indentLevelStringForOpDetail + singleBase + "  - vocab.mapping (" + op.getVocabularyMapping().hashCode() +  ") " );
 			out.append( System.lineSeparator() );
+
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
 
 			out.append( indentLevelStringForOpDetail + singleBase );
 			out.append( System.lineSeparator() );
@@ -146,6 +163,8 @@ public class TextBasedLogicalPlanPrinterImpl extends BaseForTextBasedPlanPrinter
 			printLogicalOperatorBase( op, indentLevelString, out, np );
 			out.append( System.lineSeparator() );
 
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
+
 			out.append( indentLevelStringForOpDetail + singleBase );
 			out.append( System.lineSeparator() );
 		}
@@ -155,6 +174,8 @@ public class TextBasedLogicalPlanPrinterImpl extends BaseForTextBasedPlanPrinter
 			printLogicalOperatorBase( op, indentLevelString, out, np );
 			out.append( System.lineSeparator() );
 
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
+
 			out.append( indentLevelStringForOpDetail + singleBase );
 			out.append( System.lineSeparator() );
 		}
@@ -163,6 +184,8 @@ public class TextBasedLogicalPlanPrinterImpl extends BaseForTextBasedPlanPrinter
 		public void visit( final LogicalOpMultiwayUnion op ) {
 			printLogicalOperatorBase( op, indentLevelString, out, np );
 			out.append( System.lineSeparator() );
+
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
 
 			out.append( indentLevelStringForOpDetail + singleBase );
 			out.append( System.lineSeparator() );
@@ -183,6 +206,8 @@ public class TextBasedLogicalPlanPrinterImpl extends BaseForTextBasedPlanPrinter
 				out.append( System.lineSeparator() );
 			}
 
+			printQueryPlanningInfo( indentLevelStringForOpDetail );
+
 			out.append( indentLevelStringForOpDetail );
 			out.append( System.lineSeparator() );
 		}
@@ -191,11 +216,15 @@ public class TextBasedLogicalPlanPrinterImpl extends BaseForTextBasedPlanPrinter
 		public void visit( final LogicalOpRightJoin op ) {
 			printLogicalOperatorBase( op, indentLevelString, out, np );
 			out.append( System.lineSeparator() );
+
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
 		}
 
 		@Override
 		public void visit( final LogicalOpUnion op ) {
 			printLogicalOperatorBase( op, indentLevelString, out, np );
+
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
 		}
 	}
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/CardinalityEstimator.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/CardinalityEstimator.java
@@ -1,0 +1,25 @@
+package se.liu.ida.hefquin.engine.queryproc;
+
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanProperty;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
+import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlan;
+
+public interface CardinalityEstimator
+{
+	/**
+	 * Annotates each of the given plans (including, recursively, each of
+	 * their subplans) with estimates regarding their result cardinalities.
+	 * <p>
+	 * More specifically, this method adds three query plan properties to
+	 * the {@link QueryPlanningInfo} of each of the plans:
+	 * <ul>
+	 * <li>{@link QueryPlanProperty#CARDINALITY}</li>
+	 * <li>{@link QueryPlanProperty#MAX_CARDINALITY}</li>
+	 * <li>{@link QueryPlanProperty#MIN_CARDINALITY}</li>
+	 * </ul>
+	 *
+	 * @param plans - the plans to be annotated with cardinality estimates
+	 * @see {@link LogicalPlan#getQueryPlanningInfo()}
+	 */
+	void addCardinalities( LogicalPlan ... plans );
+}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/RequestBasedCardinalityEstimator.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/RequestBasedCardinalityEstimator.java
@@ -1,0 +1,551 @@
+package se.liu.ida.hefquin.engine.queryproc.impl;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import se.liu.ida.hefquin.engine.federation.access.utils.FederationAccessUtils;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanProperty;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanProperty.Quality;
+import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlan;
+import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanVisitor;
+import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanWithNullaryRoot;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBind;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFilter;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGlobalToLocal;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpLocalToGlobal;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayJoin;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayLeftJoin;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayUnion;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRightJoin;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpUnion;
+import se.liu.ida.hefquin.engine.queryproc.CardinalityEstimator;
+import se.liu.ida.hefquin.federation.SPARQLEndpoint;
+import se.liu.ida.hefquin.federation.access.CardinalityResponse;
+import se.liu.ida.hefquin.federation.access.FederationAccessException;
+import se.liu.ida.hefquin.federation.access.FederationAccessManager;
+
+import static se.liu.ida.hefquin.engine.queryplan.info.QueryPlanProperty.CARDINALITY;
+import static se.liu.ida.hefquin.engine.queryplan.info.QueryPlanProperty.MAX_CARDINALITY;
+import static se.liu.ida.hefquin.engine.queryplan.info.QueryPlanProperty.MIN_CARDINALITY;
+
+public class RequestBasedCardinalityEstimator implements CardinalityEstimator
+{
+	protected final FederationAccessManager fedAccMgr;
+
+	public RequestBasedCardinalityEstimator( final FederationAccessManager fedAccMgr ) {
+		assert fedAccMgr != null;
+		this.fedAccMgr = fedAccMgr;
+	}
+
+	@Override
+	public void addCardinalities( final LogicalPlan ... plans ) {
+		// As a first step, make sure that all nullary subplans (i.e.,
+		// with request operators) within the given plans are annotated
+		// with a cardinality estimate.
+		addCardinalitiesForRequests(plans);
+
+		// Now, use the worker to determine the cardinality estimates
+		// for the given plans recursively. 
+		new CardinalityEstimationWorker().addCardinalities(plans);
+	}
+
+
+	public void addCardinalitiesForRequests( final LogicalPlan ... plans ) {
+		// Recursively extract all relevant nullary subplans from the
+		// given plan, where a nullary subplan is considered relevant
+		// if it does not yet have a cardinality estimate.
+		final List<LogicalPlan> subPlans = extractNullarySubPlans(plans);
+
+		// Without any relevant nullary subplans there is nothing to do here.
+		if ( subPlans.isEmpty() ) return;
+
+		// As input for method that adds cardinality estimates to the
+		// extracted subplans, obtain the request operator and the
+		// QueryPlanningInfo object of each of these subplans.
+		final List<LogicalOpRequest<?,?>> reqOps  = new ArrayList<>( subPlans.size() );
+		final List<QueryPlanningInfo> infoObjs    = new ArrayList<>( subPlans.size() );
+		for ( final LogicalPlan subPlan : subPlans ) {
+			reqOps.add( (LogicalOpRequest<?,?>) subPlan.getRootOperator() );
+			infoObjs.add( subPlan.getQueryPlanningInfo() );
+		}
+
+		// Now we are ready to add the cardinality estimates.
+		addCardinalities(reqOps, infoObjs);
+	}
+
+	protected List<LogicalPlan> extractNullarySubPlans( final LogicalPlan ... plans ) {
+		if ( plans.length == 0 )
+			return List.of();
+
+		final List<LogicalPlan> subPlans = new ArrayList<>();
+		for ( int i = 0; i < plans.length; i++ ) {
+			extractNullarySubPlans( plans[i], subPlans );
+		}
+
+		return subPlans;
+	}
+
+	protected void extractNullarySubPlans( final LogicalPlan plan,
+	                                       final List<LogicalPlan> extractedSubPlans ) {
+		if ( plan instanceof LogicalPlanWithNullaryRoot ) {
+			final QueryPlanningInfo qpInfo = plan.getQueryPlanningInfo();
+			if ( qpInfo.getProperty(CARDINALITY) == null ) {
+				extractedSubPlans.add(plan);
+			}
+		}
+		else {
+			// Recursion: extract all relevant nullary plans
+			// from the direct subplans of the given plan.
+			for ( int i = 0; i < plan.numberOfSubPlans(); i++ ) {
+				extractNullarySubPlans( plan.getSubPlan(i), extractedSubPlans );
+			}
+		}
+	}
+
+	protected void addCardinalities( final List<LogicalOpRequest<?,?>> reqOps,
+	                                 final List<QueryPlanningInfo> infoObjs ) {
+		final CardinalityResponse[] resps;
+		try {
+			resps = FederationAccessUtils.performCardinalityRequests( fedAccMgr,
+			                                                          reqOps );
+		}
+		catch ( final FederationAccessException e ) {
+			// If the cardinality requests fail, we need to guess. For the
+			// moment, we simply guess the worst possible cardinality (max).
+// TODO: We should try to be a bit smarter, using some heuristic that takes
+// the patterns of the given requests into account.
+// TODO: Also, in cases in which only some of the cardinality requests failed,
+// we should at least get the values for those that did not fail. 
+			final QueryPlanProperty est = QueryPlanProperty.cardinality(Integer.MAX_VALUE,
+			                                                            Quality.PURE_GUESS);
+			final QueryPlanProperty min = QueryPlanProperty.minCardinality(0,
+			                                                               Quality.MIN_OR_MAX_POSSIBLE);
+			final QueryPlanProperty max = QueryPlanProperty.maxCardinality(Integer.MAX_VALUE,
+			                                                               Quality.MIN_OR_MAX_POSSIBLE);
+			for ( final QueryPlanningInfo qpInfo : infoObjs ) {
+				qpInfo.addProperty(est);
+				qpInfo.addProperty(min);
+				qpInfo.addProperty(max);
+			}
+			return;
+		}
+
+		if ( resps.length != reqOps.size() )
+			throw new IllegalStateException("Wrong number of cardinality responses (namely, " + resps.length + ", but " + reqOps.size() + " expected).");
+
+		for ( int i = 0; i < resps.length; i++ ) {
+			final LogicalOpRequest<?,?> reqOp = reqOps.get(i);
+			final QueryPlanningInfo infoObj = infoObjs.get(i);
+
+			final int cardValue;
+			final int minCardValue;
+			final int maxCardValue;
+			final QueryPlanProperty.Quality cardQuality;
+			final QueryPlanProperty.Quality minCardQuality;
+			final QueryPlanProperty.Quality maxCardQuality;
+
+			if ( resps[i].isError() ) {
+				cardValue = Integer.MAX_VALUE;
+				cardQuality = Quality.PURE_GUESS;
+				minCardValue = 0;
+				minCardQuality = Quality.MIN_OR_MAX_POSSIBLE;
+				maxCardValue = Integer.MAX_VALUE;
+				maxCardQuality = Quality.MIN_OR_MAX_POSSIBLE;
+			}
+			else {
+				try {
+					cardValue = resps[i].getCardinality();
+				}
+				catch ( final Exception e ) {
+					// We should not get an exception here because we are
+					// in the branch where resps[i].isError() is false.
+					throw new IllegalStateException();
+				}
+
+				if ( reqOp.getFederationMember() instanceof SPARQLEndpoint ) {
+					cardQuality = Quality.ACCURATE;
+				}
+				else {
+					cardQuality = Quality.DIRECT_ESTIMATE;
+				}
+
+				minCardValue = cardValue;
+				maxCardValue = cardValue;
+				minCardQuality = cardQuality;
+				maxCardQuality = cardQuality;
+			}
+
+			infoObj.addProperty( QueryPlanProperty.cardinality(cardValue,
+			                                                   cardQuality) );
+
+			infoObj.addProperty( QueryPlanProperty.minCardinality(minCardValue,
+			                                                      minCardQuality) );
+
+			infoObj.addProperty( QueryPlanProperty.maxCardinality(maxCardValue,
+			                                                      maxCardQuality) );
+		}
+	}
+
+	/**
+	 * Assumes that all nullary subplans within the given plan are
+	 * already annotated with a cardinality estimate.
+	 */
+	protected void addCardinality( final LogicalPlan plan ) {
+		final QueryPlanningInfo qpInfo = plan.getQueryPlanningInfo();
+		if ( qpInfo.getProperty(CARDINALITY) != null ) {
+			return;
+		}
+
+		for ( int i = 0; i < plan.numberOfSubPlans(); i++ ) {
+			addCardinality( plan.getSubPlan(i) );
+		}
+
+		LogicalPlanVisitor v = null;
+		plan.getRootOperator().visit(v);
+	}
+
+	protected static class CardinalityEstimationWorker implements LogicalPlanVisitor {
+
+		protected LogicalPlan currentSubPlan = null;
+
+		/**
+		 * Assumes that all nullary subplans within the given plans are
+		 * already annotated with a cardinality estimate.
+		 */
+		public void addCardinalities( final LogicalPlan ... plans ) {
+			// Determine the cardinality estimates for the given plans
+			// recursively (bottom up).
+			for ( int i = 0; i < plans.length; i++ ) {
+				addCardinality( plans[i] );
+			}
+		}
+
+		/**
+		 * Assumes that all nullary subplans within the given plan are
+		 * already annotated with a cardinality estimate.
+		 */
+		protected void addCardinality( final LogicalPlan plan ) {
+			final QueryPlanningInfo qpInfo = plan.getQueryPlanningInfo();
+			if ( qpInfo.getProperty(CARDINALITY) != null ) {
+				return;
+			}
+
+			for ( int i = 0; i < plan.numberOfSubPlans(); i++ ) {
+				addCardinality( plan.getSubPlan(i) );
+			}
+
+			currentSubPlan = plan;
+			plan.getRootOperator().visit(this);
+		}
+
+		@Override
+		public void visit( final LogicalOpRequest<?,?> op ) {
+			// Since we assume that the nullary plans (which have a request
+			// operator) have all been annotated already, we should never
+			// end up here.
+			throw new IllegalArgumentException();
+		}
+
+		@Override
+		public void visit( final LogicalOpJoin op ) {
+			addCardinalityForInnerJoin();
+		}
+
+		@Override
+		public void visit( LogicalOpMultiwayJoin op ) {
+			addCardinalityForInnerJoin();
+		}
+
+		@Override
+		public void visit( final LogicalOpGPAdd op ) {
+			throw new UnsupportedOperationException("Cardinality estimation for gpOptAdd not supported yet.");
+		}
+
+		@Override
+		public void visit( final LogicalOpGPOptAdd op ) {
+			throw new UnsupportedOperationException("Cardinality estimation for gpOptAdd not supported yet.");
+		}
+
+		@Override
+		public void visit( final LogicalOpRightJoin op ) {
+			// As the estimated cardinality, we simply use the estimated
+			// cardinality of right-hand-side input plan (i.e., the non-
+			// optional input). This may be a gross underestimation!
+			// TODO: There is probably a slightly better approach.
+
+			// The min.cardinality is 0 and the max.cardinality is the
+			// product of the max.cardinalities of the two input plans.
+
+			final QueryPlanningInfo qpInfoSubPlan1 = currentSubPlan.getSubPlan(0).getQueryPlanningInfo();
+			final QueryPlanProperty crd1 = qpInfoSubPlan1.getProperty(CARDINALITY);
+			final QueryPlanProperty max1 = qpInfoSubPlan1.getProperty(MAX_CARDINALITY);
+
+			final QueryPlanningInfo qpInfoSubPlan2 = currentSubPlan.getSubPlan(1).getQueryPlanningInfo();
+			final QueryPlanProperty max2 = qpInfoSubPlan2.getProperty(MAX_CARDINALITY);
+
+			final int crdValue = crd1.getValue();
+			final int maxValue = multiplyWithoutExceedingMax( max1.getValue(), max2.getValue() );
+
+			final Quality crdQuality;
+			if ( crd1.getQuality() == Quality.ACCURATE )
+				crdQuality = Quality.ESTIMATE_BASED_ON_ACCURATES;
+			else if (    crd1.getQuality() == Quality.DIRECT_ESTIMATE
+			          || crd1.getQuality() == Quality.ESTIMATE_BASED_ON_ACCURATES
+			          || crd1.getQuality() == Quality.ESTIMATE_BASED_ON_ESTIMATES )
+				crdQuality = Quality.ESTIMATE_BASED_ON_ESTIMATES;
+			else
+				crdQuality = crd1.getQuality();
+
+			final Quality maxQuality;
+			if (    max1.getQuality() == Quality.ACCURATE
+			     && max2.getQuality() == Quality.ACCURATE )
+				maxQuality = Quality.ESTIMATE_BASED_ON_ACCURATES;
+			else if (    max1.getQuality() == Quality.ACCURATE
+			          && max2.getQuality() == Quality.DIRECT_ESTIMATE )
+				maxQuality = Quality.ESTIMATE_BASED_ON_ESTIMATES;
+			else if (    max2.getQuality() == Quality.ACCURATE
+			          && max1.getQuality() == Quality.DIRECT_ESTIMATE )
+				maxQuality = Quality.ESTIMATE_BASED_ON_ESTIMATES;
+			else if (    max1.getQuality() == Quality.DIRECT_ESTIMATE
+			          && max2.getQuality() == Quality.DIRECT_ESTIMATE )
+				maxQuality = Quality.ESTIMATE_BASED_ON_ESTIMATES;
+			else if (    max1.getQuality() == Quality.ESTIMATE_BASED_ON_ACCURATES
+			          && max2.getQuality() == Quality.ESTIMATE_BASED_ON_ACCURATES )
+				maxQuality = Quality.ESTIMATE_BASED_ON_ESTIMATES;
+			else
+				maxQuality = pickWorse( max1.getQuality(), max2.getQuality() );
+
+			final QueryPlanningInfo qpInfo = currentSubPlan.getQueryPlanningInfo();
+			qpInfo.addProperty( QueryPlanProperty.cardinality(crdValue, crdQuality) );
+			qpInfo.addProperty( QueryPlanProperty.maxCardinality(maxValue, maxQuality) );
+			qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.MIN_OR_MAX_POSSIBLE) );
+		}
+
+		@Override
+		public void visit( final LogicalOpMultiwayLeftJoin op ) {
+			throw new UnsupportedOperationException("Cardinality estimation for multiway left join not supported yet.");
+		}
+
+		@Override
+		public void visit( final LogicalOpFilter op ) {
+			final QueryPlanningInfo qpInfo = currentSubPlan.getQueryPlanningInfo();
+			final QueryPlanningInfo qpInfoSubPlan = currentSubPlan.getSubPlan(0).getQueryPlanningInfo();
+
+			final QueryPlanProperty crd = qpInfoSubPlan.getProperty(CARDINALITY);
+			final QueryPlanProperty max = qpInfoSubPlan.getProperty(MAX_CARDINALITY);
+
+			// TODO: perhaps we can be smarter here and somehow estimate the
+			// selectivity of the filter expression.
+
+			qpInfo.addProperty( QueryPlanProperty.copyWithReducedQuality(crd) );
+			qpInfo.addProperty( QueryPlanProperty.copyWithReducedQuality(max) );
+			qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.MIN_OR_MAX_POSSIBLE) );
+		}
+
+		@Override
+		public void visit( final LogicalOpBind op ) {
+			final QueryPlanningInfo qpInfo = currentSubPlan.getQueryPlanningInfo();
+			final QueryPlanningInfo qpInfoSubPlan = currentSubPlan.getSubPlan(0).getQueryPlanningInfo();
+
+			qpInfo.addProperty( qpInfoSubPlan.getProperty(CARDINALITY) );
+			qpInfo.addProperty( qpInfoSubPlan.getProperty(MAX_CARDINALITY) );
+			qpInfo.addProperty( qpInfoSubPlan.getProperty(MIN_CARDINALITY) );
+		}
+
+		@Override
+		public void visit( final LogicalOpLocalToGlobal op ) {
+			final QueryPlanningInfo qpInfo = currentSubPlan.getQueryPlanningInfo();
+			final QueryPlanningInfo qpInfoSubPlan = currentSubPlan.getSubPlan(0).getQueryPlanningInfo();
+
+			final QueryPlanProperty crd = qpInfoSubPlan.getProperty(CARDINALITY);
+			final QueryPlanProperty max = qpInfoSubPlan.getProperty(MAX_CARDINALITY);
+			final QueryPlanProperty min = qpInfoSubPlan.getProperty(MIN_CARDINALITY);
+
+			if ( op.getVocabularyMapping().isEquivalenceOnly() ) {
+				// If the vocabulary mapping contains only equivalence
+				// rules, applying this vocabulary mapping to a set of
+				// solution mappings cannot result in fewer or more
+				// output solution mappings.
+				qpInfo.addProperty(crd);
+				qpInfo.addProperty(max);
+				qpInfo.addProperty(min);
+			}
+			else {
+				// Applying a vocabulary mapping that contains not only
+				// equivalence rules may affect the result cardinality.
+				// Yet, it is not clear how to estimate this effect. So,
+				// let's simply carry over the estimates produced for the
+				// input plan, but with reduced quality scores.
+				qpInfo.addProperty( QueryPlanProperty.copyWithReducedQuality(crd) );
+				qpInfo.addProperty( QueryPlanProperty.copyWithReducedQuality(max) );
+				qpInfo.addProperty( QueryPlanProperty.copyWithReducedQuality(min) );
+			}
+		}
+
+		@Override
+		public void visit( final LogicalOpGlobalToLocal op ) {
+			final QueryPlanningInfo qpInfo = currentSubPlan.getQueryPlanningInfo();
+			final QueryPlanningInfo qpInfoSubPlan = currentSubPlan.getSubPlan(0).getQueryPlanningInfo();
+
+			final QueryPlanProperty crd = qpInfoSubPlan.getProperty(CARDINALITY);
+			final QueryPlanProperty max = qpInfoSubPlan.getProperty(MAX_CARDINALITY);
+			final QueryPlanProperty min = qpInfoSubPlan.getProperty(MIN_CARDINALITY);
+
+			if ( op.getVocabularyMapping().isEquivalenceOnly() ) {
+				// If the vocabulary mapping contains only equivalence
+				// rules, applying this vocabulary mapping to a set of
+				// solution mappings cannot result in fewer or more
+				// output solution mappings.
+				qpInfo.addProperty(crd);
+				qpInfo.addProperty(max);
+				qpInfo.addProperty(min);
+			}
+			else {
+				// Applying a vocabulary mapping that contains not only
+				// equivalence rules may affect the result cardinality.
+				// Yet, it is not clear how to estimate this effect. So,
+				// let's simply carry over the estimates produced for the
+				// input plan, but with reduced quality scores.
+				qpInfo.addProperty( QueryPlanProperty.copyWithReducedQuality(crd) );
+				qpInfo.addProperty( QueryPlanProperty.copyWithReducedQuality(max) );
+				qpInfo.addProperty( QueryPlanProperty.copyWithReducedQuality(min) );
+			}
+		}
+
+		@Override
+		public void visit( final LogicalOpUnion op ) {
+			addCardinalityForUnion();
+		}
+
+		@Override
+		public void visit( final LogicalOpMultiwayUnion op ) {
+			addCardinalityForUnion();
+		}
+
+		public void addCardinalityForUnion() {
+			int crdValue = 0;
+			int maxValue = 0;
+			int minValue = 0;
+			Quality crdQuality = Quality.ACCURATE;
+			Quality maxQuality = Quality.ACCURATE;
+			Quality minQuality = Quality.ACCURATE;
+
+			for ( int x = 0; x < currentSubPlan.numberOfSubPlans(); x++ ) {
+				final QueryPlanningInfo qpInfoSubPlanX = currentSubPlan.getSubPlan(x).getQueryPlanningInfo();
+				final QueryPlanProperty crdX = qpInfoSubPlanX.getProperty(CARDINALITY);
+				final QueryPlanProperty maxX = qpInfoSubPlanX.getProperty(MAX_CARDINALITY);
+				final QueryPlanProperty minX = qpInfoSubPlanX.getProperty(MIN_CARDINALITY);
+
+				crdValue = addWithoutExceedingMax( crdValue, crdX.getValue() );
+				maxValue = addWithoutExceedingMax( maxValue, maxX.getValue() );
+				minValue = addWithoutExceedingMax( minValue, minX.getValue() );
+
+				crdQuality = pickWorse( crdQuality, crdX.getQuality() );
+				maxQuality = pickWorse( maxQuality, maxX.getQuality() );
+				minQuality = pickWorse( minQuality, minX.getQuality() );
+			}
+
+			final QueryPlanningInfo qpInfo = currentSubPlan.getQueryPlanningInfo();
+			qpInfo.addProperty( QueryPlanProperty.cardinality(crdValue, crdQuality) );
+			qpInfo.addProperty( QueryPlanProperty.maxCardinality(maxValue, maxQuality) );
+			qpInfo.addProperty( QueryPlanProperty.minCardinality(minValue, minQuality) );
+		}
+
+		public void addCardinalityForInnerJoin() {
+			// As the estimated cardinality, we simply use the maximum
+			// of the estimated cardinality of every input plan. This
+			// is a very inaccurate estimate!
+			// TODO: There is probably a slightly better approach.
+			// TODO: An initial addition that is certainly useful (and
+			// easy to implement) is to consider the special case of a
+			// join without join variables (i.e., a cross product), in
+			// which case the cardinalities of the input plans need to
+			// be multiplied.
+
+			// The min.cardinality is 0 and the max.cardinality is the
+			// product of the max.cardinalities of all input plans.
+
+			int crdValue = 0;
+			int maxValue = 1;
+			Quality crdQuality = Quality.ACCURATE;
+			Quality maxQuality = Quality.ACCURATE;
+
+			for ( int x = 0; x < currentSubPlan.numberOfSubPlans(); x++ ) {
+				final QueryPlanningInfo qpInfoSubPlanX = currentSubPlan.getSubPlan(x).getQueryPlanningInfo();
+				final QueryPlanProperty crdX = qpInfoSubPlanX.getProperty(CARDINALITY);
+				final QueryPlanProperty maxX = qpInfoSubPlanX.getProperty(MAX_CARDINALITY);
+
+				maxValue = multiplyWithoutExceedingMax( maxValue, maxX.getValue() );
+				crdValue = Math.max( crdValue, crdX.getValue() );
+
+				maxQuality = pickWorse( maxQuality, maxX.getQuality() );
+
+				if (    x == 1
+				     || crdX.getQuality() == Quality.PURE_GUESS
+				     || crdX.getQuality() == Quality.MIN_OR_MAX_POSSIBLE
+				     || crdX.getQuality() == Quality.ESTIMATE_BASED_ON_ESTIMATES ) {
+					crdQuality = crdX.getQuality();
+				}
+				else if (    crdQuality == Quality.PURE_GUESS
+				          || crdQuality == Quality.MIN_OR_MAX_POSSIBLE
+				          || crdQuality == Quality.ESTIMATE_BASED_ON_ESTIMATES ) {
+					// crdQuality = crdQuality;  // do nothing
+				}
+				else if (    crdQuality == Quality.ACCURATE
+				          && crdX.getQuality()  == Quality.ACCURATE ) {
+					crdQuality = Quality.ESTIMATE_BASED_ON_ACCURATES;
+				}
+				else {
+					crdQuality = Quality.ESTIMATE_BASED_ON_ESTIMATES;
+				}
+			}
+
+			final QueryPlanningInfo qpInfo = currentSubPlan.getQueryPlanningInfo();
+			qpInfo.addProperty( QueryPlanProperty.cardinality(crdValue, crdQuality) );
+			qpInfo.addProperty( QueryPlanProperty.maxCardinality(maxValue, maxQuality) );
+			qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.MIN_OR_MAX_POSSIBLE) );
+		}
+
+	}
+
+
+	public static int addWithoutExceedingMax( final int x, final int y ) {
+		if ( x == Integer.MAX_VALUE || y == Integer.MAX_VALUE )
+			return Integer.MAX_VALUE;
+
+		final int result = x + y;
+
+		// check for overflow
+		return ( result < 0 ) ? Integer.MAX_VALUE : result;
+	}
+
+	public static int multiplyWithoutExceedingMax( final int x, final int y ) {
+		if ( x == Integer.MAX_VALUE || y == Integer.MAX_VALUE )
+			return Integer.MAX_VALUE;
+
+		final int result = x * y;
+
+		// check for overflow
+		return ( result < 0 ) ? Integer.MAX_VALUE : result;
+	}
+
+	public static Quality pickWorse( final Quality q1, final Quality q2 ) {
+		if ( q1 == Quality.ACCURATE ) return q2;
+		if ( q2 == Quality.ACCURATE ) return q1;
+		if ( q1 == Quality.DIRECT_ESTIMATE ) return q2;
+		if ( q2 == Quality.DIRECT_ESTIMATE ) return q1;
+		if ( q1 == Quality.ESTIMATE_BASED_ON_ACCURATES ) return q2;
+		if ( q2 == Quality.ESTIMATE_BASED_ON_ACCURATES ) return q1;
+		if ( q1 == Quality.ESTIMATE_BASED_ON_ESTIMATES ) return q2;
+		if ( q2 == Quality.ESTIMATE_BASED_ON_ESTIMATES ) return q1;
+		if ( q1 == Quality.MIN_OR_MAX_POSSIBLE ) return q2;
+		if ( q2 == Quality.MIN_OR_MAX_POSSIBLE ) return q1;
+		return q1;
+	}
+
+}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/CardinalityBasedJoinOrderingWithRequests.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/CardinalityBasedJoinOrderingWithRequests.java
@@ -1,23 +1,10 @@
 package se.liu.ida.hefquin.engine.queryproc.impl.loptimizer.heuristics;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
-import se.liu.ida.hefquin.engine.federation.access.utils.FederationAccessUtils;
-import se.liu.ida.hefquin.engine.queryplan.logical.LogicalOperator;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanProperty;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlan;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBind;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFilter;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpLocalToGlobal;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayUnion;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
-import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpUnion;
-import se.liu.ida.hefquin.engine.queryproc.LogicalOptimizationException;
 import se.liu.ida.hefquin.engine.queryproc.QueryProcContext;
-import se.liu.ida.hefquin.federation.access.CardinalityResponse;
-import se.liu.ida.hefquin.federation.access.FederationAccessException;
-import se.liu.ida.hefquin.federation.access.UnsupportedOperationDueToRetrievalError;
 
 /**
  * This class is an implementation of {@link CardinalityBasedJoinOrderingBase}
@@ -48,179 +35,23 @@ import se.liu.ida.hefquin.federation.access.UnsupportedOperationDueToRetrievalEr
  * vi) a union over any of the aforementioned options, or
  * vii) an l2g over a union over any of the aforementioned (non-union) options.
  */
+// TODO: The Javadoc comment is outdated. See the base class.
 public class CardinalityBasedJoinOrderingWithRequests extends CardinalityBasedJoinOrderingBase
 {
 	protected final QueryProcContext ctxt;
 
 	public CardinalityBasedJoinOrderingWithRequests( final QueryProcContext ctxt ) {
+		super(ctxt);
+
 		assert ctxt != null;
 		this.ctxt = ctxt;
 	}
 
 	@Override
-	protected int[] estimateCardinalities( final LogicalPlan[] plans ) throws LogicalOptimizationException {
-		// Extract all request operators from the given list of plans.
-		final List<LogicalOpRequest<?,?>>[] reqOpsPerPlan = extractAllRequestOps(plans);
-
-		// Flatten the array of request operators into a single list.
-		final List<LogicalOpRequest<?,?>> reqOpsOfAllPlans = new ArrayList<>();
-		for ( int i = 0; i < plans.length; i++ ) {
-			reqOpsOfAllPlans.addAll( reqOpsPerPlan[i] );
-		}
-
-		// Next, get cardinality estimates for all of the request
-		// operators by performing cardinality requests for them.
-		// Notice that we do this in a batch in order to leverage
-		// parallelism when doing the cardinality requests.
-		final CardinalityResponse[] resps;
-		try {
-			resps = FederationAccessUtils.performCardinalityRequests( ctxt.getFederationAccessMgr(),
-			                                                          reqOpsOfAllPlans );
-		}
-		catch ( final FederationAccessException e ) {
-			throw new LogicalOptimizationException("Issuing a cardinality request caused an exception.", e);
-		}
-
-		// Populate the result.
-		final int[] result = new int[ plans.length ];
-		int respsCounter = 0; 
-		for ( int i = 0; i < plans.length; i++ ) {
-			// The number of cardinality responses that are available for the
-			// i-th plan is equivalent to the number of request operators that
-			// were extracted from that plan.
-			final int numOfReqOps = reqOpsPerPlan[i].size();
-			if ( numOfReqOps == 1 ) {
-				// If there was only one request operator for the i-th plan
-				// and, thus, there is only one cardinality response to be
-				// considered, simply use the cardinality of that cardinality
-				// response for the result.
-				result[i] = computeEffectiveCardinality( resps[respsCounter++] );
-			}
-			else {
-				// Otherwise, aggregate the cardinalities of the cardinality
-				// responses to be considered for the i-th plan.
-				int aggregatedCardinality = 0;
-				for ( int j = 0; j < numOfReqOps; j++ ) {
-					// When aggregating, make sure that we do not end up with
-					// a negative value because we exceeded the maximum of int.
-					if ( aggregatedCardinality == Integer.MAX_VALUE ) {
-						// If we are already at the maximum, just increase the counter.
-						respsCounter++;
-						continue;
-					}
-
-					final int c = computeEffectiveCardinality( resps[respsCounter++] );
-					aggregatedCardinality += (c == Integer.MAX_VALUE) ? Integer.MAX_VALUE : c;
-					if ( aggregatedCardinality < 0 ) aggregatedCardinality = Integer.MAX_VALUE;
-				}
-
-				result[i] = aggregatedCardinality;
-			} 
-		}
-
-		return result;
+	protected int estimateJoinCardinality( final List<LogicalPlan> selectedPlans,
+	                                       final int joinCardOfSelectedPlans,
+	                                       final LogicalPlan nextCandidate ) {
+		return nextCandidate.getQueryPlanningInfo().getProperty(QueryPlanProperty.CARDINALITY).getValue();
 	}
 
-	@Override
-	protected int estimateJoinCardinality( final List<AnnotatedLogicalPlan> selectedPlans,
-	                                        final int joinCardOfSelectedPlans,
-	                                        final AnnotatedLogicalPlan nextCandidate ) {
-		return nextCandidate.cardinality;
-	}
-
-
-	/**
-	 * Extracts all request operators from the given list of plans such
-	 * that, for each of the plans, the resulting list of these operators
-	 * is ordered in the order in which the operators can be found by a
-	 * depth-first traversal of the plan.
-	 */
-	protected List<LogicalOpRequest<?,?>>[] extractAllRequestOps( final LogicalPlan[] plans ) {
-		final List<?>[] result = new List<?>[ plans.length ];
-		for ( int i = 0; i < plans.length; i++ ) {
-			result[i] = extractAllRequestOps( plans[i] );
-		}
-
-		@SuppressWarnings("unchecked")
-		final List<LogicalOpRequest<?,?>>[] result2 = (List<LogicalOpRequest<?,?>>[]) result;
-		return result2;
-	}
-
-	/**
-	 * Extracts all request operators from the given plan such that the
-	 * resulting list of these operators will be ordered in the order in
-	 * which the operators can be found by a depth-first traversal of the
-	 * given plan.
-	 */
-	protected List<LogicalOpRequest<?,?>> extractAllRequestOps( final LogicalPlan plan ) {
-		final LogicalOperator rootOp = plan.getRootOperator();
-
-		if ( rootOp instanceof LogicalOpRequest reqOp ) {
-			return Arrays.asList(reqOp);
-		}
-		else if ( rootOp instanceof LogicalOpFilter )
-		{
-			final LogicalPlan subplan = plan.getSubPlan(0);
-			final LogicalOperator subrootOp = subplan.getRootOperator();
-			if ( subrootOp instanceof LogicalOpRequest subReqOp ) {
-				return Arrays.asList(subReqOp);
-			}
-			if ( subrootOp instanceof LogicalOpLocalToGlobal ) {
-				return extractAllRequestOps(subplan);
-			}
-			else {
-				throw new IllegalArgumentException("Unsupported type of subplan under filter (" + subrootOp.getClass().getName() + ")");
-			}
-		}
-		else if ( rootOp instanceof LogicalOpBind )
-		{
-			return extractAllRequestOps( plan.getSubPlan(0) );
-		}
-		else if ( rootOp instanceof LogicalOpLocalToGlobal )
-		{
-			final LogicalPlan subplan = plan.getSubPlan(0);
-			final LogicalOperator subrootOp = subplan.getRootOperator();
-			if ( subrootOp instanceof LogicalOpRequest subReqOp ) {
-				return Arrays.asList(subReqOp);
-			}
-			if ( subrootOp instanceof LogicalOpFilter ) {
-				return extractAllRequestOps(subplan);
-			}
-			else {
-				throw new IllegalArgumentException("Unsupported type of subplan under l2g operator (" + subrootOp.getClass().getName() + ")");
-			}
-		}
-		else if ( rootOp instanceof LogicalOpUnion || rootOp instanceof LogicalOpMultiwayUnion )
-		{
-			final List<LogicalOpRequest<?,?>> result = new ArrayList<>();
-			final int numOfSubPlans = plan.numberOfSubPlans();
-			for ( int i = 0; i < numOfSubPlans; i++ ) {
-				final LogicalPlan subPlan = plan.getSubPlan(i);
-				result.addAll( extractAllRequestOps(subPlan) );
-			}
-			return result;
-		}
-		else {
-			throw new IllegalArgumentException("Unsupported type of plan given (" + rootOp.getClass().getName() + ")");
-		}
-	}
-
-	/**
-	 * TODO: Fallback behavior? Returning Integer.MAX_VALUE for now
-	 *
-	 * Computes the cardinality from the given {@link CardinalityResponse}.
-	 *
-	 * If retrieving the cardinality fails due to an {@link UnsupportedOperationDueToRetrievalError}, this method
-	 * returns {@link Integer#MAX_VALUE} as a fallback.
-	 *
-	 * @param resp the cardinality response to extract the cardinality from
-	 * @return the cardinality, or {@code Integer.MAX_VALUE} if retrieval is unsupported
-	 */
-	private int computeEffectiveCardinality( final CardinalityResponse resp ) {
-		try {
-			return resp.getCardinality();
-		} catch ( UnsupportedOperationDueToRetrievalError e ) {
-			return Integer.MAX_VALUE;
-		}
-	}
 }

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/UnionPullUpTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/UnionPullUpTest.java
@@ -15,6 +15,7 @@ import org.junit.Test;
 import se.liu.ida.hefquin.base.data.VocabularyMapping;
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.base.query.impl.TriplePatternImpl;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanVisitor;
@@ -531,6 +532,7 @@ public class UnionPullUpTest
 		@Override public ExpectedVariables getExpectedVariables() { throw new UnsupportedOperationException(); }
 		@Override public int numberOfSubPlans() { return 0; }
 		@Override public LogicalPlan getSubPlan(int i) { throw new UnsupportedOperationException(); }
+		@Override public QueryPlanningInfo getQueryPlanningInfo() { throw new UnsupportedOperationException(); }
 	}
 
 	protected static class DummyLogicalOp implements NullaryLogicalOp {


### PR DESCRIPTION
This PR is the beginning of work on a more systematic approach to capture query-planning-related information about query plans. In particular, the PR extends the `LogicalPlan` interface with a method to obtain a `QueryPlanningInfo` object for the corresponding (logical) plan. This object is meant to be populated with properties of the plan (such as the estimated cardinality of the query result produced by the plan). To demonstrate how this will work, the PR also adds an initial version of a `CardinalityEstimator` (to be refined in a future PR). Additionally, the PR extends the logical plan printer to print the plan properties (such as cardinality estimates) at each level of the plan. The result of these extensions can be seen in the following example printout of a logical plan (notice the "query planning info" parts).
```
bind (4)
│  - ?s2 <-- <https://query.wikidata.org/sparql>
│  - query planning info:  max cardinality = 1895051097 (estimate based on accurates)
│                          min cardinality = 0 (min or max possible)
│                          cardinality = 631683699 (estimate based on accurates)
│
└── filter (5)
    │  - expression: ( ?c != ?o )
    │  - query planning info:  max cardinality = 1895051097 (estimate based on accurates)
    │                          min cardinality = 0 (min or max possible)
    │                          cardinality = 631683699 (estimate based on accurates)
    │
    └── mj (3)
        │  - query planning info:  max cardinality = 1895051097 (accurate)
        │                          min cardinality = 0 (min or max possible)
        │                          cardinality = 631683699 (accurate)
        │
        ├── bind (1)
        │   │  - ?s1 <-- <http://dbpedia.org/sparql>
        │   │  - query planning info:  max cardinality = 3 (accurate)
        │   │                          min cardinality = 3 (accurate)
        │   │                          cardinality = 3 (accurate)
        │   │
        │   └── req (0)
        │         - fm (0) SPARQL endpoint at http://dbpedia.org/sparql
        │         - pattern (-2106846137): { <http://dbpedia.org/resource/Berlin> <[...] FILTER contains(str(?cc), "wikidata") }
        │         - query planning info:  max cardinality = 3 (accurate)
        │                                 min cardinality = 3 (accurate)
        │                                 cardinality = 3 (accurate)
        │       
        └── req (2)
              - fm (3) SPARQL endpoint at https://query.wikidata.org/sparql
              - pattern (-1989281089): { ?cc rdfs:label ?o }
              - query planning info:  max cardinality = 631683699 (accurate)
                                      min cardinality = 631683699 (accurate)
                                      cardinality = 631683699 (accurate)
```

As next steps (in future PRs), I will extend the physical plans accordingly. This will include carrying over the properties that have already been determined for logical plans to the corresponding physical plans, and can later be extended with other types of properties that are only sensible for physical plans (e.g., the estimated number of requests that will be issues when running the plan). Eventually, such `QueryPlanningInfo` objects can be carried over even into the executable plans, where they may be used to collect statistics about the actual accuracy of the estimates and as input to adaptive query processing approaches.

/cc @keski 