### PR TITLE
Add executable plan printer

### DIFF
--- a/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunQueryWithoutSrcSel.java
+++ b/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunQueryWithoutSrcSel.java
@@ -113,6 +113,7 @@ public class RunQueryWithoutSrcSel extends CmdARQ
 			.withSourceAssignmentPrinter( modPlanPrinting.getSourceAssignmentPrinter() )
 			.withLogicalPlanPrinter( modPlanPrinting.getLogicalPlanPrinter() )
 			.withPhysicalPlanPrinter( modPlanPrinting.getPhysicalPlanPrinter() )
+			.withExecutablePlanPrinter( modPlanPrinting.getExecutablePlanPrinter() )
 			.setSkipExecution( contains(argSkipExecution) );
 
 		if( modEngineConfig.getConfDescr() != null ){

--- a/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/modules/ModPlanPrinting.java
+++ b/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/modules/ModPlanPrinting.java
@@ -5,8 +5,10 @@ import org.apache.jena.cmd.CmdArgModule;
 import org.apache.jena.cmd.CmdGeneral;
 import org.apache.jena.cmd.ModBase;
 
+import se.liu.ida.hefquin.engine.queryplan.utils.ExecutablePlanPrinter;
 import se.liu.ida.hefquin.engine.queryplan.utils.LogicalPlanPrinter;
 import se.liu.ida.hefquin.engine.queryplan.utils.PhysicalPlanPrinter;
+import se.liu.ida.hefquin.engine.queryplan.utils.TextBasedExecutablePlanPrinterImpl;
 import se.liu.ida.hefquin.engine.queryplan.utils.TextBasedLogicalPlanPrinterImpl;
 import se.liu.ida.hefquin.engine.queryplan.utils.TextBasedPhysicalPlanPrinterImpl;
 
@@ -15,10 +17,12 @@ public class ModPlanPrinting extends ModBase
 	protected final ArgDecl argPrintSrcAssignment  = new ArgDecl(ArgDecl.NoValue, "printSourceAssignment");
 	protected final ArgDecl argPrintLogicalPlan    = new ArgDecl(ArgDecl.NoValue, "printLogicalPlan");
 	protected final ArgDecl argPrintPhysicalPlan   = new ArgDecl(ArgDecl.NoValue, "printPhysicalPlan");
+	protected final ArgDecl argPrintExecutablePlan = new ArgDecl(ArgDecl.NoValue, "printExecutablePlan");
 
 	protected LogicalPlanPrinter srcasgPrinter = null;
 	protected LogicalPlanPrinter lplanPrinter = null;
 	protected PhysicalPlanPrinter pplanPrinter = null;
+	protected ExecutablePlanPrinter eplanPrinter = null;
 
 	@Override
 	public void registerWith( final CmdGeneral cmdLine ) {
@@ -26,6 +30,7 @@ public class ModPlanPrinting extends ModBase
 		cmdLine.add(argPrintSrcAssignment, "--printSourceAssignment", "Print out the source assignment used as input to the query optimization");
 		cmdLine.add(argPrintLogicalPlan, "--printLogicalPlan", "Print out the logical plan produced by the logical query optimization");
 		cmdLine.add(argPrintPhysicalPlan, "--printPhysicalPlan", "Print out the physical plan produced by the physical query optimization and used for the query execution");
+		cmdLine.add(argPrintExecutablePlan, "--printExecutablePlan", "Print out the executable plan");
 	}
 
 	@Override
@@ -38,6 +43,9 @@ public class ModPlanPrinting extends ModBase
 
 		if ( cmdLine.contains(argPrintPhysicalPlan) )
 			pplanPrinter = new TextBasedPhysicalPlanPrinterImpl();
+
+		if ( cmdLine.contains(argPrintExecutablePlan) )
+			eplanPrinter = new TextBasedExecutablePlanPrinterImpl();
 	}
 
 	public LogicalPlanPrinter getSourceAssignmentPrinter() { return srcasgPrinter; }
