### PR TITLE
Adds QueryPlanningInfo to executable operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [unreleased]
 
 ### Added
-- Basis for proper management of query-planning-related information ([#455](https://github.com/LiUSemWeb/HeFQUIN/pull/455), [#456](https://github.com/LiUSemWeb/HeFQUIN/pull/456)).
+- Basis for proper management of query-planning-related information ([#455](https://github.com/LiUSemWeb/HeFQUIN/pull/455), [#456](https://github.com/LiUSemWeb/HeFQUIN/pull/456), [#461](https://github.com/LiUSemWeb/HeFQUIN/pull/461)).
 - Extending the text-based plan printers to include information about expected variables at each level of the plan ([#457](https://github.com/LiUSemWeb/HeFQUIN/pull/457)).
 - Adding the bound join algorithm from the FedX paper ([#458](https://github.com/LiUSemWeb/HeFQUIN/pull/458)).
 ### Changed

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/ExecutableOperator.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/ExecutableOperator.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryplan.executable;
 import java.util.List;
 
 import se.liu.ida.hefquin.base.utils.StatsProvider;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 
 /**
  * An executable operator provides the implementation of the concrete
@@ -13,6 +14,15 @@ public interface ExecutableOperator extends StatsProvider
 {
 	@Override
 	ExecutableOperatorStats getStats();
+
+	/**
+	 * Returns the {@link QueryPlanningInfo} object that was populated for
+	 * a physical plan whose root operator was the physical operator for
+	 * which this executable operator was created.
+	 *
+	 * @return the {@link QueryPlanningInfo} object or {@code null}.
+	 */
+	QueryPlanningInfo getQueryPlanningInfo();
 
 	/**
 	 * Returns exceptions that were caught and collected during the execution

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpBindJoinSPARQL.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpBindJoinSPARQL.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
 import se.liu.ida.hefquin.engine.queryplan.executable.NullaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.federation.SPARQLEndpoint;
 import se.liu.ida.hefquin.federation.access.impl.req.SPARQLRequestImpl;
 
@@ -17,13 +18,14 @@ public abstract class BaseForExecOpBindJoinSPARQL extends BaseForExecOpBindJoinW
 	                                    final ExpectedVariables inputVars,
 	                                    final boolean useOuterJoinSemantics,
 	                                    final int batchSize,
-	                                    final boolean collectExceptions ) {
-		super(p, p.getAllMentionedVariables(), fm, inputVars, useOuterJoinSemantics, batchSize, collectExceptions);
+	                                    final boolean collectExceptions,
+	                                    final QueryPlanningInfo qpInfo ) {
+		super(p, p.getAllMentionedVariables(), fm, inputVars, useOuterJoinSemantics, batchSize, collectExceptions, qpInfo);
 	}
 
 	@Override
 	protected NullaryExecutableOp createExecutableReqOpForAll() {
-		return new ExecOpRequestSPARQL( new SPARQLRequestImpl(query), fm, false );
+		return new ExecOpRequestSPARQL( new SPARQLRequestImpl(query), fm, false, null );
 	}
 
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpBindJoinWithRequestOps.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpBindJoinWithRequestOps.java
@@ -19,6 +19,7 @@ import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementS
 import se.liu.ida.hefquin.engine.queryplan.executable.NullaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.CollectingIntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 import se.liu.ida.hefquin.federation.FederationMember;
 
@@ -179,8 +180,9 @@ public abstract class BaseForExecOpBindJoinWithRequestOps<QueryType extends Quer
 	                                            final ExpectedVariables inputVars,
 	                                            final boolean useOuterJoinSemantics,
 	                                            final int batchSize,
-	                                            final boolean collectExceptions ) {
-		super(collectExceptions);
+	                                            final boolean collectExceptions,
+	                                            final QueryPlanningInfo qpInfo ) {
+		super(collectExceptions, qpInfo);
 
 		assert query != null;
 		assert fm != null;

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpIndexNestedLoopsJoinWithRequestOps.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpIndexNestedLoopsJoinWithRequestOps.java
@@ -15,6 +15,7 @@ import se.liu.ida.hefquin.engine.queryplan.executable.ExecutableOperatorStats;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.NullaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 import se.liu.ida.hefquin.federation.FederationMember;
 
@@ -53,8 +54,9 @@ public abstract class BaseForExecOpIndexNestedLoopsJoinWithRequestOps<QueryType 
 	                                                           final MemberType fm,
 	                                                           final boolean useOuterJoinSemantics,
 	                                                           final int batchSize,
-	                                                           final boolean collectExceptions ) {
-		super(batchSize, collectExceptions);
+	                                                           final boolean collectExceptions,
+	                                                           final QueryPlanningInfo qpInfo ) {
+		super(batchSize, collectExceptions, qpInfo);
 
 		assert query != null;
 		assert fm != null;
@@ -67,8 +69,9 @@ public abstract class BaseForExecOpIndexNestedLoopsJoinWithRequestOps<QueryType 
 	protected BaseForExecOpIndexNestedLoopsJoinWithRequestOps( final QueryType query,
 	                                                           final MemberType fm,
 	                                                           final boolean useOuterJoinSemantics,
-	                                                           final boolean collectExceptions ) {
-		this(query, fm, useOuterJoinSemantics, DEFAULT_BATCH_SIZE, collectExceptions);
+	                                                           final boolean collectExceptions,
+	                                                           final QueryPlanningInfo qpInfo ) {
+		this(query, fm, useOuterJoinSemantics, DEFAULT_BATCH_SIZE, collectExceptions, qpInfo);
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpIndexNestedLoopsJoinWithRequests.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpIndexNestedLoopsJoinWithRequests.java
@@ -14,6 +14,7 @@ import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutableOperator;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 import se.liu.ida.hefquin.federation.FederationMember;
 import se.liu.ida.hefquin.federation.access.DataRetrievalRequest;
@@ -53,8 +54,9 @@ public abstract class BaseForExecOpIndexNestedLoopsJoinWithRequests<
 	public BaseForExecOpIndexNestedLoopsJoinWithRequests( final QueryType query,
 	                                                      final MemberType fm,
 	                                                      final int batchSize,
-	                                                      final boolean collectExceptions ) {
-		super(batchSize, collectExceptions);
+	                                                      final boolean collectExceptions,
+	                                                      final QueryPlanningInfo qpInfo) {
+		super(batchSize, collectExceptions, qpInfo);
 
 		assert query != null;
 		assert fm != null;
@@ -65,8 +67,9 @@ public abstract class BaseForExecOpIndexNestedLoopsJoinWithRequests<
 
 	public BaseForExecOpIndexNestedLoopsJoinWithRequests( final QueryType query,
 	                                                      final MemberType fm,
-	                                                      final boolean collectExceptions ) {
-		this(query, fm, DEFAULT_BATCH_SIZE, collectExceptions);
+	                                                      final boolean collectExceptions,
+	                                                      final QueryPlanningInfo qpInfo ) {
+		this(query, fm, DEFAULT_BATCH_SIZE, collectExceptions, qpInfo);
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpIndexNestedLoopsJoinWithSolMapsRequests.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpIndexNestedLoopsJoinWithSolMapsRequests.java
@@ -4,6 +4,7 @@ import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.query.Query;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutableOperator;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.federation.FederationMember;
 import se.liu.ida.hefquin.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.federation.access.SolMapsResponse;
@@ -16,8 +17,9 @@ public abstract class BaseForExecOpIndexNestedLoopsJoinWithSolMapsRequests<Query
 {
 	public BaseForExecOpIndexNestedLoopsJoinWithSolMapsRequests( final QueryType query,
 	                                                             final MemberType fm,
-	                                                             final boolean collectExceptions ) {
-		super(query, fm, collectExceptions);
+	                                                             final boolean collectExceptions,
+	                                                             final QueryPlanningInfo qpInfo ) {
+		super(query, fm, collectExceptions, qpInfo);
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpIndexNestedLoopsJoinWithTPFRequests.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpIndexNestedLoopsJoinWithTPFRequests.java
@@ -4,6 +4,7 @@ import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.query.TriplePattern;
 import se.liu.ida.hefquin.base.query.VariableByBlankNodeSubstitutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.NullaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.federation.FederationMember;
 import se.liu.ida.hefquin.federation.access.TriplePatternRequest;
 import se.liu.ida.hefquin.federation.access.impl.req.TriplePatternRequestImpl;
@@ -14,8 +15,9 @@ public abstract class BaseForExecOpIndexNestedLoopsJoinWithTPFRequests<MemberTyp
 	protected BaseForExecOpIndexNestedLoopsJoinWithTPFRequests( final TriplePattern query,
 	                                                            final MemberType fm,
 	                                                            final boolean useOuterJoinSemantics,
-	                                                            final boolean collectExceptions ) {
-		super(query, fm, useOuterJoinSemantics, collectExceptions);
+	                                                            final boolean collectExceptions,
+	                                                            final QueryPlanningInfo qpInfo ) {
+		super(query, fm, useOuterJoinSemantics, collectExceptions, qpInfo);
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpRequest.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpRequest.java
@@ -1,6 +1,7 @@
 package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.federation.FederationMember;
 import se.liu.ida.hefquin.federation.access.DataRetrievalRequest;
 
@@ -13,8 +14,11 @@ public abstract class BaseForExecOpRequest<ReqType extends DataRetrievalRequest,
 	protected final ReqType req;
 	protected final MemberType fm;
 
-	public BaseForExecOpRequest( final ReqType req, final MemberType fm, final boolean collectExceptions ) {
-		super(collectExceptions);
+	public BaseForExecOpRequest( final ReqType req,
+	                             final MemberType fm,
+	                             final boolean collectExceptions,
+	                             final QueryPlanningInfo qpInfo ) {
+		super(collectExceptions, qpInfo);
 
 		assert req != null;
 		assert fm != null;

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpRequestWithPaging.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpRequestWithPaging.java
@@ -2,6 +2,7 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 import se.liu.ida.hefquin.federation.FederationMember;
 import se.liu.ida.hefquin.federation.access.DataRetrievalRequest;
@@ -20,8 +21,11 @@ public abstract class BaseForExecOpRequestWithPaging<
                                   PageRespType extends DataRetrievalResponse<?>>
                 extends BaseForExecOpRequest<ReqType,MemberType>
 {
-	public BaseForExecOpRequestWithPaging( final ReqType req, final MemberType fm, final boolean collectExceptions ) {
-		super( req, fm, collectExceptions );
+	public BaseForExecOpRequestWithPaging( final ReqType req,
+	                                       final MemberType fm,
+	                                       final boolean collectExceptions,
+	                                       final QueryPlanningInfo qpInfo ) {
+		super(req, fm, collectExceptions, qpInfo);
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpRequestWithTPFPaging.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpRequestWithTPFPaging.java
@@ -7,6 +7,7 @@ import se.liu.ida.hefquin.base.data.Triple;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 import se.liu.ida.hefquin.federation.FederationMember;
 import se.liu.ida.hefquin.federation.access.DataRetrievalRequest;
@@ -31,8 +32,11 @@ public abstract class BaseForExecOpRequestWithTPFPaging<
 	private int maxNumberOfMatchingTriplesPerPage = 0;
 	private int numberOfOutputMappingsProduced = 0;
 
-	public BaseForExecOpRequestWithTPFPaging( final ReqType req, final MemberType fm, final boolean collectExceptions ) {
-		super( req, fm, collectExceptions );
+	public BaseForExecOpRequestWithTPFPaging( final ReqType req,
+	                                          final MemberType fm,
+	                                          final boolean collectExceptions,
+	                                          final QueryPlanningInfo qpInfo ) {
+		super(req, fm, collectExceptions, qpInfo);
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpSolMapsRequest.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpSolMapsRequest.java
@@ -4,6 +4,7 @@ import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 import se.liu.ida.hefquin.federation.FederationMember;
 import se.liu.ida.hefquin.federation.access.DataRetrievalRequest;
@@ -20,8 +21,11 @@ public abstract class BaseForExecOpSolMapsRequest<ReqType extends DataRetrievalR
 	private long solMapsRetrieved = 0L;
 	private long numberOfOutputMappingsProduced = 0L;
 
-	public BaseForExecOpSolMapsRequest( final ReqType req, final MemberType fm, final boolean collectExceptions ) {
-		super( req, fm, collectExceptions );
+	public BaseForExecOpSolMapsRequest( final ReqType req,
+	                                    final MemberType fm,
+	                                    final boolean collectExceptions,
+	                                    final QueryPlanningInfo qpInfo ) {
+		super(req, fm, collectExceptions, qpInfo);
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpTriplePatternRequestWithTPF.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpTriplePatternRequestWithTPF.java
@@ -5,6 +5,7 @@ import java.util.Iterator;
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.data.Triple;
 import se.liu.ida.hefquin.base.data.utils.TriplesToSolMapsConverter;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.federation.FederationMember;
 import se.liu.ida.hefquin.federation.access.TPFRequest;
 import se.liu.ida.hefquin.federation.access.TriplePatternRequest;
@@ -19,8 +20,9 @@ public abstract class BaseForExecOpTriplePatternRequestWithTPF<MemberType extend
 {
 	public BaseForExecOpTriplePatternRequestWithTPF( final TriplePatternRequest req,
 	                                                 final MemberType fm,
-	                                                 final boolean collectExceptions ) {
-		super( req, fm, collectExceptions );
+	                                                 final boolean collectExceptions,
+	                                                 final QueryPlanningInfo qpInfo ) {
+		super(req, fm, collectExceptions, qpInfo);
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpTriplesRequest.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpTriplesRequest.java
@@ -6,6 +6,7 @@ import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.data.Triple;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 import se.liu.ida.hefquin.federation.FederationMember;
 import se.liu.ida.hefquin.federation.access.DataRetrievalRequest;
@@ -25,8 +26,11 @@ import se.liu.ida.hefquin.federation.access.UnsupportedOperationDueToRetrievalEr
 public abstract class BaseForExecOpTriplesRequest<ReqType extends DataRetrievalRequest, MemberType extends FederationMember>
                 extends BaseForExecOpRequest<ReqType,MemberType>
 {
-	public BaseForExecOpTriplesRequest( final ReqType req, final MemberType fm, final boolean collectExceptions ) {
-		super( req, fm, collectExceptions );
+	public BaseForExecOpTriplesRequest( final ReqType req,
+	                                    final MemberType fm,
+	                                    final boolean collectExceptions,
+	                                    final QueryPlanningInfo qpInfo ) {
+		super(req, fm, collectExceptions, qpInfo);
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOps.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOps.java
@@ -5,26 +5,48 @@ import java.util.Collections;
 import java.util.List;
 
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutableOperator;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 
 /**
  * Top-level base class for all implementations of {@link ExecutableOperator}.
  *
  * This base class handles the collection of exceptions that may occur during
- * the execution of the algorithm implemented by an executable operator.
+ * the execution of the algorithm implemented by an executable operator, and
+ * it stores the {@link QueryPlanningInfo} (if any).
  */
 public abstract class BaseForExecOps implements ExecutableOperator
 {
 	/**
-	 * If <code>true</code>, then the subclasses are expected to collect exceptions (by
-	 * calling {@link #recordExceptionCaughtDuringExecution(Exception)}); otherwise, they
-	 * are expected to throw the exceptions immediately.
+	 * May be {@code null}.
+	 */
+	protected final QueryPlanningInfo qpInfo;
+
+	/**
+	 * If {@code true}, then the subclasses are expected to collect exceptions
+	 * (by calling {@link #recordExceptionCaughtDuringExecution(Exception)});
+	 * otherwise, they are expected to throw the exceptions immediately.
 	 */
 	protected final boolean collectExceptions;
 
 	private List<Exception> exceptionsCaughtDuringExecution = null;
 
-	public BaseForExecOps( final boolean collectExceptions ) {
+	/**
+	 * @param collectExceptions - if {@code true}, then the subclasses are
+	 *           expected to collect exceptions (by calling
+	 *           {@link #recordExceptionCaughtDuringExecution(Exception)});
+	 *           otherwise, they are expected to throw the exceptions
+	 *           immediately
+	 * @param qpInfo - may be {@code null}
+	 */
+	public BaseForExecOps( final boolean collectExceptions,
+	                       final QueryPlanningInfo qpInfo ) {
 		this.collectExceptions = collectExceptions;
+		this.qpInfo = qpInfo;
+	}
+
+	@Override
+	public QueryPlanningInfo getQueryPlanningInfo() {
+		return qpInfo;
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BinaryExecutableOpBase.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BinaryExecutableOpBase.java
@@ -8,6 +8,7 @@ import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutableOperatorStats;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 /**
@@ -43,8 +44,9 @@ public abstract class BinaryExecutableOpBase extends BaseForExecOps implements B
 	private long maxRightProcessingTime              = 0L;
 	protected long timeAtCurrentRightProcStart       = 0L;
 
-	public BinaryExecutableOpBase( final boolean collectExceptions ) {
-		super(collectExceptions);
+	public BinaryExecutableOpBase( final boolean collectExceptions,
+	                               final QueryPlanningInfo qpInfo ) {
+		super(collectExceptions, qpInfo);
 	}
 
 	@Override
@@ -306,6 +308,9 @@ public abstract class BinaryExecutableOpBase extends BaseForExecOps implements B
 		s.put( "averageProcTimePerRightInputBlock",    Double.valueOf(avgProcTimeRight) );
 		s.put( "minimumProcTimePerRightInputBlock",    Long.valueOf(minRightProcessingTime) );
 		s.put( "maximumProcTimePerRightInputBlock",    Long.valueOf(maxRightProcessingTime) );
+
+		s.put( "queryPlanningInfo",    qpInfo );
+
 		return s;
 	}
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBinaryUnion.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBinaryUnion.java
@@ -5,14 +5,16 @@ import java.util.List;
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 public class ExecOpBinaryUnion extends BinaryExecutableOpBase
 {
 	private long numberOfOutputMappingsProduced = 0L;
 	
-	public ExecOpBinaryUnion( final boolean collectExceptions ) {
-		super(collectExceptions);
+	public ExecOpBinaryUnion( final boolean collectExceptions,
+	                          final QueryPlanningInfo qpInfo ) {
+		super(collectExceptions, qpInfo);
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBind.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBind.java
@@ -19,6 +19,7 @@ import se.liu.ida.hefquin.base.data.impl.SolutionMappingImpl;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 /**
@@ -30,8 +31,10 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 
 	protected final Worker worker;
 
-	public ExecOpBind( final VarExprList bindExpressions, final boolean collectExceptions ) {
-		super(collectExceptions);
+	public ExecOpBind( final VarExprList bindExpressions,
+	                   final boolean collectExceptions,
+	                   final QueryPlanningInfo qpInfo ) {
+		super(collectExceptions, qpInfo);
 
 		if ( bindExpressions.size() == 1 ) {
 			final Var var = bindExpressions.getVars().get(0);
@@ -43,8 +46,11 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 		}
 	}
 
-	public ExecOpBind( final Var var, final Expr expr, final boolean collectExceptions ) {
-		super(collectExceptions);
+	public ExecOpBind( final Var var,
+	                   final Expr expr,
+	                   final boolean collectExceptions,
+	                   final QueryPlanningInfo qpInfo ) {
+		super(collectExceptions, qpInfo);
 
 		assert var != null;
 		assert expr != null;

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinBRTPF.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinBRTPF.java
@@ -10,6 +10,7 @@ import se.liu.ida.hefquin.base.query.VariableByBlankNodeSubstitutionException;
 import se.liu.ida.hefquin.base.query.impl.TriplePatternImpl;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.NullaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.federation.BRTPFServer;
 import se.liu.ida.hefquin.federation.access.BindingsRestrictedTriplePatternRequest;
 import se.liu.ida.hefquin.federation.access.TriplePatternRequest;
@@ -65,14 +66,20 @@ public class ExecOpBindJoinBRTPF extends BaseForExecOpBindJoinWithRequestOps<Tri
 	 *          collect exceptions (which is handled entirely by one of the
 	 *          super classes); <code>false</code> if the operator should
 	 *          immediately throw every {@link ExecOpExecutionException}
+	 *
+	 * @param qpInfo - the {@link QueryPlanningInfo} object that was
+	 *          populated for a physical plan whose root operator was
+	 *          the physical operator for which this executable operator
+	 *          was created
 	 */
 	public ExecOpBindJoinBRTPF( final TriplePattern tp,
 	                            final BRTPFServer fm,
 	                            final ExpectedVariables inputVars,
 	                            final boolean useOuterJoinSemantics,
 	                            final int batchSize,
-	                            final boolean collectExceptions ) {
-		super( tp, tp.getAllMentionedVariables(), fm, inputVars, useOuterJoinSemantics, batchSize, collectExceptions );
+	                            final boolean collectExceptions,
+	                            final QueryPlanningInfo qpInfo ) {
+		super( tp, tp.getAllMentionedVariables(), fm, inputVars, useOuterJoinSemantics, batchSize, collectExceptions, qpInfo );
 	}
 
 	@Override
@@ -93,17 +100,17 @@ public class ExecOpBindJoinBRTPF extends BaseForExecOpBindJoinWithRequestOps<Tri
 			}
 
 			final TriplePatternRequest req = new TriplePatternRequestImpl(restrictedTP);
-			return new ExecOpRequestTPFatBRTPFServer(req, fm, false);
+			return new ExecOpRequestTPFatBRTPFServer(req, fm, false, null);
 		}
 
 		final BindingsRestrictedTriplePatternRequest req = new BindingsRestrictedTriplePatternRequestImpl(query, solMaps);
-		return new ExecOpRequestBRTPF(req, fm, false);
+		return new ExecOpRequestBRTPF(req, fm, false, null);
 	}
 
 	@Override
 	protected NullaryExecutableOp createExecutableReqOpForAll() {
 		final TriplePatternRequest req = new TriplePatternRequestImpl(query);
-		return new ExecOpRequestTPFatBRTPFServer(req, fm, false);
+		return new ExecOpRequestTPFatBRTPFServer(req, fm, false, null);
 	}
 
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithBoundJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithBoundJoin.java
@@ -31,6 +31,7 @@ import se.liu.ida.hefquin.base.query.impl.GenericSPARQLGraphPatternImpl1;
 import se.liu.ida.hefquin.base.query.utils.QueryPatternUtils;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.NullaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.federation.SPARQLEndpoint;
 import se.liu.ida.hefquin.federation.access.SPARQLRequest;
 import se.liu.ida.hefquin.federation.access.impl.req.SPARQLRequestImpl;
@@ -79,14 +80,20 @@ public class ExecOpBindJoinSPARQLwithBoundJoin extends BaseForExecOpBindJoinSPAR
 	 *          collect exceptions (which is handled entirely by one of the
 	 *          super classes); <code>false</code> if the operator should
 	 *          immediately throw every {@link ExecOpExecutionException}
+	 *
+	 * @param qpInfo - the {@link QueryPlanningInfo} object that was
+	 *          populated for a physical plan whose root operator was
+	 *          the physical operator for which this executable operator
+	 *          was created
 	 */
 	public ExecOpBindJoinSPARQLwithBoundJoin( final SPARQLGraphPattern query,
 	                                          final SPARQLEndpoint fm,
 	                                          final ExpectedVariables inputVars,
 	                                          final boolean useOuterJoinSemantics,
 	                                          final int batchSize,
-	                                          final boolean collectExceptions ) {
-		super(query, fm, inputVars, useOuterJoinSemantics, batchSize, collectExceptions);
+	                                          final boolean collectExceptions,
+	                                          final QueryPlanningInfo qpInfo ) {
+		super(query, fm, inputVars, useOuterJoinSemantics, batchSize, collectExceptions, qpInfo);
 		pattern = QueryPatternUtils.convertToJenaElement(query);
 
 		renamedVar = getVarForRenaming(query, inputVars);
@@ -127,7 +134,7 @@ public class ExecOpBindJoinSPARQLwithBoundJoin extends BaseForExecOpBindJoinSPAR
 		final Element elmt = createUnion(solMaps);
 		final SPARQLGraphPattern pattern = new GenericSPARQLGraphPatternImpl1(elmt);
 		final SPARQLRequest request = new SPARQLRequestImpl(pattern);
-		return new ExecOpRequestSPARQL(request, fm, false);
+		return new ExecOpRequestSPARQL(request, fm, false, null);
 	}
 
 	protected Element createUnion( final Iterable<Binding> solMaps ) {

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithFILTER.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithFILTER.java
@@ -12,7 +12,6 @@ import org.apache.jena.sparql.expr.E_LogicalOr;
 import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.ExprVar;
 import org.apache.jena.sparql.expr.nodevalue.NodeValueNode;
-import org.apache.jena.sparql.serializer.FormatterElement;
 import org.apache.jena.sparql.syntax.Element;
 import org.apache.jena.sparql.syntax.ElementFilter;
 import org.apache.jena.sparql.syntax.ElementGroup;
@@ -23,6 +22,7 @@ import se.liu.ida.hefquin.base.query.impl.GenericSPARQLGraphPatternImpl1;
 import se.liu.ida.hefquin.base.query.utils.QueryPatternUtils;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.NullaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.federation.SPARQLEndpoint;
 import se.liu.ida.hefquin.federation.access.SPARQLRequest;
 import se.liu.ida.hefquin.federation.access.impl.req.SPARQLRequestImpl;
@@ -63,14 +63,20 @@ public class ExecOpBindJoinSPARQLwithFILTER extends BaseForExecOpBindJoinSPARQL
 	 *          collect exceptions (which is handled entirely by one of the
 	 *          super classes); <code>false</code> if the operator should
 	 *          immediately throw every {@link ExecOpExecutionException}
+	 *
+	 * @param qpInfo - the {@link QueryPlanningInfo} object that was
+	 *          populated for a physical plan whose root operator was
+	 *          the physical operator for which this executable operator
+	 *          was created
 	 */
 	public ExecOpBindJoinSPARQLwithFILTER( final SPARQLGraphPattern query,
 	                                       final SPARQLEndpoint fm,
 	                                       final ExpectedVariables inputVars,
 	                                       final boolean useOuterJoinSemantics,
 	                                       final int batchSize,
-	                                       final boolean collectExceptions ) {
-		super(query, fm, inputVars, useOuterJoinSemantics, batchSize, collectExceptions);
+	                                       final boolean collectExceptions,
+	                                       final QueryPlanningInfo qpInfo ) {
+		super(query, fm, inputVars, useOuterJoinSemantics, batchSize, collectExceptions, qpInfo);
 
 		pattern = QueryPatternUtils.convertToJenaElement(query);
 	}
@@ -94,7 +100,7 @@ public class ExecOpBindJoinSPARQLwithFILTER extends BaseForExecOpBindJoinSPARQL
 
 		final SPARQLGraphPattern patternForReq = new GenericSPARQLGraphPatternImpl1(group);
 		final SPARQLRequest request = new SPARQLRequestImpl(patternForReq);
-		return new ExecOpRequestSPARQL(request, fm, false);
+		return new ExecOpRequestSPARQL(request, fm, false, null);
 	}
 
 	public static Expr createFilterExpression( final Iterable<Binding> solMaps ) {

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithUNION.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithUNION.java
@@ -21,6 +21,7 @@ import se.liu.ida.hefquin.base.query.impl.GenericSPARQLGraphPatternImpl1;
 import se.liu.ida.hefquin.base.query.utils.QueryPatternUtils;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.NullaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.federation.SPARQLEndpoint;
 import se.liu.ida.hefquin.federation.access.SPARQLRequest;
 import se.liu.ida.hefquin.federation.access.impl.req.SPARQLRequestImpl;
@@ -60,14 +61,20 @@ public class ExecOpBindJoinSPARQLwithUNION extends BaseForExecOpBindJoinSPARQL
 	 *          collect exceptions (which is handled entirely by one of the
 	 *          super classes); <code>false</code> if the operator should
 	 *          immediately throw every {@link ExecOpExecutionException}
+	 *
+	 * @param qpInfo - the {@link QueryPlanningInfo} object that was
+	 *          populated for a physical plan whose root operator was
+	 *          the physical operator for which this executable operator
+	 *          was created
 	 */
 	public ExecOpBindJoinSPARQLwithUNION( final SPARQLGraphPattern query,
 	                                      final SPARQLEndpoint fm,
 	                                      final ExpectedVariables inputVars,
 	                                      final boolean useOuterJoinSemantics,
 	                                      final int batchSize,
-	                                      final boolean collectExceptions ) {
-		super(query, fm, inputVars, useOuterJoinSemantics, batchSize, collectExceptions);
+	                                      final boolean collectExceptions,
+	                                      final QueryPlanningInfo qpInfo ) {
+		super(query, fm, inputVars, useOuterJoinSemantics, batchSize, collectExceptions, qpInfo);
 
 		pattern = QueryPatternUtils.convertToJenaElement(query);
 	}
@@ -77,7 +84,7 @@ public class ExecOpBindJoinSPARQLwithUNION extends BaseForExecOpBindJoinSPARQL
 		final Element elmt = createUnion(solMaps);
 		final SPARQLGraphPattern pattern = new GenericSPARQLGraphPatternImpl1(elmt);
 		final SPARQLRequest request = new SPARQLRequestImpl(pattern);
-		return new ExecOpRequestSPARQL(request, fm, false);
+		return new ExecOpRequestSPARQL(request, fm, false, null);
 	}
 
 	protected Element createUnion( final Iterable<Binding> solMaps ) {

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithVALUES.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithVALUES.java
@@ -17,6 +17,7 @@ import se.liu.ida.hefquin.base.query.impl.GenericSPARQLGraphPatternImpl1;
 import se.liu.ida.hefquin.base.query.utils.QueryPatternUtils;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.NullaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.federation.SPARQLEndpoint;
 import se.liu.ida.hefquin.federation.access.SPARQLRequest;
 import se.liu.ida.hefquin.federation.access.impl.req.SPARQLRequestImpl;
@@ -57,14 +58,20 @@ public class ExecOpBindJoinSPARQLwithVALUES extends BaseForExecOpBindJoinSPARQL
 	 *          collect exceptions (which is handled entirely by one of the
 	 *          super classes); <code>false</code> if the operator should
 	 *          immediately throw every {@link ExecOpExecutionException}
+	 *
+	 * @param qpInfo - the {@link QueryPlanningInfo} object that was
+	 *          populated for a physical plan whose root operator was
+	 *          the physical operator for which this executable operator
+	 *          was created
 	 */
 	public ExecOpBindJoinSPARQLwithVALUES( final SPARQLGraphPattern query,
 	                                       final SPARQLEndpoint fm,
 	                                       final ExpectedVariables inputVars,
 	                                       final boolean useOuterJoinSemantics,
 	                                       final int batchSize,
-	                                       final boolean collectExceptions ) {
-		super(query, fm, inputVars, useOuterJoinSemantics, batchSize, collectExceptions);
+	                                       final boolean collectExceptions,
+	                                       final QueryPlanningInfo qpInfo ) {
+		super(query, fm, inputVars, useOuterJoinSemantics, batchSize, collectExceptions, qpInfo);
 
 		pattern = QueryPatternUtils.convertToJenaElement(query);
 	}
@@ -88,7 +95,7 @@ public class ExecOpBindJoinSPARQLwithVALUES extends BaseForExecOpBindJoinSPARQL
 		// Create the request operator using the combined pattern.
 		final SPARQLGraphPattern patternForReq = new GenericSPARQLGraphPatternImpl1(group);
 		final SPARQLRequest request = new SPARQLRequestImpl(patternForReq);
-		return new ExecOpRequestSPARQL(request, fm, false);
+		return new ExecOpRequestSPARQL(request, fm, false, null);
 	}
 
 	public static Element createValuesClause( final Set<Binding> solMaps ) {

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithVALUESorFILTER.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithVALUESorFILTER.java
@@ -12,6 +12,7 @@ import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.NullaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 import se.liu.ida.hefquin.federation.SPARQLEndpoint;
 
@@ -67,14 +68,20 @@ public class ExecOpBindJoinSPARQLwithVALUESorFILTER extends BaseForExecOpBindJoi
 	 *          collect exceptions (which is handled entirely by one of the
 	 *          super classes); <code>false</code> if the operator should
 	 *          immediately throw every {@link ExecOpExecutionException}
+	 *
+	 * @param qpInfo - the {@link QueryPlanningInfo} object that was
+	 *          populated for a physical plan whose root operator was
+	 *          the physical operator for which this executable operator
+	 *          was created
 	 */
 	public ExecOpBindJoinSPARQLwithVALUESorFILTER( final SPARQLGraphPattern query,
 	                                               final SPARQLEndpoint fm,
 	                                               final ExpectedVariables inputVars,
 	                                               final boolean useOuterJoinSemantics,
 	                                               final int batchSize,
-	                                               final boolean collectExceptions ) {
-		super(query, fm, inputVars, useOuterJoinSemantics, batchSize, collectExceptions);
+	                                               final boolean collectExceptions,
+	                                               final QueryPlanningInfo qpInfo ) {
+		super(query, fm, inputVars, useOuterJoinSemantics, batchSize, collectExceptions, qpInfo);
 
 		pattern = QueryPatternUtils.convertToJenaElement(query);
 	}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpFilter.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpFilter.java
@@ -14,6 +14,7 @@ import org.apache.jena.sparql.util.ExprUtils;
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 public class ExecOpFilter extends UnaryExecutableOpBaseWithoutBlocking
@@ -22,8 +23,10 @@ public class ExecOpFilter extends UnaryExecutableOpBaseWithoutBlocking
 
 	protected final ExprList filterExpressions;
 
-	public ExecOpFilter( final ExprList filterExpressions, final boolean collectExceptions ) {
-		super(collectExceptions);
+	public ExecOpFilter( final ExprList filterExpressions,
+	                     final boolean collectExceptions,
+	                     final QueryPlanningInfo qpInfo ) {
+		super(collectExceptions, qpInfo);
 
 		assert filterExpressions != null;
 		assert ! filterExpressions.isEmpty();
@@ -31,8 +34,10 @@ public class ExecOpFilter extends UnaryExecutableOpBaseWithoutBlocking
 		this.filterExpressions = filterExpressions;
 	}
 
-	public ExecOpFilter( final Expr filterExpression, final boolean collectExceptions ) {
-		super(collectExceptions);
+	public ExecOpFilter( final Expr filterExpression,
+	                     final boolean collectExceptions,
+	                     final QueryPlanningInfo qpInfo ) {
+		super(collectExceptions, qpInfo);
 
 		assert filterExpression != null;
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpGlobalToLocal.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpGlobalToLocal.java
@@ -9,6 +9,7 @@ import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.data.VocabularyMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 public class ExecOpGlobalToLocal extends UnaryExecutableOpBaseWithoutBlocking
@@ -17,8 +18,10 @@ public class ExecOpGlobalToLocal extends UnaryExecutableOpBaseWithoutBlocking
 
 	protected final VocabularyMapping vm;
 
-	public ExecOpGlobalToLocal( final VocabularyMapping vm, final boolean collectExceptions ) {
-		super(collectExceptions);
+	public ExecOpGlobalToLocal( final VocabularyMapping vm,
+	                            final boolean collectExceptions,
+	                            final QueryPlanningInfo qpInfo ) {
+		super(collectExceptions, qpInfo);
 
 		assert vm != null;
 		this.vm = vm;

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashJoin.java
@@ -10,6 +10,7 @@ import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.base.query.utils.ExpectedVariablesUtils;
 import se.liu.ida.hefquin.base.utils.Stats;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 import java.util.ArrayList;
@@ -27,8 +28,9 @@ public class ExecOpHashJoin extends BinaryExecutableOpBase
 
     public ExecOpHashJoin( final ExpectedVariables inputVars1,
                            final ExpectedVariables inputVars2,
-                           final boolean collectExceptions ) {
-        super(collectExceptions);
+                           final boolean collectExceptions,
+                           final QueryPlanningInfo qpInfo ) {
+        super(collectExceptions, qpInfo);
 
         // determine the certain join variables
         final Set<Var> certainJoinVars = ExpectedVariablesUtils.intersectionOfCertainVariables(inputVars1, inputVars2);

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashRJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashRJoin.java
@@ -5,6 +5,7 @@ import java.util.List;
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.data.utils.SolutionMappingUtils;
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 
 /**
  * A right outer join version of the hash join algorithm implemented in
@@ -23,8 +24,9 @@ public class ExecOpHashRJoin extends ExecOpHashJoin {
 
 	public ExecOpHashRJoin( final ExpectedVariables inputVars1,
 	                        final ExpectedVariables inputVars2,
-	                        final boolean collectExceptions ) {
-		super(inputVars1, inputVars2, collectExceptions);
+	                        final boolean collectExceptions,
+	                        final QueryPlanningInfo qpInfo ) {
+		super(inputVars1, inputVars2, collectExceptions, qpInfo);
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinBRTPF.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinBRTPF.java
@@ -2,6 +2,7 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import se.liu.ida.hefquin.base.query.TriplePattern;
 import se.liu.ida.hefquin.engine.queryplan.executable.NullaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.federation.BRTPFServer;
 import se.liu.ida.hefquin.federation.access.TriplePatternRequest;
 
@@ -10,13 +11,14 @@ public class ExecOpIndexNestedLoopsJoinBRTPF extends BaseForExecOpIndexNestedLoo
 	public ExecOpIndexNestedLoopsJoinBRTPF( final TriplePattern query,
 	                                        final BRTPFServer fm,
 	                                        final boolean useOuterJoinSemantics,
-	                                        final boolean collectExceptions ) {
-		super(query, fm, useOuterJoinSemantics, collectExceptions);
+	                                        final boolean collectExceptions,
+	                                        final QueryPlanningInfo qpInfo ) {
+		super(query, fm, useOuterJoinSemantics, collectExceptions, qpInfo);
 	}
 
 	@Override
 	protected NullaryExecutableOp createRequestOperator( final TriplePatternRequest req ) {
-		return new ExecOpRequestTPFatBRTPFServer(req, fm, false);
+		return new ExecOpRequestTPFatBRTPFServer(req, fm, false, null);
 	}
 
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinSPARQL.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinSPARQL.java
@@ -5,6 +5,7 @@ import java.util.concurrent.CompletableFuture;
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
 import se.liu.ida.hefquin.base.query.VariableByBlankNodeSubstitutionException;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.federation.SPARQLEndpoint;
 import se.liu.ida.hefquin.federation.access.FederationAccessException;
 import se.liu.ida.hefquin.federation.access.FederationAccessManager;
@@ -17,8 +18,9 @@ public class ExecOpIndexNestedLoopsJoinSPARQL extends BaseForExecOpIndexNestedLo
 	public ExecOpIndexNestedLoopsJoinSPARQL( final SPARQLGraphPattern query,
 	                                         final SPARQLEndpoint fm,
 	                                         final boolean useOuterJoinSemantics,
-	                                         final boolean collectExceptions ) {
-		super( query, fm, collectExceptions );
+	                                         final boolean collectExceptions,
+	                                         final QueryPlanningInfo qpInfo ) {
+		super(query, fm, collectExceptions, qpInfo);
 
 		// TODO extend this implementation to support outer join semantics similar
 		// to how it is implemented in ExecOpGenericIndexNestedLoopsJoinWithRequestOps

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinTPF.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinTPF.java
@@ -2,6 +2,7 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import se.liu.ida.hefquin.base.query.TriplePattern;
 import se.liu.ida.hefquin.engine.queryplan.executable.NullaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.federation.TPFServer;
 import se.liu.ida.hefquin.federation.access.TriplePatternRequest;
 
@@ -10,13 +11,14 @@ public class ExecOpIndexNestedLoopsJoinTPF extends BaseForExecOpIndexNestedLoops
 	public ExecOpIndexNestedLoopsJoinTPF( final TriplePattern query,
 	                                      final TPFServer fm,
 	                                      final boolean useOuterJoinSemantics,
-	                                      final boolean collectExceptions ) {
-		super(query, fm, useOuterJoinSemantics, collectExceptions);
+	                                      final boolean collectExceptions,
+	                                      final QueryPlanningInfo qpInfo ) {
+		super(query, fm, useOuterJoinSemantics, collectExceptions, qpInfo);
 	}
 
 	@Override
 	protected NullaryExecutableOp createRequestOperator( final TriplePatternRequest req ) {
-		return new ExecOpRequestTPFatTPFServer(req, fm, false);
+		return new ExecOpRequestTPFatTPFServer(req, fm, false, null);
 	}
 
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLocalToGlobal.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLocalToGlobal.java
@@ -9,6 +9,7 @@ import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.data.VocabularyMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 public class ExecOpLocalToGlobal extends UnaryExecutableOpBaseWithoutBlocking
@@ -17,8 +18,10 @@ public class ExecOpLocalToGlobal extends UnaryExecutableOpBaseWithoutBlocking
 
 	protected final VocabularyMapping vm;
 
-	public ExecOpLocalToGlobal( final VocabularyMapping vm, final boolean collectExceptions ) {
-		super(collectExceptions);
+	public ExecOpLocalToGlobal( final VocabularyMapping vm,
+	                            final boolean collectExceptions,
+	                            final QueryPlanningInfo qpInfo ) {
+		super(collectExceptions, qpInfo);
 
 		assert vm != null;
 		this.vm = vm;

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpMultiwayUnion.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpMultiwayUnion.java
@@ -5,14 +5,17 @@ import java.util.List;
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 public class ExecOpMultiwayUnion extends NaryExecutableOpBase
 {
 	private long numberOfOutputMappingsProduced = 0L;
 
-	public ExecOpMultiwayUnion( final int numberOfChildren, final boolean collectExceptions ) {
-		super(numberOfChildren, collectExceptions);
+	public ExecOpMultiwayUnion( final int numberOfChildren,
+	                            final boolean collectExceptions,
+	                            final QueryPlanningInfo qpInfo ) {
+		super(numberOfChildren, collectExceptions, qpInfo);
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpNaiveNestedLoopsJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpNaiveNestedLoopsJoin.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.data.utils.SolutionMappingUtils;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 import java.util.ArrayList;
@@ -25,8 +26,9 @@ public class ExecOpNaiveNestedLoopsJoin extends BinaryExecutableOpBase
 {
 	protected final List<SolutionMapping> inputLHS = new ArrayList<>();
 
-	public ExecOpNaiveNestedLoopsJoin( final boolean collectExceptions ) {
-		super(collectExceptions);
+	public ExecOpNaiveNestedLoopsJoin( final boolean collectExceptions,
+	                                   final QueryPlanningInfo qpInfo ) {
+		super(collectExceptions, qpInfo);
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoin.java
@@ -17,6 +17,7 @@ import se.liu.ida.hefquin.base.datastructures.impl.SolutionMappingsIndexNoJoinVa
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.base.query.utils.ExpectedVariablesUtils;
 import se.liu.ida.hefquin.engine.queryplan.executable.*;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.UnaryLogicalOp;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
 import se.liu.ida.hefquin.engine.queryplan.physical.UnaryPhysicalOp;
@@ -39,15 +40,17 @@ public class ExecOpParallelMultiwayLeftJoin extends UnaryExecutableOpBaseWithBat
 	protected final Set<List<Node>> bindingsForJoinVariable = new HashSet<>();
 
 	public ExecOpParallelMultiwayLeftJoin( final boolean collectExceptions,
+	                                       final QueryPlanningInfo qpInfo,
 	                                       final ExpectedVariables inputVarsFromNonOptionalPart,
 	                                       final LogicalOpRequest<?,?> ... optionalParts ) {
-		this( collectExceptions, inputVarsFromNonOptionalPart, Arrays.asList(optionalParts) );
+		this( collectExceptions, qpInfo, inputVarsFromNonOptionalPart, Arrays.asList(optionalParts) );
 	}
 
 	public ExecOpParallelMultiwayLeftJoin( final boolean collectExceptions,
+	                                       final QueryPlanningInfo qpInfo,
 	                                       final ExpectedVariables inputVarsFromNonOptionalPart,
 	                                       final List<LogicalOpRequest<?,?>> optionalParts ) {
-		super(DEFAULT_BATCH_SIZE, collectExceptions);
+		super(DEFAULT_BATCH_SIZE, collectExceptions, qpInfo);
 
 		assert ! optionalParts.isEmpty();
 
@@ -217,7 +220,7 @@ public class ExecOpParallelMultiwayLeftJoin extends UnaryExecutableOpBaseWithBat
 
 			final UnaryLogicalOp addLop = LogicalOpUtils.createLogicalAddOpFromLogicalReqOp(req);
 			final UnaryPhysicalOp addPop = LogicalToPhysicalOpConverter.convert(addLop);
-			this.execOp = addPop.createExecOp(false, inputVarsFromNonOptionalPart);
+			this.execOp = addPop.createExecOp(false, null, inputVarsFromNonOptionalPart);
 
 			this.mySink = new IntermediateResultElementSink() {
 				@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestBRTPF.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestBRTPF.java
@@ -6,6 +6,7 @@ import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.data.Triple;
 import se.liu.ida.hefquin.base.data.utils.TriplesToSolMapsConverter;
 import se.liu.ida.hefquin.engine.federation.access.utils.FederationAccessUtils;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.federation.BRTPFServer;
 import se.liu.ida.hefquin.federation.access.BRTPFRequest;
 import se.liu.ida.hefquin.federation.access.BindingsRestrictedTriplePatternRequest;
@@ -18,8 +19,9 @@ public class ExecOpRequestBRTPF extends BaseForExecOpRequestWithTPFPaging<Bindin
 {
 	public ExecOpRequestBRTPF( final BindingsRestrictedTriplePatternRequest req,
 	                           final BRTPFServer fm,
-	                           final boolean collectExceptions ) {
-		super( req, fm, collectExceptions );
+	                           final boolean collectExceptions,
+	                           final QueryPlanningInfo qpInfo ) {
+		super(req, fm, collectExceptions, qpInfo);
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestSPARQL.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestSPARQL.java
@@ -1,6 +1,7 @@
 package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import se.liu.ida.hefquin.engine.federation.access.utils.FederationAccessUtils;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.federation.SPARQLEndpoint;
 import se.liu.ida.hefquin.federation.access.FederationAccessException;
 import se.liu.ida.hefquin.federation.access.FederationAccessManager;
@@ -9,8 +10,11 @@ import se.liu.ida.hefquin.federation.access.SolMapsResponse;
 
 public class ExecOpRequestSPARQL extends BaseForExecOpSolMapsRequest<SPARQLRequest, SPARQLEndpoint>
 {
-	public ExecOpRequestSPARQL( final SPARQLRequest req, final SPARQLEndpoint fm, final boolean collectExceptions ) {
-		super( req, fm, collectExceptions );
+	public ExecOpRequestSPARQL( final SPARQLRequest req,
+	                            final SPARQLEndpoint fm,
+	                            final boolean collectExceptions,
+	                            final QueryPlanningInfo qpInfo ) {
+		super(req, fm, collectExceptions, qpInfo);
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestTPFatBRTPFServer.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestTPFatBRTPFServer.java
@@ -1,6 +1,7 @@
 package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import se.liu.ida.hefquin.engine.federation.access.utils.FederationAccessUtils;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.federation.BRTPFServer;
 import se.liu.ida.hefquin.federation.access.FederationAccessException;
 import se.liu.ida.hefquin.federation.access.FederationAccessManager;
@@ -17,8 +18,9 @@ public class ExecOpRequestTPFatBRTPFServer extends BaseForExecOpTriplePatternReq
 {
 	public ExecOpRequestTPFatBRTPFServer( final TriplePatternRequest req,
 	                                      final BRTPFServer fm,
-	                                      final boolean collectExceptions ) {
-		super( req, fm, collectExceptions );
+	                                      final boolean collectExceptions,
+	                                      final QueryPlanningInfo qpInfo ) {
+		super(req, fm, collectExceptions, qpInfo);
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestTPFatTPFServer.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestTPFatTPFServer.java
@@ -1,6 +1,7 @@
 package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import se.liu.ida.hefquin.engine.federation.access.utils.FederationAccessUtils;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.federation.TPFServer;
 import se.liu.ida.hefquin.federation.access.FederationAccessException;
 import se.liu.ida.hefquin.federation.access.FederationAccessManager;
@@ -17,8 +18,9 @@ public class ExecOpRequestTPFatTPFServer extends BaseForExecOpTriplePatternReque
 {
 	public ExecOpRequestTPFatTPFServer( final TriplePatternRequest req,
 	                                    final TPFServer fm,
-	                                    final boolean collectExceptions ) {
-		super( req, fm, collectExceptions );
+	                                    final boolean collectExceptions,
+	                                    final QueryPlanningInfo qpInfo ) {
+		super(req, fm, collectExceptions, qpInfo);
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSymmetricHashJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSymmetricHashJoin.java
@@ -11,6 +11,7 @@ import se.liu.ida.hefquin.base.query.utils.ExpectedVariablesUtils;
 import se.liu.ida.hefquin.base.utils.Stats;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 import java.util.*;
@@ -53,8 +54,9 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 
     public ExecOpSymmetricHashJoin( final ExpectedVariables inputVars1,
                                     final ExpectedVariables inputVars2,
-                                    final boolean collectExceptions ) {
-        super(collectExceptions);
+                                    final boolean collectExceptions,
+                                    final QueryPlanningInfo qpInfo ) {
+        super(collectExceptions, qpInfo);
 
         // determine the certain join variables
         final Set<Var> certainJoinVars = ExpectedVariablesUtils.intersectionOfCertainVariables(inputVars1, inputVars2);

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/NaryExecutableOpBase.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/NaryExecutableOpBase.java
@@ -8,6 +8,7 @@ import se.liu.ida.hefquin.engine.queryplan.executable.ExecutableOperatorStats;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.NaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 /**
@@ -37,8 +38,9 @@ public abstract class NaryExecutableOpBase extends BaseForExecOps implements Nar
 	protected long[] timeAtCurrentProcStartXthInput;
 
 	public NaryExecutableOpBase( final int numberOfChildren,
-	                             final boolean collectExceptions ) {
-		super(collectExceptions);
+	                             final boolean collectExceptions,
+	                             final QueryPlanningInfo qpInfo ) {
+		super(collectExceptions, qpInfo);
 
 		this.numberOfChildren = numberOfChildren;
 
@@ -193,6 +195,7 @@ public abstract class NaryExecutableOpBase extends BaseForExecOps implements Nar
 		final ExecutableOperatorStatsImpl s = new ExecutableOperatorStatsImpl(this);
 		s.put( "xthInputConsumed", xthInputConsumed );
 		s.put( "numberOfMappingsFromXthInputProcessed",  numberOfMappingsFromXthInputProcessed );
+		s.put( "queryPlanningInfo", qpInfo );
 		return s;
 	}
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/NullaryExecutableOpBase.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/NullaryExecutableOpBase.java
@@ -5,6 +5,7 @@ import se.liu.ida.hefquin.engine.queryplan.executable.ExecutableOperatorStats;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.NullaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 /**
@@ -26,8 +27,9 @@ public abstract class NullaryExecutableOpBase extends BaseForExecOps implements 
 	protected long timeAtExecStart  = 0L;
 	protected long timeAtExecEnd    = 0L;
 
-	public NullaryExecutableOpBase( final boolean collectExceptions ) {
-		super(collectExceptions);
+	public NullaryExecutableOpBase( final boolean collectExceptions,
+	                                final QueryPlanningInfo qpInfo ) {
+		super(collectExceptions, qpInfo);
 	}
 
 	@Override
@@ -79,6 +81,7 @@ public abstract class NullaryExecutableOpBase extends BaseForExecOps implements 
 		final ExecutableOperatorStatsImpl s = new ExecutableOperatorStatsImpl(this);
 		s.put( "numberOfInvocations",  Integer.valueOf(numberOfInvocations) );
 		s.put( "overallExecTime",      Long.valueOf(timeAtExecEnd-timeAtExecStart) );
+		s.put( "queryPlanningInfo",    qpInfo );
 		return s;
 	}
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/UnaryExecutableOpBase.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/UnaryExecutableOpBase.java
@@ -8,6 +8,7 @@ import se.liu.ida.hefquin.engine.queryplan.executable.ExecutableOperatorStats;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 /**
@@ -33,8 +34,9 @@ public abstract class UnaryExecutableOpBase extends BaseForExecOps implements Un
 	private boolean executionConcluded = false;
 	private long numberOfInputMappingsProcessed = 0L;
 
-	public UnaryExecutableOpBase( final boolean collectExceptions ) {
-		super(collectExceptions);
+	public UnaryExecutableOpBase( final boolean collectExceptions,
+	                              final QueryPlanningInfo qpInfo ) {
+		super(collectExceptions, qpInfo);
 	}
 
 	@Override
@@ -156,6 +158,7 @@ public abstract class UnaryExecutableOpBase extends BaseForExecOps implements Un
 		final ExecutableOperatorStatsImpl s = new ExecutableOperatorStatsImpl(this);
 		s.put( "executionConcluded",                Boolean.valueOf(executionConcluded) );
 		s.put( "numberOfInputMappingsProcessed",    Long.valueOf(numberOfInputMappingsProcessed) );
+		s.put( "queryPlanningInfo",                 qpInfo );
 		return s;
 	}
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/UnaryExecutableOpBaseWithBatching.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/UnaryExecutableOpBaseWithBatching.java
@@ -8,6 +8,7 @@ import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 /**
@@ -30,8 +31,9 @@ public abstract class UnaryExecutableOpBaseWithBatching extends UnaryExecutableO
 	protected final List<SolutionMapping> collectedInputSolMaps;
 
 	public UnaryExecutableOpBaseWithBatching( final int batchSize,
-	                                          final boolean collectExceptions ) {
-		super(collectExceptions);
+	                                          final boolean collectExceptions,
+	                                          final QueryPlanningInfo qpInfo ) {
+		super(collectExceptions, qpInfo);
 
 		assert batchSize > 0;
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/UnaryExecutableOpBaseWithoutBlocking.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/UnaryExecutableOpBaseWithoutBlocking.java
@@ -7,6 +7,7 @@ import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 /**
@@ -32,8 +33,9 @@ public abstract class UnaryExecutableOpBaseWithoutBlocking extends UnaryExecutab
 {
 	public static final int MAX_BATCH_SIZE = 100;
 
-	public UnaryExecutableOpBaseWithoutBlocking( final boolean collectExceptions ) {
-		super(collectExceptions);
+	public UnaryExecutableOpBaseWithoutBlocking( final boolean collectExceptions,
+	                                             final QueryPlanningInfo qpInfo ) {
+		super(collectExceptions, qpInfo);
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/info/QueryPlanningInfo.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/info/QueryPlanningInfo.java
@@ -1,14 +1,18 @@
 package se.liu.ida.hefquin.engine.queryplan.info;
 
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
+
+import se.liu.ida.hefquin.base.utils.Stats;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanProperty.Type;
 
 /**
  * Every object of this class captures a collection of information about
  * a particular query plan. These objects are meant to be populated and
  * used during query planning.
  */
-public class QueryPlanningInfo
+public class QueryPlanningInfo implements Stats
 {
 	protected Map<QueryPlanProperty.Type, QueryPlanProperty> properties = new HashMap<>();
 
@@ -58,6 +62,32 @@ public class QueryPlanningInfo
 			throw new IllegalArgumentException("This QueryPlanningInfo object already contains a propety of type '" + type.name + "'.");
 
 		properties.put(type, p);
+	}
+
+	@Override
+	public Iterable<String> getEntryNames() {
+		return new Iterable<>() {
+			@Override public Iterator<String> iterator() {
+				return new EntryNamesIterator();
+			}
+		};
+	}
+
+	protected class EntryNamesIterator implements Iterator<String> {
+		protected final Iterator<Type> it = properties.keySet().iterator();
+		@Override public boolean hasNext() { return it.hasNext(); }
+		@Override public String next() { return it.next().name; }
+	}
+
+	@Override
+	public Object getEntry( final String entryName ) {
+		for ( final Map.Entry<Type, QueryPlanProperty> e : properties.entrySet() ) {
+			if ( e.getKey().name.equals(entryName) ) {
+				return e.getValue().getValue();
+			}
+		}
+
+		return null;
 	}
 
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/BinaryPhysicalOp.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/BinaryPhysicalOp.java
@@ -2,6 +2,7 @@ package se.liu.ida.hefquin.engine.queryplan.physical;
 
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.BinaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 
 /**
  * An interface for any type of {@link PhysicalOperator} whose algorithm
@@ -10,5 +11,7 @@ import se.liu.ida.hefquin.engine.queryplan.executable.BinaryExecutableOp;
 public interface BinaryPhysicalOp extends PhysicalOperator
 {
 	@Override
-	BinaryExecutableOp createExecOp( boolean collectExceptions, ExpectedVariables ... inputVars );
+	BinaryExecutableOp createExecOp( boolean collectExceptions,
+	                                 QueryPlanningInfo qpInfo,
+	                                 ExpectedVariables ... inputVars );
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/NaryPhysicalOp.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/NaryPhysicalOp.java
@@ -2,6 +2,7 @@ package se.liu.ida.hefquin.engine.queryplan.physical;
 
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.NaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 
 /**
  * An interface for any type of {@link PhysicalOperator} whose algorithm
@@ -10,5 +11,7 @@ import se.liu.ida.hefquin.engine.queryplan.executable.NaryExecutableOp;
 public interface NaryPhysicalOp extends PhysicalOperator
 {
 	@Override
-	NaryExecutableOp createExecOp( boolean collectExceptions, ExpectedVariables ... inputVars );
+	NaryExecutableOp createExecOp( boolean collectExceptions,
+	                               QueryPlanningInfo qpInfo,
+	                               ExpectedVariables ... inputVars );
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/NullaryPhysicalOp.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/NullaryPhysicalOp.java
@@ -2,6 +2,7 @@ package se.liu.ida.hefquin.engine.queryplan.physical;
 
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.NullaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 
 /**
  * An interface for any type of {@link PhysicalOperator} whose algorithm
@@ -11,5 +12,7 @@ import se.liu.ida.hefquin.engine.queryplan.executable.NullaryExecutableOp;
 public interface NullaryPhysicalOp extends PhysicalOperator
 {
 	@Override
-	NullaryExecutableOp createExecOp( boolean collectExceptions, ExpectedVariables ... inputVars );
+	NullaryExecutableOp createExecOp( boolean collectExceptions,
+	                                  QueryPlanningInfo qpInfo,
+	                                  ExpectedVariables ... inputVars );
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/PhysicalOperator.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/PhysicalOperator.java
@@ -2,6 +2,7 @@ package se.liu.ida.hefquin.engine.queryplan.physical;
 
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutableOperator;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 
 /**
  * This is the top-level interface for all types of physical operators of
@@ -25,6 +26,12 @@ public interface PhysicalOperator
 	 * has to create a new {@link ExecutableOperator} object each
 	 * time it is called.
 	 *
+	 * The given {@link QueryPlanningInfo} object is passed to
+	 * the created executable operator (to be available via the
+	 * {@link ExecutableOperator#getQueryPlanningInfo()} method)
+	 * and should be taken from the physical plan whose root
+	 * operator is this physical operator.
+	 *
 	 * The given collectExceptions flag is passed to the executable
 	 * operator and determines whether that operator collects its
 	 * exceptions (see {@link ExecutableOperator#getExceptionsCaughtDuringExecution()})
@@ -35,7 +42,9 @@ public interface PhysicalOperator
 	 * this operator (e.g., for a unary operator, exactly one such
 	 * object must be passed).
 	 */
-	ExecutableOperator createExecOp( boolean collectExceptions, ExpectedVariables ... inputVars );
+	ExecutableOperator createExecOp( boolean collectExceptions,
+	                                 QueryPlanningInfo qpInfo,
+	                                 ExpectedVariables ... inputVars );
 
 	/**
 	 * Returns the variables that can be expected in the solution

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/PhysicalPlan.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/PhysicalPlan.java
@@ -37,7 +37,17 @@ public interface PhysicalPlan
 	/**
 	 * Returns an object that captures query-planning-related
 	 * information about this plan. This object is meant to be
-	 * requested and populated by the query planner. 
+	 * requested and populated by the query planner.
+	 * <p>
+	 * If this plan does not yet have a {@link QueryPlanningInfo}
+	 * object associated with it, then this function creates a new
+	 * (empty) one and returns that.
 	 */
 	QueryPlanningInfo getQueryPlanningInfo();
+
+	/**
+	 * Returns <code>true</code> if this plan already has a
+	 * {@link QueryPlanningInfo} object associated with it.
+	 */
+	boolean hasQueryPlanningInfo();
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/UnaryPhysicalOp.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/UnaryPhysicalOp.java
@@ -2,6 +2,7 @@ package se.liu.ida.hefquin.engine.queryplan.physical;
 
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 
 /**
  * An interface for any type of {@link PhysicalOperator} whose algorithm
@@ -10,5 +11,7 @@ import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
 public interface UnaryPhysicalOp extends PhysicalOperator
 {
 	@Override
-	UnaryExecutableOp createExecOp( boolean collectExceptions, ExpectedVariables ... inputVars );
+	UnaryExecutableOp createExecOp( boolean collectExceptions,
+	                                QueryPlanningInfo qpInfo,
+	                                ExpectedVariables ... inputVars );
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/BaseForPhysicalOpSingleInputJoinAtSPARQLEndpoint.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/BaseForPhysicalOpSingleInputJoinAtSPARQLEndpoint.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryplan.physical.impl;
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
 import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
 import se.liu.ida.hefquin.federation.FederationMember;
@@ -25,6 +26,7 @@ public abstract class BaseForPhysicalOpSingleInputJoinAtSPARQLEndpoint
 
 	@Override
 	public UnaryExecutableOp createExecOp( final boolean collectExceptions,
+	                                       final QueryPlanningInfo qpInfo,
 	                                       final ExpectedVariables... inputVars ) {
 		final SPARQLGraphPattern gp;
 		final FederationMember fm;
@@ -45,7 +47,7 @@ public abstract class BaseForPhysicalOpSingleInputJoinAtSPARQLEndpoint
 		}
 
 		if ( fm instanceof SPARQLEndpoint ep )
-			return createExecOp(gp, ep, useOuterJoin, collectExceptions, inputVars);
+			return createExecOp(gp, ep, useOuterJoin, collectExceptions, qpInfo, inputVars);
 		else
 			throw new IllegalArgumentException("Unsupported type of federation member: " + fm.getClass().getName() );
 	}
@@ -54,5 +56,6 @@ public abstract class BaseForPhysicalOpSingleInputJoinAtSPARQLEndpoint
 	                                                   SPARQLEndpoint sparqlEndpoint,
 	                                                   boolean useOuterJoinSemantics,
 	                                                   boolean collectExceptions,
+	                                                   QueryPlanningInfo qpInfo,
 	        	                                       ExpectedVariables... inputVars );
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/BaseForPhysicalPlan.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/BaseForPhysicalPlan.java
@@ -28,6 +28,11 @@ public abstract class BaseForPhysicalPlan implements PhysicalPlan
 	}
 
 	@Override
+	public boolean hasQueryPlanningInfo() {
+		return info != null;
+	}
+
+	@Override
 	public QueryPlanningInfo getQueryPlanningInfo() {
 		if ( info == null )
 			info = new QueryPlanningInfo();

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBinaryUnion.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBinaryUnion.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryplan.physical.impl;
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.BinaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBinaryUnion;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.BinaryLogicalOp;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpUnion;
 import se.liu.ida.hefquin.engine.queryplan.physical.BinaryPhysicalOpForLogicalOp;
@@ -45,8 +46,9 @@ public class PhysicalOpBinaryUnion extends BaseForPhysicalOps implements BinaryP
 
 	@Override
 	public BinaryExecutableOp createExecOp( final boolean collectExceptions,
+	                                        final QueryPlanningInfo qpInfo,
 	                                        final ExpectedVariables... inputVars ) {
-		return new ExecOpBinaryUnion(collectExceptions);
+		return new ExecOpBinaryUnion(collectExceptions, qpInfo);
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBind.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBind.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryplan.physical.impl;
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBind;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.UnaryLogicalOp;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBind;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
@@ -28,8 +29,9 @@ public class PhysicalOpBind extends BaseForPhysicalOps implements UnaryPhysicalO
 
 	@Override
 	public UnaryExecutableOp createExecOp( final boolean collectExceptions,
+	                                       final QueryPlanningInfo qpInfo,
 	                                       final ExpectedVariables... inputVars ) {
-		return new ExecOpBind( lop.getBindExpressions(), collectExceptions );
+		return new ExecOpBind( lop.getBindExpressions(), collectExceptions, qpInfo );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoin.java
@@ -4,6 +4,7 @@ import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.base.query.TriplePattern;
 import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinBRTPF;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
@@ -56,6 +57,7 @@ public class PhysicalOpBindJoin extends BaseForPhysicalOpSingleInputJoin
 
 	@Override
 	public UnaryExecutableOp createExecOp( final boolean collectExceptions,
+	                                       final QueryPlanningInfo qpInfo,
 	                                       final ExpectedVariables ... inputVars )
 	{
 		final TriplePattern tp;
@@ -82,7 +84,8 @@ public class PhysicalOpBindJoin extends BaseForPhysicalOpSingleInputJoin
 			                                inputVars[0],
 			                                useOuterJoinSemantics,
 			                                ExecOpBindJoinBRTPF.DEFAULT_BATCH_SIZE,
-			                                collectExceptions );
+			                                collectExceptions,
+			                                qpInfo );
 		else
 			throw new IllegalArgumentException("Unsupported type of federation member: " + fm.getClass().getName() );
 	}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithFILTER.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithFILTER.java
@@ -4,6 +4,7 @@ import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
 import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithFILTER;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
@@ -47,13 +48,15 @@ public class PhysicalOpBindJoinWithFILTER extends BaseForPhysicalOpSingleInputJo
 	                                       final SPARQLEndpoint sparqlEndpoint,
 	                                       final boolean useOuterJoinSemantics,
 	                                       final boolean collectExceptions,
+	                                       final QueryPlanningInfo qpInfo,
 	                                       final ExpectedVariables... inputVars ) {
 		return new ExecOpBindJoinSPARQLwithFILTER( pattern,
 		                                           sparqlEndpoint,
 		                                           inputVars[0],
 		                                           useOuterJoinSemantics,
 		                                           ExecOpBindJoinSPARQLwithFILTER.DEFAULT_BATCH_SIZE,
-		                                           collectExceptions );
+		                                           collectExceptions,
+		                                           qpInfo );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithUNION.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithUNION.java
@@ -4,6 +4,7 @@ import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
 import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithUNION;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
@@ -46,13 +47,15 @@ public class PhysicalOpBindJoinWithUNION extends BaseForPhysicalOpSingleInputJoi
 	                                       final SPARQLEndpoint sparqlEndpoint,
 	                                       final boolean useOuterJoinSemantics,
 	                                       final boolean collectExceptions,
+	                                       final QueryPlanningInfo qpInfo,
 	                                       final ExpectedVariables... inputVars ) {
 		return new ExecOpBindJoinSPARQLwithUNION( pattern,
 		                                          sparqlEndpoint,
 		                                          inputVars[0],
 		                                          useOuterJoinSemantics,
 		                                          ExecOpBindJoinSPARQLwithUNION.DEFAULT_BATCH_SIZE,
-		                                          collectExceptions );
+		                                          collectExceptions,
+		                                          qpInfo );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithVALUES.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithVALUES.java
@@ -5,6 +5,7 @@ import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
 import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithFILTER;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithVALUES;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
@@ -48,13 +49,15 @@ public class PhysicalOpBindJoinWithVALUES extends BaseForPhysicalOpSingleInputJo
 	                                       final SPARQLEndpoint sparqlEndpoint,
 	                                       final boolean useOuterJoinSemantics,
 	                                       final boolean collectExceptions,
+	                                       final QueryPlanningInfo qpInfo,
 	                                       final ExpectedVariables... inputVars ) {
 		return new ExecOpBindJoinSPARQLwithFILTER( pattern,
 		                                           sparqlEndpoint,
 		                                           inputVars[0],
 		                                           useOuterJoinSemantics,
 		                                           ExecOpBindJoinSPARQLwithVALUES.DEFAULT_BATCH_SIZE,
-		                                           collectExceptions );
+		                                           collectExceptions,
+		                                           qpInfo );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithVALUESorFILTER.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpBindJoinWithVALUESorFILTER.java
@@ -4,6 +4,7 @@ import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
 import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithVALUESorFILTER;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
@@ -37,13 +38,15 @@ public class PhysicalOpBindJoinWithVALUESorFILTER extends BaseForPhysicalOpSingl
 	                                       final SPARQLEndpoint sparqlEndpoint,
 	                                       final boolean useOuterJoinSemantics,
 	                                       final boolean collectExceptions,
+	                                       final QueryPlanningInfo qpInfo,
 	                                       final ExpectedVariables... inputVars ) {
 		return new ExecOpBindJoinSPARQLwithVALUESorFILTER( pattern,
 		                                                   sparqlEndpoint,
 		                                                   inputVars[0],
 		                                                   useOuterJoinSemantics,
 		                                                   ExecOpBindJoinSPARQLwithVALUESorFILTER.DEFAULT_BATCH_SIZE,
-		                                                   collectExceptions );
+		                                                   collectExceptions,
+		                                                   qpInfo );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpFilter.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpFilter.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryplan.physical.impl;
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpFilter;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.UnaryLogicalOp;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFilter;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
@@ -34,8 +35,9 @@ public class PhysicalOpFilter extends BaseForPhysicalOps implements UnaryPhysica
 
 	@Override
 	public UnaryExecutableOp createExecOp( final boolean collectExceptions,
+	                                       final QueryPlanningInfo qpInfo,
 	                                       final ExpectedVariables... inputVars ) {
-		return new ExecOpFilter( lop.getFilterExpressions(), collectExceptions );
+		return new ExecOpFilter( lop.getFilterExpressions(), collectExceptions, qpInfo );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpGlobalToLocal.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpGlobalToLocal.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryplan.physical.impl;
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpGlobalToLocal;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.UnaryLogicalOp;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGlobalToLocal;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
@@ -38,8 +39,9 @@ public class PhysicalOpGlobalToLocal extends BaseForPhysicalOps
 
 	@Override
 	public UnaryExecutableOp createExecOp( final boolean collectExceptions,
+	                                       final QueryPlanningInfo qpInfo,
 	                                       final ExpectedVariables... inputVars ) {
-		return new ExecOpGlobalToLocal( lop.getVocabularyMapping(), collectExceptions );
+		return new ExecOpGlobalToLocal( lop.getVocabularyMapping(), collectExceptions, qpInfo );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpHashJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpHashJoin.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryplan.physical.impl;
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.BinaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpHashJoin;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
 
@@ -31,10 +32,11 @@ public class PhysicalOpHashJoin extends BaseForPhysicalOpBinaryJoin
 
 	@Override
 	public BinaryExecutableOp createExecOp( final boolean collectExceptions,
+	                                        final QueryPlanningInfo qpInfo,
 	                                        final ExpectedVariables ... inputVars ) {
 		assert inputVars.length == 2;
 
-		return new ExecOpHashJoin( inputVars[0], inputVars[1], collectExceptions );
+		return new ExecOpHashJoin( inputVars[0], inputVars[1], collectExceptions, qpInfo );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpHashRJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpHashRJoin.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.BinaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpHashRJoin;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.BinaryLogicalOp;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRightJoin;
 import se.liu.ida.hefquin.engine.queryplan.physical.BinaryPhysicalOpForLogicalOp;
@@ -48,10 +49,11 @@ public class PhysicalOpHashRJoin extends BaseForPhysicalOps
 
 	@Override
 	public BinaryExecutableOp createExecOp( final boolean collectExceptions,
+	                                        final QueryPlanningInfo qpInfo,
 	                                        final ExpectedVariables ... inputVars ) {
 		assert inputVars.length == 2;
 
-		return new ExecOpHashRJoin( inputVars[0], inputVars[1], collectExceptions );
+		return new ExecOpHashRJoin( inputVars[0], inputVars[1], collectExceptions, qpInfo );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpIndexNestedLoopsJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpIndexNestedLoopsJoin.java
@@ -7,6 +7,7 @@ import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpIndexNestedLoopsJoinBRTPF;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpIndexNestedLoopsJoinSPARQL;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpIndexNestedLoopsJoinTPF;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
@@ -73,6 +74,7 @@ public class PhysicalOpIndexNestedLoopsJoin extends BaseForPhysicalOpSingleInput
 
 	@Override
 	public UnaryExecutableOp createExecOp( final boolean collectExceptions,
+	                                       final QueryPlanningInfo qpInfo,
 	                                       final ExpectedVariables ... inputVars )
 	{
 		final SPARQLGraphPattern gp;
@@ -111,11 +113,11 @@ public class PhysicalOpIndexNestedLoopsJoin extends BaseForPhysicalOpSingleInput
 		}
 
 		if ( fm instanceof TPFServer tpf )
-			return new ExecOpIndexNestedLoopsJoinTPF( tp, tpf, useOuterJoin, collectExceptions );
+			return new ExecOpIndexNestedLoopsJoinTPF(tp, tpf, useOuterJoin, collectExceptions, qpInfo);
 		else if ( fm instanceof BRTPFServer brtpf )
-			return new ExecOpIndexNestedLoopsJoinBRTPF( tp, brtpf, useOuterJoin, collectExceptions );
+			return new ExecOpIndexNestedLoopsJoinBRTPF(tp, brtpf, useOuterJoin, collectExceptions, qpInfo);
 		else if ( fm instanceof SPARQLEndpoint ep )
-			return new ExecOpIndexNestedLoopsJoinSPARQL( gp, ep, useOuterJoin, collectExceptions );
+			return new ExecOpIndexNestedLoopsJoinSPARQL(gp, ep, useOuterJoin, collectExceptions, qpInfo);
 		else
 			throw new IllegalArgumentException("Unsupported type of federation member: " + fm.getClass().getName() );
 	}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpLocalToGlobal.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpLocalToGlobal.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryplan.physical.impl;
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpLocalToGlobal;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.UnaryLogicalOp;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpLocalToGlobal;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
@@ -37,8 +38,9 @@ public class PhysicalOpLocalToGlobal extends BaseForPhysicalOps
 
 	@Override
 	public UnaryExecutableOp createExecOp( final boolean collectExceptions,
+	                                       final QueryPlanningInfo qpInfo,
 	                                       final ExpectedVariables... inputVars ) {
-		return new ExecOpLocalToGlobal( lop.getVocabularyMapping(), collectExceptions );
+		return new ExecOpLocalToGlobal( lop.getVocabularyMapping(), collectExceptions, qpInfo );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpMultiwayUnion.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpMultiwayUnion.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryplan.physical.impl;
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.NaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpMultiwayUnion;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.NaryLogicalOp;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayUnion;
 import se.liu.ida.hefquin.engine.queryplan.physical.NaryPhysicalOpForLogicalOp;
@@ -29,8 +30,9 @@ public class PhysicalOpMultiwayUnion extends BaseForPhysicalOps
 
 	@Override
 	public NaryExecutableOp createExecOp( final boolean collectExceptions,
+	                                      final QueryPlanningInfo qpInfo,
 	                                      final ExpectedVariables... inputVars) {
-		return new ExecOpMultiwayUnion( inputVars.length, collectExceptions );
+		return new ExecOpMultiwayUnion( inputVars.length, collectExceptions, qpInfo );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpNaiveNestedLoopsJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpNaiveNestedLoopsJoin.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryplan.physical.impl;
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.BinaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpNaiveNestedLoopsJoin;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
 
@@ -31,8 +32,9 @@ public class PhysicalOpNaiveNestedLoopsJoin extends BaseForPhysicalOpBinaryJoin
 
 	@Override
 	public BinaryExecutableOp createExecOp( final boolean collectExceptions,
+	                                        final QueryPlanningInfo qpInfo,
 	                                        final ExpectedVariables... inputVars ) {
-		return new ExecOpNaiveNestedLoopsJoin(collectExceptions);
+		return new ExecOpNaiveNestedLoopsJoin(collectExceptions, qpInfo);
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpParallelMultiLeftJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpParallelMultiLeftJoin.java
@@ -11,6 +11,7 @@ import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.base.query.utils.ExpectedVariablesUtils;
 import se.liu.ida.hefquin.engine.queryplan.executable.UnaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpParallelMultiwayLeftJoin;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
@@ -126,10 +127,11 @@ public class PhysicalOpParallelMultiLeftJoin extends BaseForPhysicalOps implemen
 
 	@Override
 	public UnaryExecutableOp createExecOp( final boolean collectExceptions,
+	                                       final QueryPlanningInfo qpInfo,
 	                                       final ExpectedVariables... inputVars ) {
 		assert inputVars.length == 1;
 
-		return new ExecOpParallelMultiwayLeftJoin( collectExceptions, inputVars[0], optionalParts );
+		return new ExecOpParallelMultiwayLeftJoin( collectExceptions, qpInfo, inputVars[0], optionalParts );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpRequest.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpRequest.java
@@ -6,6 +6,7 @@ import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpRequestBRTP
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpRequestSPARQL;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpRequestTPFatBRTPFServer;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpRequestTPFatTPFServer;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
 import se.liu.ida.hefquin.engine.queryplan.physical.NullaryPhysicalOpForLogicalOp;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
@@ -61,20 +62,21 @@ public class PhysicalOpRequest<ReqType extends DataRetrievalRequest, MemberType 
 
 	@Override
 	public NullaryExecutableOp createExecOp( final boolean collectExceptions,
-	                                         final ExpectedVariables ... inputVars ) {
+	                                         final QueryPlanningInfo qpInfo,
+		                                     final ExpectedVariables ... inputVars ) {
 		final ReqType req = lop.getRequest();
 		final MemberType fm = lop.getFederationMember();
-		if ( fm instanceof SPARQLEndpoint && req instanceof SPARQLRequest ) {
-			return new ExecOpRequestSPARQL( (SPARQLRequest) req, (SPARQLEndpoint) fm, collectExceptions );
+		if ( fm instanceof SPARQLEndpoint sep && req instanceof SPARQLRequest sreq ) {
+			return new ExecOpRequestSPARQL(sreq, sep, collectExceptions, qpInfo);
 		}
-		else if ( fm instanceof TPFServer && req instanceof TriplePatternRequest ) {
-			return new ExecOpRequestTPFatTPFServer( (TriplePatternRequest) req, (TPFServer) fm, collectExceptions );
+		else if ( fm instanceof TPFServer tpf && req instanceof TriplePatternRequest tpreq ) {
+			return new ExecOpRequestTPFatTPFServer(tpreq, tpf, collectExceptions, qpInfo);
 		}
-		else if ( fm instanceof BRTPFServer && req instanceof TriplePatternRequest ) {
-			return new ExecOpRequestTPFatBRTPFServer( (TriplePatternRequest) req, (BRTPFServer) fm, collectExceptions );
+		else if ( fm instanceof BRTPFServer brtpf && req instanceof TriplePatternRequest tpreq ) {
+			return new ExecOpRequestTPFatBRTPFServer(tpreq, brtpf, collectExceptions, qpInfo);
 		}
-		else if ( fm instanceof BRTPFServer && req instanceof TriplePatternRequest ) {
-			return new ExecOpRequestBRTPF( (BindingsRestrictedTriplePatternRequest) req, (BRTPFServer) fm, collectExceptions );
+		else if ( fm instanceof BRTPFServer brtpf && req instanceof BindingsRestrictedTriplePatternRequest brtpreq ) {
+			return new ExecOpRequestBRTPF(brtpreq, brtpf, collectExceptions, qpInfo);
 		}
 		else
 			throw new IllegalArgumentException("Unsupported combination of federation member (type: " + fm.getClass().getName() + ") and request type (" + req.getClass().getName() + ")");

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpSymmetricHashJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpSymmetricHashJoin.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryplan.physical.impl;
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.BinaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpSymmetricHashJoin;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
 
@@ -29,10 +30,11 @@ public class PhysicalOpSymmetricHashJoin extends BaseForPhysicalOpBinaryJoin
 
     @Override
     public BinaryExecutableOp createExecOp( final boolean collectExceptions,
-                                            final ExpectedVariables ... inputVars ) {
+                                            final QueryPlanningInfo qpInfo,
+	                                        final ExpectedVariables ... inputVars ) {
         assert inputVars.length == 2;
 
-        return new ExecOpSymmetricHashJoin( inputVars[0], inputVars[1], collectExceptions );
+        return new ExecOpSymmetricHashJoin( inputVars[0], inputVars[1], collectExceptions, qpInfo );
     }
 
     @Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalToPhysicalPlanConverterImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/LogicalToPhysicalPlanConverterImpl.java
@@ -162,7 +162,7 @@ public class LogicalToPhysicalPlanConverterImpl implements LogicalToPhysicalPlan
 			if ( keepMultiwayJoins ) {
 				final NaryPhysicalOp pop = new BaseForPhysicalOpMultiwayJoin(lop) {
 					@Override public void visit(PhysicalPlanVisitor visitor) { throw new UnsupportedOperationException(); }
-					@Override public NaryExecutableOp createExecOp(boolean collectExceptions, ExpectedVariables... inputVars) { throw new UnsupportedOperationException(); }
+					@Override public NaryExecutableOp createExecOp(boolean collectExceptions, QueryPlanningInfo qpInfo, ExpectedVariables... inputVars) { throw new UnsupportedOperationException(); }
 				};
 				return PhysicalPlanFactory.createPlan(pop, qpInfo, children);
 			}

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/iterbased/ResultElementIterWithNullaryExecOpTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/iterbased/ResultElementIterWithNullaryExecOpTest.java
@@ -76,12 +76,12 @@ public class ResultElementIterWithNullaryExecOpTest
 		final List<SolutionMapping> list;
 
 		public NullaryExecutableOpForTest() {
-			super(false);
+			super(false, null);
 			list = null;
 		}
 
 		public NullaryExecutableOpForTest( final SolutionMapping[] elements ) {
-			super(false);
+			super(false, null);
 			list = Arrays.asList(elements);
 		}
 

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/iterbased/ResultElementIterWithUnaryExecOpTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/iterbased/ResultElementIterWithUnaryExecOpTest.java
@@ -107,7 +107,7 @@ public class ResultElementIterWithUnaryExecOpTest
 
 	protected static class UnaryExecutableOp2ForTest extends BaseForExecOps implements UnaryExecutableOp
 	{
-		public UnaryExecutableOp2ForTest() { super(false); }
+		public UnaryExecutableOp2ForTest() { super(false, null); }
 
 		@Override
 		public void process( final SolutionMapping inputSolMap,

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBinaryUnionTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBinaryUnionTest.java
@@ -49,7 +49,7 @@ public class ExecOpBinaryUnionTest extends TestsForUnionAlgorithms
 
 	@Override
 	protected BinaryExecutableOp createExecOpForTest() {
-		return new ExecOpBinaryUnion(false);
+		return new ExecOpBinaryUnion(false, null);
 	}
 	
 }

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinBRTPFTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinBRTPFTest.java
@@ -124,6 +124,7 @@ public class ExecOpBindJoinBRTPFTest extends TestsForTPAddAlgorithms<BRTPFServer
 		                                expectedVariables,
 		                                useOuterJoinSemantics,
 		                                ExecOpBindJoinBRTPF.DEFAULT_BATCH_SIZE,
-		                                false );
+		                                false,
+		                                null);
 	}
 }

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithBoundJoinTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithBoundJoinTest.java
@@ -167,6 +167,7 @@ public class ExecOpBindJoinSPARQLwithBoundJoinTest extends TestsForTPAddAlgorith
 		                                              expectedVariables,
 		                                              useOuterJoinSemantics,
 		                                              ExecOpBindJoinSPARQLwithBoundJoin.DEFAULT_BATCH_SIZE,
-		                                              false );
+		                                              false,
+		                                              null );
 	}
 }

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithFILTERTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithFILTERTest.java
@@ -124,7 +124,8 @@ public class ExecOpBindJoinSPARQLwithFILTERTest extends TestsForTPAddAlgorithms<
 		                                           expectedVariables,
 		                                           useOuterJoinSemantics,
 		                                           ExecOpBindJoinSPARQLwithFILTER.DEFAULT_BATCH_SIZE,
-		                                           false );
+		                                           false,
+		                                           null );
 	}
 
 }

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithUNIONTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithUNIONTest.java
@@ -123,7 +123,8 @@ public class ExecOpBindJoinSPARQLwithUNIONTest extends TestsForTPAddAlgorithms<S
 		                                          expectedVariables,
 		                                          useOuterJoinSemantics,
 		                                          ExecOpBindJoinSPARQLwithUNION.DEFAULT_BATCH_SIZE,
-		                                          false );
+		                                          false,
+		                                          null );
 	}
 
 }

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithVALUESTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithVALUESTest.java
@@ -124,7 +124,8 @@ public class ExecOpBindJoinSPARQLwithVALUESTest extends TestsForTPAddAlgorithms<
 		                                           expectedVariables,
 		                                           useOuterJoinSemantics,
 		                                           ExecOpBindJoinSPARQLwithVALUES.DEFAULT_BATCH_SIZE,
-		                                           false );
+		                                           false,
+		                                           null );
 	}
 
 }

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithVALUESorFILTERTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindJoinSPARQLwithVALUESorFILTERTest.java
@@ -243,7 +243,8 @@ public class ExecOpBindJoinSPARQLwithVALUESorFILTERTest extends TestsForTPAddAlg
 		                                                   expectedVariables,
 		                                                   useOuterJoinSemantics,
 		                                                   ExecOpBindJoinSPARQLwithVALUESorFILTER.DEFAULT_BATCH_SIZE,
-		                                                   false );
+		                                                   false,
+		                                                   null );
 	}
 
 }

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindTest.java
@@ -37,7 +37,7 @@ public class ExecOpBindTest
 
 		final Var v2 = Var.alloc("v2");
 		final Expr addOne = ExprUtils.parse("?v1 + 1");
-		final ExecOpBind op = new ExecOpBind(v2, addOne, false);
+		final ExecOpBind op = new ExecOpBind(v2, addOne, false, null);
 
 		final CollectingIntermediateResultElementSink sink = new CollectingIntermediateResultElementSink();
 
@@ -69,7 +69,7 @@ public class ExecOpBindTest
 
 		final Var v2 = Var.alloc("v2");
 		final Expr addOne = ExprUtils.parse("?v1 + 1");
-		final ExecOpBind op = new ExecOpBind(v2, addOne, false);
+		final ExecOpBind op = new ExecOpBind(v2, addOne, false, null);
 
 		final CollectingIntermediateResultElementSink sink = new CollectingIntermediateResultElementSink();
 
@@ -99,7 +99,7 @@ public class ExecOpBindTest
 
 		final Var v2 = Var.alloc("v2");
 		final Expr addOne = ExprUtils.parse("?v1 + 1"); //should fail for the URI
-		final ExecOpBind op = new ExecOpBind(v2, addOne, false);
+		final ExecOpBind op = new ExecOpBind(v2, addOne, false, null);
 
 		final CollectingIntermediateResultElementSink sink = new CollectingIntermediateResultElementSink();
 
@@ -130,7 +130,7 @@ public class ExecOpBindTest
 
 		final Var v2 = Var.alloc("v2");
 		final Expr addOne = ExprUtils.parse("?v1 + 1"); //should fail for the URI
-		final ExecOpBind op = new ExecOpBind(v2, addOne, false);
+		final ExecOpBind op = new ExecOpBind(v2, addOne, false, null);
 
 		final CollectingIntermediateResultElementSink sink = new CollectingIntermediateResultElementSink();
 
@@ -156,7 +156,7 @@ public class ExecOpBindTest
 		final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(v1, lit8);
 
 		final Expr addOne = ExprUtils.parse("?v1 + 1");
-		final ExecOpBind op = new ExecOpBind(v1, addOne, false);
+		final ExecOpBind op = new ExecOpBind(v1, addOne, false, null);
 
 		final CollectingIntermediateResultElementSink sink = new CollectingIntermediateResultElementSink();
 
@@ -178,7 +178,7 @@ public class ExecOpBindTest
 		veList.add( v2, ExprUtils.parse("?v1 + 1") );
 		veList.add( v3, ExprUtils.parse("?v1 - 1") );
 
-		final ExecOpBind op = new ExecOpBind(veList, false);
+		final ExecOpBind op = new ExecOpBind(veList, false, null);
 
 		final CollectingIntermediateResultElementSink sink = new CollectingIntermediateResultElementSink();
 
@@ -220,7 +220,7 @@ public class ExecOpBindTest
 		veList.add( v2, ExprUtils.parse("?v1 + 1") );
 		veList.add( v3, ExprUtils.parse("?v1 - 1") );
 
-		final ExecOpBind op = new ExecOpBind(veList, false);
+		final ExecOpBind op = new ExecOpBind(veList, false, null);
 
 		final CollectingIntermediateResultElementSink sink = new CollectingIntermediateResultElementSink();
 

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpFilterTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpFilterTest.java
@@ -41,7 +41,7 @@ public class ExecOpFilterTest
 		final SolutionMapping sol9 = SolutionMappingUtils.createSolutionMapping(x, value9);
 		final SolutionMapping sol12 = SolutionMappingUtils.createSolutionMapping(x, value12);
 
-		final ExecOpFilter filterLessThan10 = new ExecOpFilter(lessThan10, false);
+		final ExecOpFilter filterLessThan10 = new ExecOpFilter(lessThan10, false, null);
 		final ExecutionContext ctx = TestUtils.createExecContextForTests();
 		filterLessThan10.process(sol8, sink, ctx);
 		filterLessThan10.process(sol12, sink, ctx);  // 12 is processed before 9. This should not pass the filter. 9 should be after 8.
@@ -65,7 +65,7 @@ public class ExecOpFilterTest
 		final SolutionMapping sol8 = SolutionMappingUtils.createSolutionMapping(x, value8);
 		final SolutionMapping sol9 = SolutionMappingUtils.createSolutionMapping(y, value9);
 
-		final ExecOpFilter filterLessThan10 = new ExecOpFilter(lessThan10, false);
+		final ExecOpFilter filterLessThan10 = new ExecOpFilter(lessThan10, false, null);
 		final ExecutionContext ctx = TestUtils.createExecContextForTests();
 		filterLessThan10.process(sol8, sink, ctx);
 		filterLessThan10.process(sol9, sink, ctx);
@@ -93,7 +93,7 @@ public class ExecOpFilterTest
 		final SolutionMapping solNYE = SolutionMappingUtils.createSolutionMapping(x, dateNewYearsEve);
 		final SolutionMapping solNYD = SolutionMappingUtils.createSolutionMapping(x, dateNewYearsDay);
 
-		final ExecOpFilter filterAfter2019 = new ExecOpFilter(after2019, false);
+		final ExecOpFilter filterAfter2019 = new ExecOpFilter(after2019, false, null);
 		final ExecutionContext ctx = TestUtils.createExecContextForTests();
 		filterAfter2019.process(sol2020, sink, ctx);
 		filterAfter2019.process(sol2019, sink, ctx);
@@ -124,7 +124,7 @@ public class ExecOpFilterTest
 		final SolutionMapping sm3 = SolutionMappingUtils.createSolutionMapping(x, value12);
 		final SolutionMapping sm4 = SolutionMappingUtils.createSolutionMapping(x, value15);
 
-		final ExecOpFilter filterOp = new ExecOpFilter(exprs, false);
+		final ExecOpFilter filterOp = new ExecOpFilter(exprs, false, null);
 
 		final CollectingIntermediateResultElementSink sink = new CollectingIntermediateResultElementSink();		
 		final ExecutionContext ctx = TestUtils.createExecContextForTests();
@@ -168,7 +168,7 @@ public class ExecOpFilterTest
 		input2.add( SolutionMappingUtils.createSolutionMapping(x, value12) );
 		input2.add( SolutionMappingUtils.createSolutionMapping(x, value15) );
 
-		final ExecOpFilter filterOp = new ExecOpFilter(exprs, false);
+		final ExecOpFilter filterOp = new ExecOpFilter(exprs, false, null);
 
 		final CollectingIntermediateResultElementSink sink = new CollectingIntermediateResultElementSink();		
 		final ExecutionContext ctx = TestUtils.createExecContextForTests();
@@ -209,7 +209,7 @@ public class ExecOpFilterTest
 		input.add( SolutionMappingUtils.createSolutionMapping(x, value12) );
 		input.add( SolutionMappingUtils.createSolutionMapping(x, value15) );
 
-		final ExecOpFilter filterOp = new ExecOpFilter(exprs, false);
+		final ExecOpFilter filterOp = new ExecOpFilter(exprs, false, null);
 
 		final CollectingIntermediateResultElementSink sink = new CollectingIntermediateResultElementSink();		
 		final ExecutionContext ctx = TestUtils.createExecContextForTests();

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashJoinTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashJoinTest.java
@@ -82,7 +82,7 @@ public class ExecOpHashJoinTest extends TestsForInnerJoinAlgorithms
 	protected BinaryExecutableOp createExecOpForTest( final ExpectedVariables... inputVars ) {
 		assert inputVars.length == 2;
 
-		return new ExecOpHashJoin( inputVars[0], inputVars[1], false );
+		return new ExecOpHashJoin( inputVars[0], inputVars[1], false, null );
 	}
 
 }

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashRJoinTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashRJoinTest.java
@@ -82,7 +82,7 @@ public class ExecOpHashRJoinTest extends TestsForRightJoinAlgorithms
 	protected BinaryExecutableOp createExecOpForTest( final ExpectedVariables... inputVars ) {
 		assert inputVars.length == 2;
 
-		return new ExecOpHashRJoin( inputVars[0], inputVars[1], false );
+		return new ExecOpHashRJoin( inputVars[0], inputVars[1], false, null );
 	}
 
 }

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinSPARQLTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinSPARQLTest.java
@@ -64,6 +64,6 @@ public class ExecOpIndexNestedLoopsJoinSPARQLTest extends TestsForTPAddAlgorithm
 	                                                 final SPARQLEndpoint fm,
 	                                                 final ExpectedVariables expectedVariables,
 	                                                 final boolean useOuterJoinSemantics ) {
-		return new ExecOpIndexNestedLoopsJoinSPARQL(tp, fm, useOuterJoinSemantics, false);
+		return new ExecOpIndexNestedLoopsJoinSPARQL(tp, fm, useOuterJoinSemantics, false, null);
 	}
 }

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinTPFTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinTPFTest.java
@@ -98,6 +98,6 @@ public class ExecOpIndexNestedLoopsJoinTPFTest extends TestsForTPAddAlgorithms<T
 	                                                 final TPFServer fm,
 	                                                 final ExpectedVariables expectedVariables,
 	                                                 final boolean useOuterJoinSemantics ) {
-		return new ExecOpIndexNestedLoopsJoinTPF(tp, fm, useOuterJoinSemantics, false);
+		return new ExecOpIndexNestedLoopsJoinTPF(tp, fm, useOuterJoinSemantics, false, null);
 	}
 }

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpMultiwayUnionTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpMultiwayUnionTest.java
@@ -49,8 +49,7 @@ public class ExecOpMultiwayUnionTest extends TestsForUnionAlgorithms
 
 	@Override
 	protected NaryExecutableOp createExecOpForTest() {
-		// TODO Auto-generated method stub
-		return new ExecOpMultiwayUnion(2, false);
+		return new ExecOpMultiwayUnion(2, false, null);
 	}
 
 }

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpNaiveNestedLoopJoinTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpNaiveNestedLoopJoinTest.java
@@ -110,6 +110,6 @@ public class ExecOpNaiveNestedLoopJoinTest extends TestsForInnerJoinAlgorithms
 
 	@Override
 	protected BinaryExecutableOp createExecOpForTest( final ExpectedVariables... inputVars ) {
-		return new ExecOpNaiveNestedLoopsJoin(false);
+		return new ExecOpNaiveNestedLoopsJoin(false, null);
 	}
 }

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoinTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoinTest.java
@@ -1496,20 +1496,20 @@ public class ExecOpParallelMultiwayLeftJoinTest extends TestsForTPAddAlgorithms<
 		final LogicalOpRequest<?,?> reqOp1 = new LogicalOpRequest<>(fm1, req1);
 
 		if ( tp2 == null ) {
-			return new ExecOpParallelMultiwayLeftJoin( false, expectedInputVariables, reqOp1 );
+			return new ExecOpParallelMultiwayLeftJoin( false, null, expectedInputVariables, reqOp1 );
 		}
 
 		final TriplePatternRequest req2 = new TriplePatternRequestImpl(tp2);
 		final LogicalOpRequest<?,?> reqOp2 = new LogicalOpRequest<>(fm2, req2);
 
 		if ( tp3 == null ) {
-			return new ExecOpParallelMultiwayLeftJoin( false, expectedInputVariables, reqOp1, reqOp2 );
+			return new ExecOpParallelMultiwayLeftJoin( false, null, expectedInputVariables, reqOp1, reqOp2 );
 		}
 
 		final TriplePatternRequest req3 = new TriplePatternRequestImpl(tp3);
 		final LogicalOpRequest<?,?> reqOp3 = new LogicalOpRequest<>(fm3, req3);
 
-		return new ExecOpParallelMultiwayLeftJoin( false, expectedInputVariables, reqOp1, reqOp2, reqOp3 );
+		return new ExecOpParallelMultiwayLeftJoin( false, null, expectedInputVariables, reqOp1, reqOp2, reqOp3 );
 	}
 
 }

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestTPFatTPFServerTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestTPFatTPFServerTest.java
@@ -69,7 +69,8 @@ public class ExecOpRequestTPFatTPFServerTest extends ExecOpTestBase
 		final ExecOpRequestTPFatTPFServer op = new ExecOpRequestTPFatTPFServer(
 				new TriplePatternRequestImpl(tp),
 				getDBpediaTPFServer(),
-				false );
+				false,
+				null );
 
 		final CollectingIntermediateResultElementSink sink = new CollectingIntermediateResultElementSink();
 
@@ -99,7 +100,8 @@ public class ExecOpRequestTPFatTPFServerTest extends ExecOpTestBase
 		final ExecOpRequestTPFatTPFServer op = new ExecOpRequestTPFatTPFServer(
 				new TriplePatternRequestImpl(tp),
 				new TPFServerForTest(),
-				false );
+				false,
+				null );
 		final CollectingIntermediateResultElementSink sink = new CollectingIntermediateResultElementSink();
 
 		op.execute( sink, createExecContextForTests() );

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSymmetricHashJoinTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSymmetricHashJoinTest.java
@@ -82,7 +82,7 @@ public class ExecOpSymmetricHashJoinTest extends TestsForInnerJoinAlgorithms
 	protected BinaryExecutableOp createExecOpForTest( final ExpectedVariables... inputVars ) {
 		assert inputVars.length == 2;
 
-		return new ExecOpSymmetricHashJoin( inputVars[0], inputVars[1], false );
+		return new ExecOpSymmetricHashJoin( inputVars[0], inputVars[1], false, null );
 	}
 
 }


### PR DESCRIPTION
This is the next step following PRs #455 and #456.

This PR:
* extends the `ExecutableOperator` interface with a method to obtain a `QueryPlanningInfo` object for the plan rooted in each such operator,
* extends `QueryPlanningInfo` objects to be `Stats` objects,
* adds these `QueryPlanningInfo` objects to the `Stats` object created by each executable operator (to have them printed when printing the stats).