### PR TITLE
Adds QueryPlanningInfo to physical plans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [unreleased]
 
 ### Added
-- Basis for proper management of query-planning-related information ([#455](https://github.com/LiUSemWeb/HeFQUIN/pull/455)).
+- Basis for proper management of query-planning-related information ([#455](https://github.com/LiUSemWeb/HeFQUIN/pull/455), [#456](https://github.com/LiUSemWeb/HeFQUIN/pull/456)).
 ### Changed
 - Merging the logical operators tpAdd, bgpAdd, and gpAdd into just one: gpAdd; likewise for tpOptAdd, bgpOptAdd, and gpOptAdd ([#454](https://github.com/LiUSemWeb/HeFQUIN/pull/454)).
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlan.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlan.java
@@ -37,7 +37,17 @@ public interface LogicalPlan
 	/**
 	 * Returns an object that captures query-planning-related
 	 * information about this plan. This object is meant to be
-	 * requested and populated by the query planner. 
+	 * requested and populated by the query planner.
+	 * <p>
+	 * If this plan does not yet have a {@link QueryPlanningInfo}
+	 * object associated with it, then this function creates a new
+	 * (empty) one and returns that.
 	 */
 	QueryPlanningInfo getQueryPlanningInfo();
+
+	/**
+	 * Returns <code>true</code> if this plan already has a
+	 * {@link QueryPlanningInfo} object associated with it.
+	 */
+	boolean hasQueryPlanningInfo();
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/BaseForLogicalPlan.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/BaseForLogicalPlan.java
@@ -12,6 +12,11 @@ public abstract class BaseForLogicalPlan implements LogicalPlan
 	private QueryPlanningInfo info = null;
 
 	@Override
+	public boolean hasQueryPlanningInfo() {
+		return info != null;
+	}
+
+	@Override
 	public QueryPlanningInfo getQueryPlanningInfo() {
 		if ( info == null )
 			info = new QueryPlanningInfo();

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/PhysicalPlan.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/PhysicalPlan.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryplan.physical;
 import java.util.NoSuchElementException;
 
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 
 public interface PhysicalPlan
 {
@@ -32,4 +33,11 @@ public interface PhysicalPlan
 	 * then a {@link NoSuchElementException} will be thrown.
 	 */
 	PhysicalPlan getSubPlan( int i ) throws NoSuchElementException;
+
+	/**
+	 * Returns an object that captures query-planning-related
+	 * information about this plan. This object is meant to be
+	 * requested and populated by the query planner. 
+	 */
+	QueryPlanningInfo getQueryPlanningInfo();
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/BaseForPhysicalPlan.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/BaseForPhysicalPlan.java
@@ -1,0 +1,21 @@
+package se.liu.ida.hefquin.engine.queryplan.physical.impl;
+
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
+import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
+
+/**
+ * A base class for implementations of {@link PhysicalPlan}.
+ */
+public abstract class BaseForPhysicalPlan implements PhysicalPlan
+{
+	// to be created only when requested
+	private QueryPlanningInfo info = null;
+
+	@Override
+	public QueryPlanningInfo getQueryPlanningInfo() {
+		if ( info == null )
+			info = new QueryPlanningInfo();
+
+		return info;
+	}
+}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/BaseForPhysicalPlan.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/BaseForPhysicalPlan.java
@@ -8,8 +8,24 @@ import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
  */
 public abstract class BaseForPhysicalPlan implements PhysicalPlan
 {
-	// to be created only when requested
-	private QueryPlanningInfo info = null;
+	// to be created only when requested, or provided via the constructor
+	private QueryPlanningInfo info;
+
+	/**
+	 * Use this constructor only if the plan is meant to be constructed with
+	 * an already existing {@link QueryPlanningInfo} object. This object may
+	 * later be extended with additional properties for this plan. Therefore,
+	 * do not create multiple plans with the same {@link QueryPlanningInfo}
+	 * object; instead, make copies of such an object if needed.
+	 */
+	protected BaseForPhysicalPlan( final QueryPlanningInfo qpInfo ) {
+		assert qpInfo != null;
+		info = qpInfo;
+	}
+
+	protected BaseForPhysicalPlan() {
+		info = null;
+	}
 
 	@Override
 	public QueryPlanningInfo getQueryPlanningInfo() {

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpParallelMultiLeftJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpParallelMultiLeftJoin.java
@@ -39,17 +39,16 @@ public class PhysicalOpParallelMultiLeftJoin extends BaseForPhysicalOps implemen
 	 * the optional parts of that multi-left-join. If not, this method returns
 	 * <code>null</code>.
 	 */
-	public static List<LogicalOpRequest<?,?>> checkApplicability( final List<PhysicalPlan> children )
+	public static List<LogicalOpRequest<?,?>> checkApplicability( final PhysicalPlan[] children )
 	{
-		final List<LogicalOpRequest<?,?>> optionalParts = new ArrayList<>( children.size()-1 );
-		final List<ExpectedVariables> expVarsOfOptionalParts = new ArrayList<>( children.size()-1 );
+		final List<LogicalOpRequest<?,?>> optionalParts = new ArrayList<>( children.length - 1 );
+		final List<ExpectedVariables> expVarsOfOptionalParts = new ArrayList<>( children.length - 1 );
 
-		final Iterator<PhysicalPlan> it = children.iterator();
-		final PhysicalPlan firstChildPlan = it.next(); // the non-optional part
+		final PhysicalPlan firstChildPlan = children[0]; // the non-optional part
 
 		// condition 1: every non-optional part is just a request operator
-		while ( it.hasNext() ) {
-			final PhysicalOperator childRootOp = it.next().getRootOperator();
+		for ( int i = 1; i < children.length; i++ ) {
+			final PhysicalOperator childRootOp = children[i].getRootOperator();
 			final LogicalOpRequest<?,?> reqOp;
 			if ( childRootOp instanceof PhysicalOpRequest<?,?> ) {
 				reqOp = ((PhysicalOpRequest<?,?>) childRootOp).getLogicalOperator();

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalPlanWithBinaryRootImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalPlanWithBinaryRootImpl.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryplan.physical.impl;
 import java.util.NoSuchElementException;
 
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.physical.BinaryPhysicalOp;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanWithBinaryRoot;
@@ -22,6 +23,31 @@ public class PhysicalPlanWithBinaryRootImpl extends BaseForPhysicalPlan
 	protected PhysicalPlanWithBinaryRootImpl( final BinaryPhysicalOp rootOp,
 	                                          final PhysicalPlan subPlan1,
 	                                          final PhysicalPlan subPlan2 ) {
+		assert rootOp != null;
+		assert subPlan1 != null;
+		assert subPlan2 != null;
+
+		this.rootOp = rootOp;
+		this.subPlan1 = subPlan1;
+		this.subPlan2 = subPlan2;
+	}
+
+	/**
+	 * Instead of creating such a plan directly using
+	 * this constructor, use {@link PhysicalPlanFactory}.
+	 * <p>
+	 * This constructor should be used only if the plan is meant to be
+	 * constructed with an already existing {@link QueryPlanningInfo}
+	 * object. Since this object may later be extended with additional
+	 * properties for this plan, it is important not to create multiple
+	 * plans with the same {@link QueryPlanningInfo} object.
+	 */
+	protected PhysicalPlanWithBinaryRootImpl( final BinaryPhysicalOp rootOp,
+	                                          final QueryPlanningInfo qpInfo,
+	                                          final PhysicalPlan subPlan1,
+	                                          final PhysicalPlan subPlan2 ) {
+		super(qpInfo);
+
 		assert rootOp != null;
 		assert subPlan1 != null;
 		assert subPlan2 != null;

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalPlanWithBinaryRootImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalPlanWithBinaryRootImpl.java
@@ -8,7 +8,8 @@ import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanWithBinaryRoot;
 import se.liu.ida.hefquin.engine.queryplan.utils.PhysicalPlanFactory;
 
-public class PhysicalPlanWithBinaryRootImpl implements PhysicalPlanWithBinaryRoot
+public class PhysicalPlanWithBinaryRootImpl extends BaseForPhysicalPlan
+                                            implements PhysicalPlanWithBinaryRoot
 {
 	private final BinaryPhysicalOp rootOp;
 	private final PhysicalPlan subPlan1;

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalPlanWithNaryRootImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalPlanWithNaryRootImpl.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.physical.NaryPhysicalOp;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanWithNaryRoot;
@@ -29,9 +30,48 @@ public class PhysicalPlanWithNaryRootImpl extends BaseForPhysicalPlan
 	/**
 	 * Instead of creating such a plan directly using
 	 * this constructor, use {@link PhysicalPlanFactory}.
+	 * <p>
+	 * This constructor should be used only if the plan is meant to be
+	 * constructed with an already existing {@link QueryPlanningInfo}
+	 * object. Since this object may later be extended with additional
+	 * properties for this plan, it is important not to create multiple
+	 * plans with the same {@link QueryPlanningInfo} object.
+	 */
+	protected PhysicalPlanWithNaryRootImpl( final NaryPhysicalOp rootOp,
+	                                        final QueryPlanningInfo qpInfo,
+	                                        final PhysicalPlan... subPlans ) {
+		this( rootOp, qpInfo, Arrays.asList(subPlans) );
+	}
+
+	/**
+	 * Instead of creating such a plan directly using
+	 * this constructor, use {@link PhysicalPlanFactory}.
 	 */
 	protected PhysicalPlanWithNaryRootImpl( final NaryPhysicalOp rootOp,
 	                                        final List<PhysicalPlan> subPlans ) {
+		assert rootOp != null;
+		assert subPlans != null;
+		assert ! subPlans.isEmpty();
+
+		this.rootOp = rootOp;
+		this.subPlans = subPlans;
+	}
+
+	/**
+	 * Instead of creating such a plan directly using
+	 * this constructor, use {@link PhysicalPlanFactory}.
+	 * <p>
+	 * This constructor should be used only if the plan is meant to be
+	 * constructed with an already existing {@link QueryPlanningInfo}
+	 * object. Since this object may later be extended with additional
+	 * properties for this plan, it is important not to create multiple
+	 * plans with the same {@link QueryPlanningInfo} object.
+	 */
+	protected PhysicalPlanWithNaryRootImpl( final NaryPhysicalOp rootOp,
+	                                        final QueryPlanningInfo qpInfo,
+	                                        final List<PhysicalPlan> subPlans ) {
+		super(qpInfo);
+
 		assert rootOp != null;
 		assert subPlans != null;
 		assert ! subPlans.isEmpty();

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalPlanWithNaryRootImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalPlanWithNaryRootImpl.java
@@ -11,7 +11,8 @@ import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanWithNaryRoot;
 import se.liu.ida.hefquin.engine.queryplan.utils.PhysicalPlanFactory;
 
-public class PhysicalPlanWithNaryRootImpl implements PhysicalPlanWithNaryRoot
+public class PhysicalPlanWithNaryRootImpl extends BaseForPhysicalPlan
+                                          implements PhysicalPlanWithNaryRoot
 {
 	protected final NaryPhysicalOp rootOp;
 	protected final List<PhysicalPlan> subPlans;

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalPlanWithNullaryRootImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalPlanWithNullaryRootImpl.java
@@ -8,7 +8,8 @@ import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanWithNullaryRoot;
 import se.liu.ida.hefquin.engine.queryplan.utils.PhysicalPlanFactory;
 
-public class PhysicalPlanWithNullaryRootImpl implements PhysicalPlanWithNullaryRoot
+public class PhysicalPlanWithNullaryRootImpl extends BaseForPhysicalPlan
+                                             implements PhysicalPlanWithNullaryRoot
 {
 	private final NullaryPhysicalOp rootOp;
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalPlanWithNullaryRootImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalPlanWithNullaryRootImpl.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryplan.physical.impl;
 import java.util.NoSuchElementException;
 
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.physical.NullaryPhysicalOp;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanWithNullaryRoot;
@@ -18,6 +19,24 @@ public class PhysicalPlanWithNullaryRootImpl extends BaseForPhysicalPlan
 	 * this constructor, use {@link PhysicalPlanFactory}.
 	 */
 	protected PhysicalPlanWithNullaryRootImpl( final NullaryPhysicalOp rootOp ) {
+		assert rootOp != null;
+		this.rootOp = rootOp;
+	}
+
+	/**
+	 * Instead of creating such a plan directly using
+	 * this constructor, use {@link PhysicalPlanFactory}.
+	 * <p>
+	 * This constructor should be used only if the plan is meant to be
+	 * constructed with an already existing {@link QueryPlanningInfo}
+	 * object. Since this object may later be extended with additional
+	 * properties for this plan, it is important not to create multiple
+	 * plans with the same {@link QueryPlanningInfo} object.
+	 */
+	protected PhysicalPlanWithNullaryRootImpl( final NullaryPhysicalOp rootOp,
+	                                           final QueryPlanningInfo qpInfo ) {
+		super(qpInfo);
+
 		assert rootOp != null;
 		this.rootOp = rootOp;
 	}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalPlanWithUnaryRootImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalPlanWithUnaryRootImpl.java
@@ -8,7 +8,8 @@ import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanWithUnaryRoot;
 import se.liu.ida.hefquin.engine.queryplan.physical.UnaryPhysicalOp;
 import se.liu.ida.hefquin.engine.queryplan.utils.PhysicalPlanFactory;
 
-public class PhysicalPlanWithUnaryRootImpl implements PhysicalPlanWithUnaryRoot
+public class PhysicalPlanWithUnaryRootImpl extends BaseForPhysicalPlan
+                                           implements PhysicalPlanWithUnaryRoot
 {
 	private final UnaryPhysicalOp rootOp;
 	private final PhysicalPlan subPlan;

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalPlanWithUnaryRootImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalPlanWithUnaryRootImpl.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryplan.physical.impl;
 import java.util.NoSuchElementException;
 
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanWithUnaryRoot;
 import se.liu.ida.hefquin.engine.queryplan.physical.UnaryPhysicalOp;
@@ -20,6 +21,28 @@ public class PhysicalPlanWithUnaryRootImpl extends BaseForPhysicalPlan
 	 */
 	protected PhysicalPlanWithUnaryRootImpl( final UnaryPhysicalOp rootOp,
 	                                         final PhysicalPlan subPlan ) {
+		assert rootOp != null;
+		assert subPlan != null;
+
+		this.rootOp = rootOp;
+		this.subPlan = subPlan;
+	}
+
+	/**
+	 * Instead of creating such a plan directly using
+	 * this constructor, use {@link PhysicalPlanFactory}.
+	 * <p>
+	 * This constructor should be used only if the plan is meant to be
+	 * constructed with an already existing {@link QueryPlanningInfo}
+	 * object. Since this object may later be extended with additional
+	 * properties for this plan, it is important not to create multiple
+	 * plans with the same {@link QueryPlanningInfo} object.
+	 */
+	protected PhysicalPlanWithUnaryRootImpl( final UnaryPhysicalOp rootOp,
+	                                         final QueryPlanningInfo qpInfo,
+	                                         final PhysicalPlan subPlan ) {
+		super(qpInfo);
+
 		assert rootOp != null;
 		assert subPlan != null;
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalToPhysicalPlanConverterImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalToPhysicalPlanConverterImpl.java
@@ -1,12 +1,12 @@
 package se.liu.ida.hefquin.engine.queryplan.utils;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.NaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.BinaryLogicalOp;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlan;
@@ -51,8 +51,15 @@ public class LogicalToPhysicalPlanConverterImpl implements LogicalToPhysicalPlan
 				return alreadyConverted;
 			}
 
-			final List<PhysicalPlan> children = convertChildren(lp, keepMultiwayJoins);
-			final PhysicalPlan pp = createPhysicalPlan( lp.getRootOperator(), children, keepMultiwayJoins );
+			final PhysicalPlan[] children = convertChildren(lp, keepMultiwayJoins);
+
+			final QueryPlanningInfo qpInfo;
+			if ( lp.hasQueryPlanningInfo() )
+				qpInfo = lp.getQueryPlanningInfo();
+			else
+				qpInfo = null;
+
+			final PhysicalPlan pp = createPhysicalPlan( lp.getRootOperator(), qpInfo, children, keepMultiwayJoins );
 			convertedSubPlans.put(lp, pp);
 			return pp;
 		}
@@ -65,84 +72,91 @@ public class LogicalToPhysicalPlanConverterImpl implements LogicalToPhysicalPlan
 		 * the given logical plan. For logical plans that do not contain any
 		 * sub-plans, an empty list is returned.
 		 */
-		protected List<PhysicalPlan> convertChildren( final LogicalPlan lp,
-		                                              final boolean keepMultiwayJoins ) {
-			final List<PhysicalPlan> children = new ArrayList<PhysicalPlan>();
+		protected PhysicalPlan[] convertChildren( final LogicalPlan lp,
+		                                          final boolean keepMultiwayJoins ) {
 			final int numChildren = lp.numberOfSubPlans();
-			if ( numChildren > 0 ) {
-				for ( int i = 0; i < numChildren; ++i ) {
-					children.add( convert(lp.getSubPlan(i), keepMultiwayJoins) );
-				}
+			final PhysicalPlan[] children = new PhysicalPlan[numChildren];
+
+			for ( int i = 0; i < numChildren; ++i ) {
+				children[i] = convert( lp.getSubPlan(i), keepMultiwayJoins );
 			}
+
 			return children;
 		}
 
 		protected PhysicalPlan createPhysicalPlan( final LogicalOperator lop,
-		                                           final List<PhysicalPlan> children,
+		                                           final QueryPlanningInfo qpInfo,
+		                                           final PhysicalPlan[] children,
 		                                           final boolean keepMultiwayJoins )
 		{
-			if ( lop instanceof NullaryLogicalOp ) {
-				if ( children.size() != 0 )
-					throw new IllegalArgumentException( "unexpected number of sub-plans: " + children.size() );
+			if ( lop instanceof NullaryLogicalOp nullaryLOP ) {
+				if ( children.length != 0 )
+					throw new IllegalArgumentException( "unexpected number of sub-plans: " + children.length );
 
-				return createPhysicalPlanWithNullaryRoot( (NullaryLogicalOp) lop );
+				return createPhysicalPlanWithNullaryRoot(nullaryLOP, qpInfo);
 			}
-			else if ( lop instanceof UnaryLogicalOp ) {
-				if ( children.size() != 1 )
-					throw new IllegalArgumentException( "unexpected number of sub-plans: " + children.size() );
+			else if ( lop instanceof UnaryLogicalOp unaryLOP ) {
+				if ( children.length != 1 )
+					throw new IllegalArgumentException( "unexpected number of sub-plans: " + children.length );
 
-				return createPhysicalPlanWithUnaryRoot( (UnaryLogicalOp) lop, children.get(0) );
+				return createPhysicalPlanWithUnaryRoot( unaryLOP, qpInfo, children[0] );
 			}
-			else if ( lop instanceof BinaryLogicalOp ) {
-				if ( children.size() != 2 )
-					throw new IllegalArgumentException( "unexpected number of sub-plans: " + children.size() );
+			else if ( lop instanceof BinaryLogicalOp binaryLOP ) {
+				if ( children.length != 2 )
+					throw new IllegalArgumentException( "unexpected number of sub-plans: " + children.length );
 
-				return createPhysicalPlanWithBinaryRoot( (BinaryLogicalOp) lop, children.get(0), children.get(1) );
+				return createPhysicalPlanWithBinaryRoot( binaryLOP, qpInfo, children[0], children[1] );
 			}
-			else if ( lop instanceof NaryLogicalOp ) {
-				if ( children.size() < 1 )
-					throw new IllegalArgumentException( "unexpected number of sub-plans: " + children.size() );
+			else if ( lop instanceof NaryLogicalOp naryLOP ) {
+				if ( children.length < 1 )
+					throw new IllegalArgumentException( "unexpected number of sub-plans: " + children.length );
 
-				return createPhysicalPlanWithNaryRoot( (NaryLogicalOp) lop, children, keepMultiwayJoins );
+				return createPhysicalPlanWithNaryRoot( naryLOP, qpInfo, children, keepMultiwayJoins );
 			}
 			else {
 				throw new IllegalArgumentException( "unknown logical operator: " + lop.getClass().getName() );
 			}
 		}
 
-		protected PhysicalPlan createPhysicalPlanWithNullaryRoot( final NullaryLogicalOp lop ) {
-			return PhysicalPlanFactory.createPlan(lop);
+		protected PhysicalPlan createPhysicalPlanWithNullaryRoot( final NullaryLogicalOp lop,
+		                                                          final QueryPlanningInfo qpInfo ) {
+			return PhysicalPlanFactory.createPlan(lop, qpInfo);
 		}
 
-		protected PhysicalPlan createPhysicalPlanWithUnaryRoot( final UnaryLogicalOp lop, final PhysicalPlan child ) {
-			return PhysicalPlanFactory.createPlan(lop, child);
+		protected PhysicalPlan createPhysicalPlanWithUnaryRoot( final UnaryLogicalOp lop,
+		                                                        final QueryPlanningInfo qpInfo,
+		                                                        final PhysicalPlan child ) {
+			return PhysicalPlanFactory.createPlan(lop, qpInfo, child);
 		}
 
-		protected PhysicalPlan createPhysicalPlanWithBinaryRoot( final BinaryLogicalOp lop, final PhysicalPlan child1, final PhysicalPlan child2 ) {
-			return PhysicalPlanFactory.createPlan(lop, child1, child2);
+		protected PhysicalPlan createPhysicalPlanWithBinaryRoot( final BinaryLogicalOp lop,
+		                                                         final QueryPlanningInfo qpInfo,
+		                                                         final PhysicalPlan child1,
+		                                                         final PhysicalPlan child2 ) {
+			return PhysicalPlanFactory.createPlan(lop, qpInfo, child1, child2);
 		}
 
 		protected PhysicalPlan createPhysicalPlanWithNaryRoot( final NaryLogicalOp lop,
-		                                                       final List<PhysicalPlan> children,
+		                                                       final QueryPlanningInfo qpInfo,
+		                                                       final PhysicalPlan[] children,
 		                                                       final boolean keepMultiwayJoins )
 		{
-			if ( lop instanceof LogicalOpMultiwayJoin ) {
-				return createPhysicalPlanForMultiwayJoin( (LogicalOpMultiwayJoin) lop, children, keepMultiwayJoins );
-			}
-			else if ( lop instanceof LogicalOpMultiwayLeftJoin ) {
-				return createPhysicalPlanForMultiwayLeftJoin( (LogicalOpMultiwayLeftJoin) lop, children, keepMultiwayJoins );
-			}
-			else {
-				return PhysicalPlanFactory.createPlan(lop, children);
-			}
+			if ( lop instanceof LogicalOpMultiwayJoin mj )
+				return createPhysicalPlanForMultiwayJoin( mj, qpInfo, children, keepMultiwayJoins );
+
+			if ( lop instanceof LogicalOpMultiwayLeftJoin mlj )
+				return createPhysicalPlanForMultiwayLeftJoin( mlj, qpInfo, children, keepMultiwayJoins );
+
+			return PhysicalPlanFactory.createPlan(lop, qpInfo, children);
 		}
 
 		protected PhysicalPlan createPhysicalPlanForMultiwayJoin( final LogicalOpMultiwayJoin lop,
-		                                                          final List<PhysicalPlan> children,
+		                                                          final QueryPlanningInfo qpInfo,
+		                                                          final PhysicalPlan[] children,
 		                                                          final boolean keepMultiwayJoins )
 		{
-			if ( children.size() == 1 ) {
-				return children.get(0);
+			if ( children.length == 1 ) {
+				return children[0];
 			}
 
 			if ( keepMultiwayJoins ) {
@@ -150,21 +164,34 @@ public class LogicalToPhysicalPlanConverterImpl implements LogicalToPhysicalPlan
 					@Override public void visit(PhysicalPlanVisitor visitor) { throw new UnsupportedOperationException(); }
 					@Override public NaryExecutableOp createExecOp(boolean collectExceptions, ExpectedVariables... inputVars) { throw new UnsupportedOperationException(); }
 				};
-				return PhysicalPlanFactory.createPlan(pop, children);
+				return PhysicalPlanFactory.createPlan(pop, qpInfo, children);
 			}
 
 			// Multiway joins are converted to a left-deep plan of joins, where
-			// tpAdd and bgpAdd are used when possible; otherwise, binary joins
+			// gpAdd operators are used if possible; otherwise, binary joins
 			// are used by default.
-			PhysicalPlan currentSubPlan = children.get(0);
-			for ( int i = 1; i < children.size(); ++i ) {
-				final PhysicalPlan nextChild = children.get(i);
+			PhysicalPlan currentSubPlan = children[0];
+			for ( int i = 1; i < children.length; ++i ) {
+				final PhysicalPlan nextChild = children[i];
+
+				// If we are at the last subplan, which will end up becoming
+				// the top of the left-deep plan constructed here, then we
+				// can carry over the given qpInfo to that top plan. For all
+				// intermediate steps of the left-deep plan we do not have
+				// qpInfo objects.
+				final QueryPlanningInfo qpInfoForSubPlan;
+				if ( i == children.length - 1 )
+					qpInfoForSubPlan = qpInfo;
+				else
+					qpInfoForSubPlan = null;
+
 				if( ! ignorePhysicalOpsForLogicalAddOps ) {
-					currentSubPlan = PhysicalPlanFactory.createPlanWithDefaultUnaryOpIfPossible(currentSubPlan, nextChild);
+					currentSubPlan = PhysicalPlanFactory.createPlanWithDefaultUnaryOpIfPossible(currentSubPlan, nextChild, qpInfoForSubPlan);
 				}
 				else {
 					currentSubPlan = createPhysicalPlanWithBinaryRoot(
 							LogicalOpJoin.getInstance(),
+							qpInfoForSubPlan,
 							currentSubPlan,
 							nextChild );
 				}
@@ -174,22 +201,23 @@ public class LogicalToPhysicalPlanConverterImpl implements LogicalToPhysicalPlan
 		}
 
 		protected PhysicalPlan createPhysicalPlanForMultiwayLeftJoin( final LogicalOpMultiwayLeftJoin lop,
-		                                                              final List<PhysicalPlan> children,
+		                                                              final QueryPlanningInfo qpInfo,
+			                                                          final PhysicalPlan[] children,
 		                                                              final boolean keepMultiwayJoins )
 		{
-			if ( children.size() == 1 ) {
-				return children.get(0);
+			if ( children.length == 1 ) {
+				return children[0];
 			}
 
 			// Before going to the generic option that works for all cases,
 			// check whether we have a case in which the parallel multi-left-
 			// join can be used.
-			if ( ! ignoreParallelMultiLeftJoin && children.size() > 2 ) {
+			if ( ! ignoreParallelMultiLeftJoin && children.length > 2 ) {
 				final List<LogicalOpRequest<?,?>> optionalParts = PhysicalOpParallelMultiLeftJoin.checkApplicability(children);
 				if ( optionalParts != null ) {
 					// If the parallel multi-left-join can indeed be used, do so.
 					final UnaryPhysicalOp rootOp = new PhysicalOpParallelMultiLeftJoin(optionalParts);
-					return PhysicalPlanFactory.createPlan( rootOp, children.get(0) );
+					return PhysicalPlanFactory.createPlan( rootOp, qpInfo, children[0] );
 				}
 			}
 
@@ -203,39 +231,23 @@ public class LogicalToPhysicalPlanConverterImpl implements LogicalToPhysicalPlan
 			// and, thus, is used as the right input to the first right outer join
 			// (second case below) or as the input to the tpOptAdd/bgpOptAdd (first
 			// case below).
-			PhysicalPlan currentSubPlan = children.get(0);
-			for ( int i = 1; i < children.size(); ++i ) {
-				final PhysicalPlan nextChild = children.get(i);
+			PhysicalPlan currentSubPlan = children[0];
+			for ( int i = 1; i < children.length; ++i ) {
+				final PhysicalPlan nextChild = children[i];
 				final PhysicalOperator rootOpOfNextChild = nextChild.getRootOperator();
 				if( ! ignorePhysicalOpsForLogicalAddOps && rootOpOfNextChild instanceof PhysicalOpRequest ){
 					currentSubPlan = createPhysicalPlanWithUnaryRoot(
 							LogicalOpUtils.createLogicalOptAddOpFromPhysicalReqOp(rootOpOfNextChild),
+							null, // no qpInfo as we don't have it for the subplan created here
 							currentSubPlan );
 				}
 				else {
 					currentSubPlan = createPhysicalPlanWithBinaryRoot(
 							LogicalOpRightJoin.getInstance(),
+							null,  // no qpInfo as we don't have it for the subplan created here
 							nextChild,
 							currentSubPlan );
 				}
-			}
-
-			return currentSubPlan;
-		}
-
-		protected PhysicalPlan createPhysicalPlanForMultiwayUnion( final LogicalOpMultiwayUnion lop, final List<PhysicalPlan> children ) {
-			if ( children.size() == 1 ) {
-				return children.get(0);
-			}
-
-			// As long as we do not have an actual algorithm for multiway unions,
-			// we simply convert this to a left-deep plan of binary unions.
-			PhysicalPlan currentSubPlan = children.get(0);
-			for ( int i = 1; i < children.size(); ++i ) {
-				currentSubPlan = createPhysicalPlanWithBinaryRoot(
-						LogicalOpUnion.getInstance(),
-						currentSubPlan,
-						children.get(i) );
 			}
 
 			return currentSubPlan;

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedPhysicalPlanPrinterImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedPhysicalPlanPrinterImpl.java
@@ -59,6 +59,7 @@ public class TextBasedPhysicalPlanPrinterImpl extends BaseForTextBasedPlanPrinte
 		final String indentLevelStringForOpDetail = getIndentLevelStringForDetail(planNumber, planLevel, numberOfSiblings, plan.numberOfSubPlans(), indentLevelString);
 		opPrinter.setIndentLevelStringForOpDetail(indentLevelStringForOpDetail);
 
+		opPrinter.setQueryPlanningInfo( plan.getQueryPlanningInfo() );
 		plan.getRootOperator().visit(opPrinter);
 
 		for ( int i = 0; i < plan.numberOfSubPlans(); ++i ) {
@@ -77,6 +78,7 @@ public class TextBasedPhysicalPlanPrinterImpl extends BaseForTextBasedPlanPrinte
 			out.append( indentLevelString + "binary union (" + op.getID() + ") " );
 			out.append( System.lineSeparator() );
 			printLogicalOperator( op, indentLevelStringForOpDetail + singleBase, out, np );
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
 		}
 
 		@Override
@@ -85,6 +87,10 @@ public class TextBasedPhysicalPlanPrinterImpl extends BaseForTextBasedPlanPrinte
 			out.append( System.lineSeparator() );
 			printLogicalOperator( op, indentLevelStringForOpDetail + singleBase, out, np );
 			printOperatorInfoFmAndPattern( op, indentLevelStringForOpDetail );
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
+
+			out.append( indentLevelStringForOpDetail + singleBase );
+			out.append( System.lineSeparator() );
 		}
 
 		@Override
@@ -93,6 +99,10 @@ public class TextBasedPhysicalPlanPrinterImpl extends BaseForTextBasedPlanPrinte
 			out.append( System.lineSeparator() );
 			printLogicalOperator( op, indentLevelStringForOpDetail + singleBase, out, np );
 			printOperatorInfoFmAndPattern( op, indentLevelStringForOpDetail );
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
+
+			out.append( indentLevelStringForOpDetail + singleBase );
+			out.append( System.lineSeparator() );
 		}
 
 		@Override
@@ -101,6 +111,10 @@ public class TextBasedPhysicalPlanPrinterImpl extends BaseForTextBasedPlanPrinte
 			out.append( System.lineSeparator() );
 			printLogicalOperator( op, indentLevelStringForOpDetail + singleBase, out, np );
 			printOperatorInfoFmAndPattern( op, indentLevelStringForOpDetail );
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
+
+			out.append( indentLevelStringForOpDetail + singleBase );
+			out.append( System.lineSeparator() );
 		}
 
 		@Override
@@ -109,6 +123,10 @@ public class TextBasedPhysicalPlanPrinterImpl extends BaseForTextBasedPlanPrinte
 			out.append( System.lineSeparator() );
 			printLogicalOperator( op, indentLevelStringForOpDetail + singleBase, out, np );
 			printOperatorInfoFmAndPattern( op, indentLevelStringForOpDetail );
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
+
+			out.append( indentLevelStringForOpDetail + singleBase );
+			out.append( System.lineSeparator() );
 		}
 
 		@Override
@@ -117,6 +135,10 @@ public class TextBasedPhysicalPlanPrinterImpl extends BaseForTextBasedPlanPrinte
 			out.append( System.lineSeparator() );
 			printLogicalOperator( op, indentLevelStringForOpDetail + singleBase, out, np );
 			printOperatorInfoFmAndPattern( op, indentLevelStringForOpDetail );
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
+
+			out.append( indentLevelStringForOpDetail + singleBase );
+			out.append( System.lineSeparator() );
 		}
 
 		@Override
@@ -130,6 +152,8 @@ public class TextBasedPhysicalPlanPrinterImpl extends BaseForTextBasedPlanPrinte
 			printExpressions( lop.getFilterExpressions(),
 			                  indentLevelStringForOpDetail + singleBase,
 			                  out );
+
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
 
 			out.append( indentLevelStringForOpDetail + singleBase );
 			out.append( System.lineSeparator() );
@@ -152,6 +176,8 @@ public class TextBasedPhysicalPlanPrinterImpl extends BaseForTextBasedPlanPrinte
 				out.append( System.lineSeparator() );
 			}
 
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
+
 			out.append( indentLevelStringForOpDetail + singleBase );
 			out.append( System.lineSeparator() );
 		}
@@ -167,6 +193,8 @@ public class TextBasedPhysicalPlanPrinterImpl extends BaseForTextBasedPlanPrinte
 			out.append( indentLevelStringForOpDetail + singleBase + "  - vocab.mapping (" + lop.getVocabularyMapping().hashCode() + ")" );
 			out.append( System.lineSeparator() );
 
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
+
 			out.append( indentLevelStringForOpDetail + singleBase );
 			out.append( System.lineSeparator() );
 		}
@@ -176,6 +204,7 @@ public class TextBasedPhysicalPlanPrinterImpl extends BaseForTextBasedPlanPrinte
 			out.append( indentLevelString + "hash join (" + op.getID() + ") " );
 			out.append( System.lineSeparator() );
 			printLogicalOperator( op, indentLevelStringForOpDetail + singleBase, out, np );
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
 		}
 
 		@Override
@@ -183,6 +212,7 @@ public class TextBasedPhysicalPlanPrinterImpl extends BaseForTextBasedPlanPrinte
 			out.append( indentLevelString + "right-outer hash join (" + op.getID() + ") " );
 			out.append( System.lineSeparator() );
 			printLogicalOperator( op, indentLevelStringForOpDetail + singleBase, out, np );
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
 		}
 
 		@Override
@@ -191,6 +221,10 @@ public class TextBasedPhysicalPlanPrinterImpl extends BaseForTextBasedPlanPrinte
 			out.append( System.lineSeparator() );
 			printLogicalOperator( op, indentLevelStringForOpDetail + singleBase, out, np );
 			printOperatorInfoFmAndPattern( op, indentLevelStringForOpDetail );
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
+
+			out.append( indentLevelStringForOpDetail + singleBase );
+			out.append( System.lineSeparator() );
 		}
 
 		@Override
@@ -204,6 +238,8 @@ public class TextBasedPhysicalPlanPrinterImpl extends BaseForTextBasedPlanPrinte
 			out.append( indentLevelStringForOpDetail + singleBase + "  - vocab.mapping (" + lop.getVocabularyMapping().hashCode() + ")" );
 			out.append( System.lineSeparator() );
 
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
+
 			out.append( indentLevelStringForOpDetail + singleBase );
 			out.append( System.lineSeparator() );
 		}
@@ -214,6 +250,8 @@ public class TextBasedPhysicalPlanPrinterImpl extends BaseForTextBasedPlanPrinte
 			out.append( System.lineSeparator() );
 			printLogicalOperator( op, indentLevelStringForOpDetail + singleBase, out, np );
 
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
+
 			out.append( indentLevelStringForOpDetail + singleBase );
 			out.append( System.lineSeparator() );
 		}
@@ -223,12 +261,15 @@ public class TextBasedPhysicalPlanPrinterImpl extends BaseForTextBasedPlanPrinte
 			out.append( indentLevelString + "naive NLJ (" + op.getID() + ") " );
 			out.append( System.lineSeparator() );
 			printLogicalOperator( op, indentLevelStringForOpDetail + singleBase, out, np );
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
 		}
 
 		@Override
 		public void visit( final PhysicalOpParallelMultiLeftJoin op ) {
 			out.append( indentLevelString + "parallel multiway left-outer join (" + op.getID() + ") " );
 			out.append( System.lineSeparator() );
+
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
 
 			out.append( indentLevelStringForOpDetail + singleBase );
 			out.append( System.lineSeparator() );
@@ -252,6 +293,8 @@ public class TextBasedPhysicalPlanPrinterImpl extends BaseForTextBasedPlanPrinte
 				out.append( System.lineSeparator() );
 			}
 
+			printQueryPlanningInfo( indentLevelStringForOpDetail );
+
 			out.append( indentLevelStringForOpDetail );
 			out.append( System.lineSeparator() );
 		}
@@ -261,6 +304,8 @@ public class TextBasedPhysicalPlanPrinterImpl extends BaseForTextBasedPlanPrinte
 			out.append( indentLevelString + "SHJ (" + op.getID() + ") " );
 			out.append( System.lineSeparator() );
 			printLogicalOperator( op, indentLevelStringForOpDetail + singleBase, out, np );
+
+			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
 
 			out.append( indentLevelStringForOpDetail + singleBase );
 			out.append( System.lineSeparator() );
@@ -285,8 +330,6 @@ public class TextBasedPhysicalPlanPrinterImpl extends BaseForTextBasedPlanPrinte
 
 			printFederationMember( fm, indentLevelStringForOpDetail + singleBase, out );
 			printSPARQLGraphPattern( gp, indentLevelStringForOpDetail + singleBase );
-			out.append( indentLevelStringForOpDetail + singleBase );
-			out.append( System.lineSeparator() );
 		}
 	}
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/simple/CardinalityBasedGreedyJoinPlanOptimizerImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/simple/CardinalityBasedGreedyJoinPlanOptimizerImpl.java
@@ -4,6 +4,7 @@ import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.base.query.utils.ExpectedVariablesUtils;
 import se.liu.ida.hefquin.engine.federation.access.utils.FederationAccessUtils;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.BaseForExecOpBindJoinWithRequestOps;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
@@ -254,11 +255,12 @@ public class CardinalityBasedGreedyJoinPlanOptimizerImpl extends JoinPlanOptimiz
             }
 
             final PhysicalPlan newPlan;
+            final QueryPlanningInfo qpInfoForNewPlan = null;
             if ( accNumSHJ <= accNumBJ ) {
-                newPlan = PhysicalPlanFactory.createPlanWithJoin(currentPlan.plan, nextPlan.plan);
+                newPlan = PhysicalPlanFactory.createPlanWithJoin(currentPlan.plan, nextPlan.plan, qpInfoForNewPlan);
             }
             else {
-                newPlan = PhysicalPlanFactory.createPlanWithDefaultUnaryOpIfPossible(currentPlan.plan, nextPlan.plan);
+                newPlan = PhysicalPlanFactory.createPlanWithDefaultUnaryOpIfPossible(currentPlan.plan, nextPlan.plan, qpInfoForNewPlan);
             }
 
             // "We estimate the join cardinality of two subexpressions SEi and SEj as the minimum of their cardinalities."(see page 1052 in paper[1])

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/simple/CostModelBasedGreedyJoinPlanOptimizerImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/simple/CostModelBasedGreedyJoinPlanOptimizerImpl.java
@@ -176,7 +176,7 @@ public class CostModelBasedGreedyJoinPlanOptimizerImpl extends JoinPlanOptimizer
 		else if (    rootOfSubPlan instanceof PhysicalOpBinaryUnion
 		          || rootOfSubPlan instanceof PhysicalOpMultiwayUnion ) {
 			if ( PhysicalPlanFactory.checkUnaryOpApplicableToUnionPlan(rightOrTop) ) {
-				final PhysicalPlan planWithUnariesUnderUnion = PhysicalPlanFactory.createPlanWithUnaryOpForUnionPlan(leftOrChild, rightOrTop);
+				final PhysicalPlan planWithUnariesUnderUnion = PhysicalPlanFactory.createPlanWithUnaryOpForUnionPlan(leftOrChild, rightOrTop, null);
 				plans.add(planWithUnariesUnderUnion);
 			}
 		}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/simple/DPBasedJoinPlanOptimizer.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/simple/DPBasedJoinPlanOptimizer.java
@@ -179,7 +179,7 @@ public abstract class DPBasedJoinPlanOptimizer extends JoinPlanOptimizerBase
 				else if (    rightRootOp instanceof PhysicalOpBinaryUnion
 				          || rightRootOp instanceof PhysicalOpMultiwayUnion ) {
 					if ( PhysicalPlanFactory.checkUnaryOpApplicableToUnionPlan(optmRight) ) {
-						final PhysicalPlan planWithUnariesUnderUnion = PhysicalPlanFactory.createPlanWithUnaryOpForUnionPlan(optmLeft, optmRight);
+						final PhysicalPlan planWithUnariesUnderUnion = PhysicalPlanFactory.createPlanWithUnaryOpForUnionPlan(optmLeft, optmRight, null);
 						candidatePlans.add(planWithUnariesUnderUnion);
 					}
 				}

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/UnionPullUpTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/UnionPullUpTest.java
@@ -533,6 +533,7 @@ public class UnionPullUpTest
 		@Override public int numberOfSubPlans() { return 0; }
 		@Override public LogicalPlan getSubPlan(int i) { throw new UnsupportedOperationException(); }
 		@Override public QueryPlanningInfo getQueryPlanningInfo() { throw new UnsupportedOperationException(); }
+		@Override public boolean hasQueryPlanningInfo() { throw new UnsupportedOperationException(); }
 	}
 
 	protected static class DummyLogicalOp implements NullaryLogicalOp {


### PR DESCRIPTION
This is the next step following PR #455.

This PR:
1. extends the `PhysicalPlan` interface with a method to obtain a `QueryPlanningInfo` object for the corresponding (physical) plan,
2. extends the physical plan printer to print the content of such `QueryPlanningInfo` objects at each level of the plan, and
3. extends both the `LogicalToPhysicalPlanConverterImpl` and `PhysicalPlanFactory` such that `QueryPlanningInfo` objects are carried over when converting a logical plan into a physical one.