@@ -45,4 +53,6 @@ public class ModPlanPrinting extends ModBase
 	public LogicalPlanPrinter getLogicalPlanPrinter() { return lplanPrinter; }
 
 	public PhysicalPlanPrinter getPhysicalPlanPrinter() { return pplanPrinter; }
+
+	public ExecutablePlanPrinter getExecutablePlanPrinter() { return eplanPrinter; }
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/HeFQUINEngineBuilder.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/HeFQUINEngineBuilder.java
@@ -12,6 +12,7 @@ import org.apache.jena.sparql.engine.main.OpExecutorFactory;
 import org.apache.jena.sparql.engine.main.QC;
 
 import se.liu.ida.hefquin.engine.HeFQUINEngineConfigReader.Context;
+import se.liu.ida.hefquin.engine.queryplan.utils.ExecutablePlanPrinter;
 import se.liu.ida.hefquin.engine.queryplan.utils.LogicalPlanPrinter;
 import se.liu.ida.hefquin.engine.queryplan.utils.PhysicalPlanPrinter;
 import se.liu.ida.hefquin.engine.queryproc.QueryProcessor;
@@ -35,6 +36,7 @@ public class HeFQUINEngineBuilder
 	private LogicalPlanPrinter srcasgPrinter = null;
 	private LogicalPlanPrinter lplanPrinter = null;
 	private PhysicalPlanPrinter pplanPrinter = null;
+	private ExecutablePlanPrinter eplanPrinter = null;
 
 	private final int DEFAULT_THREAD_POOL_SIZE = 10;
 	private final String DEFAULT_CONF_DESCR_FILE = "config/DefaultConfDescr.ttl";
@@ -118,6 +120,17 @@ public class HeFQUINEngineBuilder
 	}
 
 	/**
+	 * Sets the executable plan printer to be used by the engine.
+	 *
+	 * @param printer a executable plan printer
+	 * @return this builder instance for method chaining
+	 */
+	public HeFQUINEngineBuilder withExecutablePlanPrinter( final ExecutablePlanPrinter printer ) {
+		this.eplanPrinter = printer;
+		return this;
+	}
+
+	/**
 	 * Sets the source assignment printer to be used by the engine.
 	 *
 	 * @param printer a logical plan printer to be used when printing a source
@@ -185,6 +198,7 @@ public class HeFQUINEngineBuilder
 			public LogicalPlanPrinter getSourceAssignmentPrinter() { return srcasgPrinter; }
 			public LogicalPlanPrinter getLogicalPlanPrinter() { return lplanPrinter; }
 			public PhysicalPlanPrinter getPhysicalPlanPrinter() { return pplanPrinter; }
+			public ExecutablePlanPrinter getExecutablePlanPrinter() { return eplanPrinter; }
 		};
 
 		// init engine

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/HeFQUINEngineConfigReader.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/HeFQUINEngineConfigReader.java
@@ -18,6 +18,7 @@ import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.vocabulary.RDF;
 
+import se.liu.ida.hefquin.engine.queryplan.utils.ExecutablePlanPrinter;
 import se.liu.ida.hefquin.engine.queryplan.utils.LogicalPlanPrinter;
 import se.liu.ida.hefquin.engine.queryplan.utils.PhysicalPlanPrinter;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionEngine;
@@ -115,6 +116,9 @@ public class HeFQUINEngineConfigReader
 
 		/** may be <code>null</code> if physical plan printing is not requested by the user */
 		PhysicalPlanPrinter getPhysicalPlanPrinter();
+
+		/** may be <code>null</code> if executable plan printing is not requested by the user */
+		ExecutablePlanPrinter getExecutablePlanPrinter();
 	}
 
 
@@ -197,7 +201,8 @@ public class HeFQUINEngineConfigReader
 		return new QueryPlannerImpl( spl, lopt, popt,
 		                             ctx.getSourceAssignmentPrinter(),
 		                             ctx.getLogicalPlanPrinter(),
-		                             ctx.getPhysicalPlanPrinter() );
+		                             ctx.getPhysicalPlanPrinter(),
+		                             ctx.getExecutablePlanPrinter() );
 	}
 
 	public SourcePlanner readSourcePlanner( final Resource qplRsrc, final ExtendedContext ctx ) {
@@ -466,6 +471,9 @@ public class HeFQUINEngineConfigReader
 
 		@Override
 		public PhysicalPlanPrinter getPhysicalPlanPrinter() { return ctx.getPhysicalPlanPrinter(); }
+
+		@Override
+		public ExecutablePlanPrinter getExecutablePlanPrinter() { return ctx.getExecutablePlanPrinter(); }
 	}
 
 	protected class ExtendedContextImpl2 implements ExtendedContext {
@@ -531,6 +539,9 @@ public class HeFQUINEngineConfigReader
 
 		@Override
 		public PhysicalPlanPrinter getPhysicalPlanPrinter() { return ctx.getPhysicalPlanPrinter(); }
+
+		@Override
+		public ExecutablePlanPrinter getExecutablePlanPrinter() { return ctx.getExecutablePlanPrinter(); }
 	}
 
 	protected QueryProcContext createQueryProcContext( final Context ctx,

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/ExecutablePlanPrinter.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/ExecutablePlanPrinter.java
@@ -1,0 +1,17 @@
+package se.liu.ida.hefquin.engine.queryplan.utils;
+
+import java.io.PrintStream;
+
+import se.liu.ida.hefquin.engine.queryplan.executable.ExecutablePlan;
+
+/**
+ * Implementations of this interface provide the functionality
+ * to print executable plans in some way.
+ */
+public interface ExecutablePlanPrinter
+{
+	/**
+	 * Prints the given plan to the given stream.
+	 */
+	void print( ExecutablePlan plan, PrintStream out );
+}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedExecutablePlanPrinterImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedExecutablePlanPrinterImpl.java
@@ -18,6 +18,9 @@ public class TextBasedExecutablePlanPrinterImpl extends BaseForTextBasedPlanPrin
 		if ( plan instanceof PushBasedExecutablePlanImpl p ) {
 			print(p, out);
 		}
+		else {
+			throw new IllegalArgumentException("Unsupported type of executable plan (" + plan.getClass().getName() + ").");
+		}
 	}
 
 	public void print( final PushBasedExecutablePlanImpl plan, final PrintStream out ) {

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedExecutablePlanPrinterImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedExecutablePlanPrinterImpl.java
@@ -1,0 +1,13 @@
+package se.liu.ida.hefquin.engine.queryplan.utils;
+
+import java.io.PrintStream;
+import se.liu.ida.hefquin.engine.queryplan.executable.ExecutablePlan;
+
+public class TextBasedExecutablePlanPrinterImpl extends BaseForTextBasedPlanPrinters
+		implements ExecutablePlanPrinter
+{	
+	@Override
+	public void print( final ExecutablePlan plan, final PrintStream out ) {
+		out.print( "Not implemented" );
+	}
+}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedExecutablePlanPrinterImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedExecutablePlanPrinterImpl.java
@@ -1,13 +1,93 @@
 package se.liu.ida.hefquin.engine.queryplan.utils;
 
 import java.io.PrintStream;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+
+import se.liu.ida.hefquin.base.utils.Stats;
+import se.liu.ida.hefquin.engine.queryplan.executable.ExecutableOperatorStats;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutablePlan;
+import se.liu.ida.hefquin.engine.queryplan.executable.ExecutablePlanStats;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBinaryUnion;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBind;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinBRTPF;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithBoundJoin;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithFILTER;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithUNION;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithVALUES;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithVALUESorFILTER;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpFilter;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpGlobalToLocal;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpHashJoin;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpHashRJoin;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpIndexNestedLoopsJoinBRTPF;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpIndexNestedLoopsJoinSPARQL;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpIndexNestedLoopsJoinTPF;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpLocalToGlobal;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpMultiwayUnion;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpNaiveNestedLoopsJoin;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpParallelMultiwayLeftJoin;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpRequestBRTPF;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpRequestSPARQL;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpRequestTPFatBRTPFServer;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpRequestTPFatTPFServer;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpSymmetricHashJoin;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.pushbased.PushBasedExecutablePlanImpl;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.pushbased.PushBasedPlanThread;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.pushbased.StatsOfPushBasedExecutablePlan;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.pushbased.StatsOfPushBasedPlanThread;
+import se.liu.ida.hefquin.engine.queryproc.ExecutionException;
 
 public class TextBasedExecutablePlanPrinterImpl extends BaseForTextBasedPlanPrinters
 		implements ExecutablePlanPrinter
 {	
+	protected String parentIndent = "";
+
 	@Override
 	public void print( final ExecutablePlan plan, final PrintStream out ) {
-		out.print( "Not implemented" );
+		if ( plan instanceof PushBasedExecutablePlanImpl p ) {
+			print(p, out);
+		}
+	}
+
+	public void print( final PushBasedExecutablePlanImpl plan, final PrintStream out ) {
+		final StatsOfPushBasedExecutablePlan planStats = (StatsOfPushBasedExecutablePlan) plan.getStats();
+		@SuppressWarnings("unchecked")
+		List<Stats> statsOfTasks = (List<Stats>) planStats.getEntry("statsOfTasks");
+
+		int i = 0;
+		for(final Stats statsOfTask : statsOfTasks){
+			final ExecutableOperatorStats opStats = (ExecutableOperatorStats) statsOfTask.getEntry("operatorStats");
+			print(opStats, i, out);
+			i++;
+		}
+	}
+	
+	public void print( final ExecutableOperatorStats stats,
+	                   final int planLevel,
+	                   final PrintStream out ) {
+		final String indentLevelString = getIndentLevelString(0, planLevel, 1, parentIndent);
+		final String indentLevelStringForOpDetail = getIndentLevelStringForDetail(0, planLevel, 1, 0, indentLevelString);
+
+		// Print the first line prefixed with indentLevelString,
+		// prefix remaining line with indentLevelStringForOpDetail
+		boolean first = true;
+		for ( String line : stats.getShortString().split( "\\R", -1 ) ) {
+			if ( first ) {
+				out.print(indentLevelString);
+				out.print(line);
+				out.print(System.lineSeparator());
+				first = false;
+			} else {
+				out.print(indentLevelStringForOpDetail);
+				out.print(line);
+				out.print(System.lineSeparator());
+			}
+		}
+
+		parentIndent = indentLevelString;
 	}
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedExecutablePlanPrinterImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedExecutablePlanPrinterImpl.java
@@ -1,45 +1,12 @@
 package se.liu.ida.hefquin.engine.queryplan.utils;
 
 import java.io.PrintStream;
-import java.util.Iterator;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.concurrent.Future;
-import java.util.concurrent.RejectedExecutionException;
-
 import se.liu.ida.hefquin.base.utils.Stats;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutableOperatorStats;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutablePlan;
-import se.liu.ida.hefquin.engine.queryplan.executable.ExecutablePlanStats;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBinaryUnion;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBind;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinBRTPF;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithBoundJoin;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithFILTER;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithUNION;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithVALUES;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpBindJoinSPARQLwithVALUESorFILTER;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpFilter;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpGlobalToLocal;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpHashJoin;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpHashRJoin;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpIndexNestedLoopsJoinBRTPF;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpIndexNestedLoopsJoinSPARQL;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpIndexNestedLoopsJoinTPF;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpLocalToGlobal;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpMultiwayUnion;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpNaiveNestedLoopsJoin;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpParallelMultiwayLeftJoin;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpRequestBRTPF;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpRequestSPARQL;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpRequestTPFatBRTPFServer;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpRequestTPFatTPFServer;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpSymmetricHashJoin;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.pushbased.PushBasedExecutablePlanImpl;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.pushbased.PushBasedPlanThread;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.pushbased.StatsOfPushBasedExecutablePlan;
-import se.liu.ida.hefquin.engine.queryplan.executable.impl.pushbased.StatsOfPushBasedPlanThread;
-import se.liu.ida.hefquin.engine.queryproc.ExecutionException;
 
 public class TextBasedExecutablePlanPrinterImpl extends BaseForTextBasedPlanPrinters
 		implements ExecutablePlanPrinter

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedExecutablePlanPrinterImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedExecutablePlanPrinterImpl.java
@@ -26,7 +26,7 @@ public class TextBasedExecutablePlanPrinterImpl extends BaseForTextBasedPlanPrin
 	public void print( final PushBasedExecutablePlanImpl plan, final PrintStream out ) {
 		final StatsOfPushBasedExecutablePlan planStats = (StatsOfPushBasedExecutablePlan) plan.getStats();
 		@SuppressWarnings("unchecked")
-		List<Stats> statsOfTasks = (List<Stats>) planStats.getEntry("statsOfTasks");
+		final List<Stats> statsOfTasks = (List<Stats>) planStats.getEntry("statsOfTasks");
 
 		int i = 0;
 		for(final Stats statsOfTask : statsOfTasks){

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/QueryPlanner.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/QueryPlanner.java
@@ -3,6 +3,7 @@ package se.liu.ida.hefquin.engine.queryproc;
 import se.liu.ida.hefquin.base.query.Query;
 import se.liu.ida.hefquin.base.utils.Pair;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
+import se.liu.ida.hefquin.engine.queryplan.utils.ExecutablePlanPrinter;
 
 public interface QueryPlanner
 {
@@ -13,4 +14,6 @@ public interface QueryPlanner
 	LogicalOptimizer getLogicalOptimizer();
 
 	PhysicalOptimizer getPhysicalOptimizer();
+
+	ExecutablePlanPrinter getExecutablePlanPrinter();
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/QueryProcessorImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/QueryProcessorImpl.java
@@ -79,6 +79,11 @@ public class QueryProcessorImpl implements QueryProcessor
 		else {
 			prg = planCompiler.compile(qepAndStats.object1);
 
+			if ( planner.getExecutablePlanPrinter() != null ) {
+				System.out.println("--------- Executable Plan ---------");
+				planner.getExecutablePlanPrinter().print( prg, System.out );
+			}
+
 			t3 = System.currentTimeMillis();
 			execStats = execEngine.execute(prg, resultSink);
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/planning/QueryPlannerImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/planning/QueryPlannerImpl.java
@@ -4,6 +4,7 @@ import se.liu.ida.hefquin.base.query.Query;
 import se.liu.ida.hefquin.base.utils.Pair;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
+import se.liu.ida.hefquin.engine.queryplan.utils.ExecutablePlanPrinter;
 import se.liu.ida.hefquin.engine.queryplan.utils.LogicalPlanPrinter;
 import se.liu.ida.hefquin.engine.queryplan.utils.PhysicalPlanPrinter;
 import se.liu.ida.hefquin.engine.queryproc.LogicalOptimizer;
@@ -26,13 +27,15 @@ public class QueryPlannerImpl implements QueryPlanner
 	protected final LogicalPlanPrinter srcasgPrinter;
 	protected final LogicalPlanPrinter lplanPrinter;
 	protected final PhysicalPlanPrinter pplanPrinter;
+	protected final ExecutablePlanPrinter eplanPrinter;
 
 	public QueryPlannerImpl( final SourcePlanner sourcePlanner,
 	                         final LogicalOptimizer loptimizer, // may be null
 	                         final PhysicalOptimizer poptimizer,
 	                         final LogicalPlanPrinter srcasgPrinter,     // may be null
 	                         final LogicalPlanPrinter lplanPrinter,      // may be null
-	                         final PhysicalPlanPrinter pplanPrinter ) {  // may be null
+	                         final PhysicalPlanPrinter pplanPrinter,     // may be null
+	                         final ExecutablePlanPrinter eplanPrinter ) {  // may be null
 		assert sourcePlanner != null;
 		assert poptimizer != null;
 
@@ -42,6 +45,7 @@ public class QueryPlannerImpl implements QueryPlanner
 		this.srcasgPrinter = srcasgPrinter;
 		this.lplanPrinter = lplanPrinter;
 		this.pplanPrinter = pplanPrinter;
+		this.eplanPrinter = eplanPrinter;
 	}
 
 	@Override
@@ -96,6 +100,11 @@ public class QueryPlannerImpl implements QueryPlanner
 		                                                               planAndStats.object2 );
 
 		return new Pair<>(planAndStats.object1, myStats);
+	}
+
+	@Override
+	public ExecutablePlanPrinter getExecutablePlanPrinter() {
+		return eplanPrinter;
 	}
 
 }

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/HeFQUINEngineConfigReaderTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/HeFQUINEngineConfigReaderTest.java
@@ -14,6 +14,7 @@ import org.apache.jena.riot.RDFParser;
 import org.apache.jena.riot.RDFParserBuilder;
 import org.junit.Test;
 
+import se.liu.ida.hefquin.engine.queryplan.utils.ExecutablePlanPrinter;
 import se.liu.ida.hefquin.engine.queryplan.utils.LogicalPlanPrinter;
 import se.liu.ida.hefquin.engine.queryplan.utils.PhysicalPlanPrinter;
 import se.liu.ida.hefquin.engine.queryproc.QueryProcContext;
@@ -308,6 +309,9 @@ public class HeFQUINEngineConfigReaderTest
 			public PhysicalPlanPrinter getPhysicalPlanPrinter() { throw new UnsupportedOperationException(); }
 
 			@Override
+			public ExecutablePlanPrinter getExecutablePlanPrinter() { throw new UnsupportedOperationException(); }
+
+			@Override
 			public void complete( final CostModel cm ) { throw new UnsupportedOperationException(); }
 
 			@Override
@@ -372,6 +376,9 @@ public class HeFQUINEngineConfigReaderTest
 
 			@Override
 			public PhysicalPlanPrinter getPhysicalPlanPrinter() { throw new UnsupportedOperationException(); }
+
+			@Override
+			public ExecutablePlanPrinter getExecutablePlanPrinter() { throw new UnsupportedOperationException(); }
 
 			@Override
 			public void complete( final CostModel cm ) { throw new UnsupportedOperationException(); }

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/QueryProcessorImplTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/QueryProcessorImplTest.java
@@ -374,7 +374,7 @@ public class QueryProcessorImplTest extends EngineTestBase
 		};
 
 		final PhysicalOptimizer poptimizer = new PhysicalOptimizerWithoutOptimization(l2pConverter);
-		final QueryPlanner planner = new QueryPlannerImpl(sourcePlanner, loptimizer, poptimizer, null, null, null);
+		final QueryPlanner planner = new QueryPlannerImpl(sourcePlanner, loptimizer, poptimizer, null, null, null,  null);
 		final QueryPlanCompiler planCompiler = new
 				//IteratorBasedQueryPlanCompilerImpl(ctxt);
 				//PullBasedQueryPlanCompilerImpl(ctxt);


### PR DESCRIPTION
This PR provides a first implementation of a text based printer for executable plans (see https://github.com/LiUSemWeb/HeFQUIN/issues/27).

The printer currently supports only `PushBasedExecutablePlanImpl`. Also note that the `toString()` methods have not yet been implemented for the executable operators (see https://github.com/LiUSemWeb/HeFQUIN/issues/210), which means the printer defaults to printing class reference + hash code.

@hartig, I was also experimenting with implementing the visitor pattern for executable plans. This would provide more control over how the operators are actually printed, but the executable operators aren't available from the tasks in the current code. Thoughts? 
