### PR TITLE
Reimplement the printers for logical and for physical plans

### DIFF
--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/info/QueryPlanProperty.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/info/QueryPlanProperty.java
@@ -150,4 +150,19 @@ public class QueryPlanProperty
 	 */
 	public Quality getQuality() { return quality; }
 
+	@Override
+	public String toString() {
+		// Note that the query plan printer relies on this implementation.
+		final StringBuilder b = new StringBuilder( type.name + " = " + value );
+		switch ( quality ) {
+		case PURE_GUESS:                   b.append(" (pure guess)"); break;
+		case MIN_OR_MAX_POSSIBLE:          b.append(" (min or max possible)"); break;
+		case ESTIMATE_BASED_ON_ESTIMATES:  b.append(" (estimate based on estimates)"); break;
+		case ESTIMATE_BASED_ON_ACCURATES:  b.append(" (estimate based on accurates)"); break;
+		case DIRECT_ESTIMATE:              b.append(" (direct estimate)"); break;
+		case ACCURATE:                     b.append(" (accurate)"); break;
+		}
+
+		return b.toString();
+	}
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/PhysicalPlanWithNaryRoot.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/PhysicalPlanWithNaryRoot.java
@@ -1,7 +1,15 @@
 package se.liu.ida.hefquin.engine.queryplan.physical;
 
+import java.util.Iterator;
+
 public interface PhysicalPlanWithNaryRoot extends PhysicalPlan
 {
 	@Override
 	NaryPhysicalOp getRootOperator();
+
+	/**
+	 * Convenience method that always should return an iterator over the same
+	 * sub-plans that can be accessed via {@link PhysicalPlan#getSubPlan(int)}.
+	 */
+	Iterator<PhysicalPlan> getSubPlans();
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalPlanWithNaryRootImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalPlanWithNaryRootImpl.java
@@ -134,6 +134,11 @@ public class PhysicalPlanWithNaryRootImpl extends BaseForQueryPlan
 	}
 
 	@Override
+	public Iterator<PhysicalPlan> getSubPlans() {
+		return subPlans.iterator();
+	}
+
+	@Override
 	public NaryPhysicalOp getRootOperator() {
 		return rootOp;
 	}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/BaseForTextBasedPlanPrinters.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/BaseForTextBasedPlanPrinters.java
@@ -1,315 +1,165 @@
 package se.liu.ida.hefquin.engine.queryplan.utils;
 
 import java.io.PrintStream;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
 import org.apache.jena.sparql.core.Var;
-import org.apache.jena.sparql.expr.Expr;
-import org.apache.jena.sparql.expr.ExprList;
-import org.apache.jena.sparql.util.ExprUtils;
 
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
+import se.liu.ida.hefquin.base.utils.PlanPrinter.PrintablePlan;
 import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanProperty;
 import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
-import se.liu.ida.hefquin.engine.queryplan.logical.LogicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanVisitor;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.*;
-import se.liu.ida.hefquin.federation.FederationMember;
 
 public class BaseForTextBasedPlanPrinters
 {
-	// The string represents '|'.
-	protected static String singleBase = "\u2502";
-	// The string represents '|   '.
-	protected static String levelIndentBase = "\u2502   ";
-	// The string represents '├── '.
-	protected static String nonLastChildIndentBase = "\u251C\u2500\u2500 ";
-	// The string represents '└── '.
-	protected static String lastChildIndentBase = "\u2514\u2500\u2500 ";
-	protected static String spaceBase = "    ";
+	public static final ShortNameCreator snc = new ShortNameCreator();
 
-	protected String getIndentLevelString( final int planNumber,
-	                                       final int planLevel,
-	                                       final int numberOfSiblings,
-	                                       final String upperRootOpIndentString ) {
-		if ( planLevel == 0 ) {
-			// This is only for the root operator of the overall plan to be printed.
-			return "";
+	/**
+	 * An extension of {@link PrintablePlan} objects that makes it possible
+	 * to record the graph pattern of the root operator of the plan (if any)
+	 * as well as a full-string representation of that pattern. We use the
+	 * latter only for cases in which the full-string representation of the
+	 * pattern was too long to be put as a root-operator property (in which
+	 * case the property that we put is only a shortened version of the full
+	 * string).
+	 */
+	public static class ExtPrintablePlan extends PrintablePlan {
+		public final SPARQLGraphPattern graphPattern;
+		public final String fullStringForGraphPattern;
+
+		public ExtPrintablePlan( final String rootOpAsString,
+		                         final List<String> rootOpProperties,
+		                         final List<PrintablePlan> subPlans,
+		                         final SPARQLGraphPattern graphPattern,
+		                         final String fullStringForGraphPattern ) {
+			super(rootOpAsString, rootOpProperties, subPlans);
+			this.graphPattern = graphPattern;
+			this.fullStringForGraphPattern = fullStringForGraphPattern;
 		}
-
-		if ( upperRootOpIndentString.isEmpty() ) {
-			if ( planNumber < numberOfSiblings-1 ) {
-				return nonLastChildIndentBase;
-			}
-			else {
-				return lastChildIndentBase;
-			}
-		}
-
-		if ( upperRootOpIndentString.endsWith(nonLastChildIndentBase) ) {
-			final String indentLevelString = upperRootOpIndentString.substring( 0, upperRootOpIndentString.length() - nonLastChildIndentBase.length() ) + levelIndentBase;
-
-			if ( planNumber < numberOfSiblings-1 ) {
-				return indentLevelString + nonLastChildIndentBase;
-			}
-			else {
-				return indentLevelString + lastChildIndentBase;
-			}
-		}
-
-		if ( upperRootOpIndentString.endsWith(lastChildIndentBase) ) {
-			final String indentLevelString = upperRootOpIndentString.substring( 0, upperRootOpIndentString.length() - lastChildIndentBase.length() ) + spaceBase;
-			if ( planNumber < numberOfSiblings-1 ) {
-				return indentLevelString + nonLastChildIndentBase;
-			}
-			else {
-				return indentLevelString + lastChildIndentBase;
-			}
-		}
-
-		return "";
 	}
 
-	protected String getIndentLevelStringForDetail( final int planNumber,
-	                                                final int planLevel,
-	                                                final int numberOfSiblings,
-	                                                final int numberOfSubPlans,
-	                                                final String indentLevelString ) {
-		if ( planLevel == 0 ) {
-			if ( numberOfSubPlans > 0 ) {
-				return "";
-			}
-			else {
-				return spaceBase;
-			}
-		}
-
-		if ( indentLevelString == "") {
-			return spaceBase;
-		}
-		else if ( indentLevelString.endsWith(nonLastChildIndentBase) ) {
-			return indentLevelString.substring( 0, indentLevelString.length() - nonLastChildIndentBase.length() ) + levelIndentBase;
-		}
-		else if ( indentLevelString.endsWith(lastChildIndentBase) ) {
-			return indentLevelString.substring( 0, indentLevelString.length() - lastChildIndentBase.length() ) + spaceBase;
-		}
-
-		return "";
+	public void printFullStringsForGraphPatterns( final ExtPrintablePlan pp,
+	                                              final PrintStream out ) {
+		printFullStringsForGraphPatterns( pp, new HashSet<>(), out );
 	}
 
-	protected static void printFederationMember( final FederationMember fm,
-	                                             final String indentString,
-	                                             final PrintStream out ) {
-		out.append( indentString );
-		out.append( "  - fm (" + fm.getID() + ") " + fm.toString() );
-		out.append( System.lineSeparator() );
-	}
+	public void printFullStringsForGraphPatterns( final ExtPrintablePlan pp,
+	                                              final Set<SPARQLGraphPattern> alreadyPrinted,
+	                                              final PrintStream out ) {
+		if (    pp.fullStringForGraphPattern != null
+		     && ! alreadyPrinted.contains(pp.graphPattern) ) {
+			alreadyPrinted.add(pp.graphPattern);
 
-	protected static String printSPARQLGraphPattern( final SPARQLGraphPattern gp,
-	                                                 final String indentString,
-	                                                 final PrintStream out ) {
-		final String gpAsString = gp.toStringForPlanPrinters();
-		final String gpAsString2 = gpAsString.replaceAll( "\\s+", " ");
-		final String gpAsShortString;
-		if ( gpAsString2.length() > 88 )
-			gpAsShortString = gpAsString2.substring(0, 40) + "[...]" + gpAsString2.substring( gpAsString2.length()-40 );
-		else
-			gpAsShortString = gpAsString2;
-
-		out.append( indentString );
-		out.append( "  - pattern (" + gp.hashCode() +  "): " + gpAsShortString );
-		out.append( System.lineSeparator() );
-
-		return gpAsString;
-	}
-
-	protected static void printExpressions( final ExprList exprs,
-	                                        final String indentString,
-	                                        final PrintStream out ) {
-		final int numberOfExprs = exprs.size();
-		if ( numberOfExprs == 1 ) {
-			final Expr expr = exprs.get(0);
-			out.append( indentString + "  - expression: " + ExprUtils.fmtSPARQL(expr) );
-			out.append( System.lineSeparator() );
+			out.println();
+			out.print( "--- pattern (" + pp.graphPattern.hashCode() + ") " );
+			out.print( pp.graphPattern.getClass().getName() );
+			out.println();
+			out.println( pp.fullStringForGraphPattern );
 		}
-		else {
-			out.append( indentString + "  - number of expressions: " + numberOfExprs );
-			out.append( System.lineSeparator() );
-			for ( int i = 0; i < numberOfExprs; i++ ) {
-				final Expr expr = exprs.get(i);
-				out.append( indentString + "  - expression " + (i+1) + ": " + ExprUtils.fmtSPARQL(expr) );
-				out.append( System.lineSeparator() );
+
+		if ( pp.subPlans != null ) {
+			for ( final PrintablePlan sub : pp.subPlans ) {
+				printFullStringsForGraphPatterns( (ExtPrintablePlan) sub,
+				                                  alreadyPrinted,
+				                                  out );
 			}
 		}
 	}
 
-	protected static void printLogicalOperatorBase( final LogicalOperator lop,
-	                                                final String indentString,
-	                                                final PrintStream out,
-	                                                final OpNamePrinter np ) {
-		out.append( indentString );
-		lop.visit(np);
-		out.append( " (" + lop.getID()  + ")" );
+	protected void addPropStrings( final ExpectedVariables expVars,
+	                               final List<String> propStrings ) {
+		if ( expVars == null ) {
+			propStrings.add( "expected variables: ?" );
+			return;
+		}
+
+		String certainVarsStr = "certain variables: ";
+		final Iterator<Var> itC = expVars.getCertainVariables().iterator();
+		certainVarsStr += itC.hasNext() ? itC.next().toString() : "none";
+		while ( itC.hasNext() ) {
+			certainVarsStr += ", " + itC.next().toString();
+		}
+
+		String possibleVarsStr = "possible variables: ";
+		final Iterator<Var> itP = expVars.getPossibleVariables().iterator();
+		possibleVarsStr += itP.hasNext() ? itP.next().toString() : "none";
+		while ( itP.hasNext() ) {
+			possibleVarsStr += ", " + itP.next().toString();
+		}
+
+		propStrings.add(certainVarsStr);
+		propStrings.add(possibleVarsStr);
 	}
 
-	protected static class OpNamePrinter implements LogicalPlanVisitor {
-		protected final PrintStream out;
-		public OpNamePrinter( final PrintStream out ) { this.out = out; }
+	protected void addPropStrings( final QueryPlanningInfo qpInfo,
+	                               final List<String> propStrings ) {
+		if ( qpInfo == null || qpInfo.isEmpty() ) {
+			propStrings.add("query planning info: none" );
+			return;
+		}
 
-		@Override
-		public void visit( final LogicalOpRequest<?, ?> op )    { out.append("req"); }
+		final Iterator<QueryPlanProperty> it = qpInfo.getProperties().iterator();
+		propStrings.add( "query planning info:  " + it.next().toString() );
 
-		@Override
-		public void visit( final LogicalOpFixedSolMap op )      { out.append("sm"); }
-
-		@Override
-		public void visit( final LogicalOpGPAdd op )            { out.append("gpAdd"); }
-
-		@Override
-		public void visit( final LogicalOpGPOptAdd op )         { out.append("gpOptAdd"); }
-
-		@Override
-		public void visit( final LogicalOpJoin op )             { out.append("join"); }
-
-		@Override
-		public void visit( final LogicalOpRightJoin op )        { out.append("rightJoin"); }
-
-		@Override
-		public void visit( final LogicalOpUnion op )            { out.append("union"); }
-
-		@Override
-		public void visit( final LogicalOpMultiwayJoin op )     { out.append("mj"); }
-
-		@Override
-		public void visit( final LogicalOpMultiwayLeftJoin op ) { out.append("mlj"); }
-
-		@Override
-		public void visit( final LogicalOpMultiwayUnion op )    { out.append("mu"); }
-
-		@Override
-		public void visit( final LogicalOpFilter op )           { out.append("filter"); }
-
-		@Override
-		public void visit( final LogicalOpBind op )             { out.append("bind"); }
-
-		@Override
-		public void visit( final LogicalOpLocalToGlobal op )    { out.append("l2g"); }
-
-		@Override
-		public void visit( final LogicalOpGlobalToLocal op )    { out.append("g2l"); }
+		while ( it.hasNext() ) {
+			propStrings.add( "                      " + it.next().toString() );
+		}
 	}
 
-	protected static class OpPrinterBase {
-		protected final PrintStream out;
-		protected final OpNamePrinter np;
 
-		protected String indentLevelString = null;
-		protected String indentLevelStringForOpDetail = null;
-		protected ExpectedVariables expVars = null;
-		protected QueryPlanningInfo qpInfo = null;
+	public static class ShortNameCreator implements LogicalPlanVisitor {
+		/**
+		 * The short name of the most recently visited operator.
+		 */
+		public String name = null;
 
-		protected Set<SPARQLGraphPattern> graphPatterns = new HashSet<>();
-		protected List<String> fullStringsForGraphPatterns = new ArrayList<>();
+		@Override
+		public void visit( final LogicalOpRequest<?, ?> op )    { name = "req"; }
 
-		public OpPrinterBase( final PrintStream out ) {
-			this.out = out;
-			this.np = new OpNamePrinter(out);
-		}
+		@Override
+		public void visit( final LogicalOpFixedSolMap op )      { name = "sm"; }
 
-		public void setIndentLevelString( final String s ) { indentLevelString = s; }
-		public void setIndentLevelStringForOpDetail( final String s ) { indentLevelStringForOpDetail = s; }
-		public void setExpectedVariables( final ExpectedVariables expVars ) { this.expVars = expVars; }
-		public void setQueryPlanningInfo( final QueryPlanningInfo qpInfo ) { this.qpInfo = qpInfo; }
+		@Override
+		public void visit( final LogicalOpGPAdd op )            { name = "gpAdd"; }
 
-		public void printExpectedVariables( final String indentString ) {
-			if ( expVars == null ) {
-				out.append( indentString );
-				out.append( "  - expected variables: ?" );
-				out.append( System.lineSeparator() );
-				return;
-			}
+		@Override
+		public void visit( final LogicalOpGPOptAdd op )         { name = "gpOptAdd"; }
 
-			String certainVarsStr = "  - certain variables: ";
-			final Iterator<Var> itC = expVars.getCertainVariables().iterator();
-			certainVarsStr += itC.hasNext() ? itC.next().toString() : "none";
-			while ( itC.hasNext() ) {
-				certainVarsStr += ", " + itC.next().toString();
-			}
+		@Override
+		public void visit( final LogicalOpJoin op )             { name = "join"; }
 
-			out.append( indentString + certainVarsStr + System.lineSeparator() );
+		@Override
+		public void visit( final LogicalOpRightJoin op )        { name = "rightJoin"; }
 
-			String possibleVarsStr = "  - possible variables: ";
-			final Iterator<Var> itP = expVars.getPossibleVariables().iterator();
-			possibleVarsStr += itP.hasNext() ? itP.next().toString() : "none";
-			while ( itP.hasNext() ) {
-				possibleVarsStr += ", " + itP.next().toString();
-			}
+		@Override
+		public void visit( final LogicalOpUnion op )            { name = "union"; }
 
-			out.append( indentString + possibleVarsStr + System.lineSeparator() );
-		}
+		@Override
+		public void visit( final LogicalOpMultiwayJoin op )     { name = "mj"; }
 
-		public void printQueryPlanningInfo( final String indentString ) {
-			out.append( indentString );
-			out.append( "  - query planning info: " );
+		@Override
+		public void visit( final LogicalOpMultiwayLeftJoin op ) { name = "mlj"; }
 
-			if ( qpInfo == null || qpInfo.isEmpty() ) {
-				out.append( "none" + System.lineSeparator() );
-			}
-			else {
-				final Iterator<QueryPlanProperty> it = qpInfo.getProperties().iterator();
-				out.append( " " );
-				print( it.next() );
-				out.append( System.lineSeparator() );
+		@Override
+		public void visit( final LogicalOpMultiwayUnion op )    { name = "mu"; }
 
-				while ( it.hasNext() ) {
-					out.append( indentString );
-					out.append( "                          " );
-					print( it.next() );
-					out.append( System.lineSeparator() );
-				}
-			}
-		}
+		@Override
+		public void visit( final LogicalOpFilter op )           { name = "filter"; }
 
-		protected void print( final QueryPlanProperty prop ) {
-			out.append( prop.getType().name + " = " + prop.getValue() );
-			switch ( prop.getQuality() ) {
-			case PURE_GUESS:                   out.append(" (pure guess)"); break;
-			case MIN_OR_MAX_POSSIBLE:          out.append(" (min or max possible)"); break;
-			case ESTIMATE_BASED_ON_ESTIMATES:  out.append(" (estimate based on estimates)"); break;
-			case ESTIMATE_BASED_ON_ACCURATES:  out.append(" (estimate based on accurates)"); break;
-			case DIRECT_ESTIMATE:              out.append(" (direct estimate)"); break;
-			case ACCURATE:                     out.append(" (accurate)"); break;
-			}
-		}
+		@Override
+		public void visit( final LogicalOpBind op )             { name = "bind"; }
 
-		public void printFullStringsForGraphPatterns() {
-			if ( fullStringsForGraphPatterns.isEmpty() )
-				return;
+		@Override
+		public void visit( final LogicalOpLocalToGlobal op )    { name = "l2g"; }
 
-			for ( final String s : fullStringsForGraphPatterns ) {
-				out.append( s + System.lineSeparator() );
-			}
-		}
-
-		protected void printSPARQLGraphPattern( final SPARQLGraphPattern gp,
-		                                        final String indentString ) {
-			final String full = BaseForTextBasedPlanPrinters.printSPARQLGraphPattern(gp, indentString, out);
-
-			if ( ! graphPatterns.contains(gp) ) {
-				final String full2 =
-						"--- pattern (" + gp.hashCode() + ") "
-						+ gp.getClass().getName()
-						+ System.lineSeparator()
-						+ full
-						+ System.lineSeparator();
-				fullStringsForGraphPatterns.add(full2);
-			}
-		}
+		@Override
+		public void visit( final LogicalOpGlobalToLocal op )    { name = "g2l"; }
 	}
 
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedLogicalPlanPrinterImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedLogicalPlanPrinterImpl.java
@@ -1,6 +1,9 @@
 package se.liu.ida.hefquin.engine.queryplan.utils;
 
 import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.jena.sparql.core.Var;
@@ -8,9 +11,18 @@ import org.apache.jena.sparql.core.VarExprList;
 import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.util.ExprUtils;
 
+import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
+import se.liu.ida.hefquin.base.utils.PlanPrinter;
+import se.liu.ida.hefquin.base.utils.PlanPrinter.PrintablePlan;
+import se.liu.ida.hefquin.engine.queryplan.logical.LogicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanVisitor;
+import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanWithBinaryRoot;
+import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanWithNaryRoot;
+import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanWithNullaryRoot;
+import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanWithUnaryRoot;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.*;
+import se.liu.ida.hefquin.federation.FederationMember;
 import se.liu.ida.hefquin.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.federation.access.SPARQLRequest;
 
@@ -20,252 +32,225 @@ import se.liu.ida.hefquin.federation.access.SPARQLRequest;
  * error whenever we add a new type of logical operator but forget to
  * extend this class here to cover that new operator.
  */
-public class TextBasedLogicalPlanPrinterImpl extends BaseForTextBasedPlanPrinters implements LogicalPlanPrinter
+public class TextBasedLogicalPlanPrinterImpl extends BaseForTextBasedPlanPrinters
+                                             implements LogicalPlanPrinter
 {
+	public static final MyPropertiesExtractor pe = new MyPropertiesExtractor();
+
 	@Override
 	public void print( final LogicalPlan plan, final PrintStream out ) {
-		final OpPrinter opPrinter = new OpPrinter(out);
-		planWalk(plan, 0, 0, 1, opPrinter, "");
-		opPrinter.printFullStringsForGraphPatterns();
+		final ExtPrintablePlan pp = createPrintablePlan(plan);
+		PlanPrinter.print(pp, out);
+		printFullStringsForGraphPatterns(pp, out);
 		out.flush();
 	}
 
-	/**
-	 * This method recursively goes through a plan, and appends specific strings to a print stream.
-	 * @param plan The current plan (root operator) that will be formatted.
-	 * @param planNumber The number of a plan in terms of its super plan.
-	 * @param planLevel The depth of the root operator in a plan.
-	 * @param numberOfSiblings The number of sibling plans of a plan.
-	 * @param opPrinter The helper object for the printing.
-	 */
-	public void planWalk( final LogicalPlan plan,
-	                      final int planNumber,
-	                      final int planLevel,
-	                      final int numberOfSiblings,
-	                      final OpPrinter opPrinter,
-	                      final String rootOpIndentString ) {
-		final String indentLevelString = getIndentLevelString(planNumber, planLevel, numberOfSiblings, rootOpIndentString);
-		opPrinter.setIndentLevelString(indentLevelString);
-		final String indentLevelStringForOpDetail = getIndentLevelStringForDetail(planNumber, planLevel, numberOfSiblings, plan.numberOfSubPlans(), indentLevelString);
-		opPrinter.setIndentLevelStringForOpDetail(indentLevelStringForOpDetail);
+	public ExtPrintablePlan createPrintablePlan( final LogicalPlan lp ) {
+		final LogicalOperator rootOp = lp.getRootOperator();
 
-		opPrinter.setExpectedVariables( plan.getExpectedVariables() );
-		opPrinter.setQueryPlanningInfo( plan.getQueryPlanningInfo() );
-		plan.getRootOperator().visit(opPrinter);
+		rootOp.visit(snc);
+		final String rootOpString = snc.name + " (" + rootOp.getID()  + ")";
 
-		for ( int i = 0; i < plan.numberOfSubPlans(); ++i ) {
-			planWalk( plan.getSubPlan(i), i, planLevel+1, plan.numberOfSubPlans(), opPrinter, indentLevelString );
+		pe.graphPattern = null;
+		pe.fullStringForGraphPattern = null;
+		pe.props = new ArrayList<>();
+
+		rootOp.visit(pe);
+
+		final SPARQLGraphPattern graphPattern  = pe.graphPattern;
+		final String fullStringForGraphPattern = pe.fullStringForGraphPattern;
+		final List<String> rootOpProps         = pe.props;
+
+		addPropStrings( lp.getExpectedVariables(), rootOpProps );
+		addPropStrings( lp.getQueryPlanningInfo(), rootOpProps );
+
+		final List<PrintablePlan> subPlans = createPrintableSubPlans(lp);
+
+		return new ExtPrintablePlan( rootOpString, rootOpProps, subPlans,
+		                             graphPattern, fullStringForGraphPattern );
+	}
+
+	public List<PrintablePlan> createPrintableSubPlans( final LogicalPlan lp ) {
+		if ( lp instanceof LogicalPlanWithNullaryRoot ) {
+			return null;
+		}
+		else if ( lp instanceof LogicalPlanWithUnaryRoot u ) {
+			final PrintablePlan pp = createPrintablePlan( u.getSubPlan() );
+			return List.of(pp);
+		}
+		else if ( lp instanceof LogicalPlanWithBinaryRoot b ) {
+			final PrintablePlan pp1 = createPrintablePlan( b.getSubPlan1() );
+			final PrintablePlan pp2 = createPrintablePlan( b.getSubPlan2() );
+			return List.of(pp1, pp2);
+		}
+		else if ( lp instanceof LogicalPlanWithNaryRoot n ) {
+			final List<PrintablePlan> subPlans = new ArrayList<>( n.numberOfSubPlans() );
+			final Iterator<LogicalPlan> it = n.getSubPlans();
+			while ( it.hasNext() ) {
+				final PrintablePlan pp = createPrintablePlan( it.next() );
+				subPlans.add(pp);
+			}
+
+			return subPlans;
+		}
+		else {
+			throw new IllegalArgumentException( lp.getClass().getName() );
 		}
 	}
 
-	protected static class OpPrinter extends OpPrinterBase implements LogicalPlanVisitor {
 
-		public OpPrinter( final PrintStream out ) {
-			super(out);
+	public static class MyPropertiesExtractor implements LogicalPlanVisitor {
+		/**
+		 * Strings representing the properties of the most recently visited
+		 * operator.
+		 */
+		public List<String> props = null;
+
+		/**
+		 * The graph pattern of  the most recently visited operator (if any).
+		 */
+		public SPARQLGraphPattern graphPattern;
+
+		/**
+		 * A full-string representation of the graph pattern of the most
+		 * recently visited operator (if any), but only if that string is
+		 * too long to be put as a property into {@link #props} (in which
+		 * case we put a shortened version of that string into {@link #props}).
+		 */
+		public String fullStringForGraphPattern;
+
+		@Override
+		public void visit( final LogicalOpRequest<?,?> op ) {
+			record( op.getFederationMember() );
+			record( op.getRequest() );
+		}
+
+		@Override
+		public void visit( final LogicalOpFixedSolMap op ) {
+			props.add( "solmap: " + op.getSolutionMapping().toString() );
+		}
+
+		@Override
+		public void visit( final LogicalOpGPAdd op ) {
+			record( op.getFederationMember() );
+
+			final StringBuilder b = new StringBuilder("parameter variables:");
+			if ( op.hasParameterVariables() ) {
+				for ( final Var v : op.getParameterVariables() )
+					b.append( " " + v.toString() );
+			}
+			else {
+				b.append( " none" );
+			}
+			props.add( b.toString() );
+
+			record( op.getPattern() );
+		}
+
+		@Override
+		public void visit( final LogicalOpGPOptAdd op ) {
+			record( op.getFederationMember() );
+			record( op.getPattern() );
+		}
+
+		@Override
+		public void visit( final LogicalOpJoin op ) {
+			// nothing extra
+		}
+
+		@Override
+		public void visit( final LogicalOpRightJoin op ) {
+			// nothing extra
+		}
+
+		@Override
+		public void visit( final LogicalOpUnion op ) {
+			// nothing extra
+		}
+
+		@Override
+		public void visit( final LogicalOpMultiwayJoin op ) {
+			// nothing extra
+		}
+
+		@Override
+		public void visit( final LogicalOpMultiwayLeftJoin op ) {
+			// nothing extra
+		}
+
+		@Override
+		public void visit( final LogicalOpMultiwayUnion op ) {
+			// nothing extra
+		}
+
+		@Override
+		public void visit( final LogicalOpFilter op ) {
+			final int numberOfExprs = op.getFilterExpressions().size();
+			if ( numberOfExprs == 1 ) {
+				final Expr expr = op.getFilterExpressions().get(0);
+				props.add( "expression: " + ExprUtils.fmtSPARQL(expr) );
+			}
+			else {
+				props.add( "number of expressions: " + numberOfExprs );
+				for ( int i = 0; i < numberOfExprs; i++ ) {
+					final Expr expr = op.getFilterExpressions().get(i);
+					props.add( "expression " + (i+1) + ": " + ExprUtils.fmtSPARQL(expr) );
+				}
+			}
 		}
 
 		@Override
 		public void visit( final LogicalOpBind op ) {
-			printLogicalOperatorBase( op, indentLevelString, out, np );
-			out.append( System.lineSeparator() );
+			props = new ArrayList<>();
 
 			final VarExprList bindExpressions = op.getBindExpressions();
 			for ( Map.Entry<Var, Expr> e : bindExpressions.getExprs().entrySet() ) {
 				final Var var = e.getKey();
 				final Expr expr = e.getValue();
-				out.append( indentLevelStringForOpDetail + singleBase );
-				out.append( "  - " + var.toString() + " <-- " + ExprUtils.fmtSPARQL(expr) );
-				out.append( System.lineSeparator() );
+				props.add( var.toString() + " <-- " + ExprUtils.fmtSPARQL(expr) );
 			}
-
-			printExpectedVariables( indentLevelStringForOpDetail + singleBase );
-			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
-
-			out.append( indentLevelStringForOpDetail + singleBase );
-			out.append( System.lineSeparator() );
-		}
-
-		@Override
-		public void visit( final LogicalOpFilter op ) {
-			printLogicalOperatorBase( op, indentLevelString, out, np );
-			out.append( System.lineSeparator() );
-
-			printExpressions( op.getFilterExpressions(),
-			                  indentLevelStringForOpDetail + singleBase,
-			                  out );
-
-			printExpectedVariables( indentLevelStringForOpDetail + singleBase );
-			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
-
-			out.append( indentLevelStringForOpDetail + singleBase );
-			out.append( System.lineSeparator() );
-		}
-
-		@Override
-		public void visit( final LogicalOpGlobalToLocal op ) {
-			printLogicalOperatorBase( op, indentLevelString, out, np );
-			out.append( System.lineSeparator() );
-			out.append( indentLevelStringForOpDetail + singleBase + "  - vocab.mapping (" + op.getVocabularyMapping().hashCode() +  ") " );
-			out.append( System.lineSeparator() );
-
-			printExpectedVariables( indentLevelStringForOpDetail + singleBase );
-			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
-
-			out.append( indentLevelStringForOpDetail + singleBase );
-			out.append( System.lineSeparator() );
-		}
-
-		@Override
-		public void visit( final LogicalOpGPAdd op ) {
-			printLogicalOperatorBase( op, indentLevelString, out, np );
-			out.append( System.lineSeparator() );
-			printFederationMember( op.getFederationMember(), indentLevelStringForOpDetail + singleBase, out );
-
-			out.append( indentLevelStringForOpDetail + singleBase );
-			out.append( "  - parameter variables:" );
-			if ( op.hasParameterVariables() ) {
-				for ( final Var v : op.getParameterVariables() )
-					out.append( " " + v.toString() );
-			}
-			else {
-				out.append( " none" );
-			}
-			out.append( System.lineSeparator() );
-
-			printSPARQLGraphPattern( op.getPattern(), indentLevelStringForOpDetail + singleBase );
-
-			printExpectedVariables( indentLevelStringForOpDetail + singleBase );
-			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
-
-			out.append( indentLevelStringForOpDetail + singleBase );
-			out.append( System.lineSeparator() );
-		}
-
-		@Override
-		public void visit( final LogicalOpGPOptAdd op ) {
-			printLogicalOperatorBase( op, indentLevelString, out, np );
-			out.append( System.lineSeparator() );
-			printFederationMember( op.getFederationMember(), indentLevelStringForOpDetail + singleBase, out );
-			printSPARQLGraphPattern( op.getPattern(), indentLevelStringForOpDetail + singleBase );
-
-			printExpectedVariables( indentLevelStringForOpDetail + singleBase );
-			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
-
-			out.append( indentLevelStringForOpDetail + singleBase );
-			out.append( System.lineSeparator() );
-		}
-
-		@Override
-		public void visit( final LogicalOpJoin op ) {
-			printLogicalOperatorBase( op, indentLevelString, out, np );
-			out.append( System.lineSeparator() );
-
-			printExpectedVariables( indentLevelStringForOpDetail + singleBase );
-			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
 		}
 
 		@Override
 		public void visit( final LogicalOpLocalToGlobal op ) {
-			printLogicalOperatorBase( op, indentLevelString, out, np );
-			out.append( System.lineSeparator() );
-			out.append( indentLevelStringForOpDetail + singleBase + "  - vocab.mapping (" + op.getVocabularyMapping().hashCode() +  ") " );
-			out.append( System.lineSeparator() );
-
-			printExpectedVariables( indentLevelStringForOpDetail + singleBase );
-			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
-
-			out.append( indentLevelStringForOpDetail + singleBase );
-			out.append( System.lineSeparator() );
+			props.add( "vocab.mapping (" + op.getVocabularyMapping().hashCode() +  ") " );
 		}
 
 		@Override
-		public void visit( final LogicalOpMultiwayJoin op ) {
-			printLogicalOperatorBase( op, indentLevelString, out, np );
-			out.append( System.lineSeparator() );
-
-			printExpectedVariables( indentLevelStringForOpDetail + singleBase );
-			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
-
-			out.append( indentLevelStringForOpDetail + singleBase );
-			out.append( System.lineSeparator() );
+		public void visit( final LogicalOpGlobalToLocal op ) {
+			props.add( "vocab.mapping (" + op.getVocabularyMapping().hashCode() +  ") " );
 		}
 
-		@Override
-		public void visit( final LogicalOpMultiwayLeftJoin op ) {
-			printLogicalOperatorBase( op, indentLevelString, out, np );
-			out.append( System.lineSeparator() );
-
-			printExpectedVariables( indentLevelStringForOpDetail + singleBase );
-			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
-
-			out.append( indentLevelStringForOpDetail + singleBase );
-			out.append( System.lineSeparator() );
+		protected void record( final FederationMember fm ) {
+			props.add( "fm (" + fm.getID() + ") " + fm.toString() );
 		}
 
-		@Override
-		public void visit( final LogicalOpMultiwayUnion op ) {
-			printLogicalOperatorBase( op, indentLevelString, out, np );
-			out.append( System.lineSeparator() );
-
-			printExpectedVariables( indentLevelStringForOpDetail + singleBase );
-			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
-
-			out.append( indentLevelStringForOpDetail + singleBase );
-			out.append( System.lineSeparator() );
-		}
-
-		@Override
-		public void visit( final LogicalOpRequest<?,?> op ) {
-			printLogicalOperatorBase( op, indentLevelString, out, np );
-			out.append( System.lineSeparator() );
-			printFederationMember( op.getFederationMember(), indentLevelStringForOpDetail, out );
-
-			final DataRetrievalRequest req = op.getRequest();
+		protected void record( final DataRetrievalRequest req ) {
 			if ( req instanceof SPARQLRequest sreq ) {
-				printSPARQLGraphPattern( sreq.getQueryPattern(), indentLevelStringForOpDetail );
+				record( sreq.getQueryPattern() );
 			}
 			else {
-				out.append( indentLevelStringForOpDetail + "  - request (" + req.hashCode() +  "): " + req.toString() );
-				out.append( System.lineSeparator() );
+				props.add( "request (" + req.hashCode() +  "): " + req.toString() );
 			}
-
-			printExpectedVariables( indentLevelStringForOpDetail );
-			printQueryPlanningInfo( indentLevelStringForOpDetail );
-
-			out.append( indentLevelStringForOpDetail );
-			out.append( System.lineSeparator() );
 		}
 
-		@Override
-		public void visit( final LogicalOpFixedSolMap op ) {
-			printLogicalOperatorBase( op, indentLevelString, out, np );
-			out.append( System.lineSeparator() );
+		protected void record( final SPARQLGraphPattern gp ) {
+			final String gpAsString = gp.toStringForPlanPrinters();
+			final String gpAsString2 = gpAsString.replaceAll( "\\s+", " ");
 
-			out.append( indentLevelStringForOpDetail + "  - solmap: " + op.getSolutionMapping().toString() );
-			out.append( System.lineSeparator() );
-
-			printExpectedVariables( indentLevelStringForOpDetail );
-			printQueryPlanningInfo( indentLevelStringForOpDetail );
-
-			out.append( indentLevelStringForOpDetail );
-			out.append( System.lineSeparator() );
-		}
-
-		@Override
-		public void visit( final LogicalOpRightJoin op ) {
-			printLogicalOperatorBase( op, indentLevelString, out, np );
-			out.append( System.lineSeparator() );
-
-			printExpectedVariables( indentLevelStringForOpDetail + singleBase );
-			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
-		}
-
-		@Override
-		public void visit( final LogicalOpUnion op ) {
-			printLogicalOperatorBase( op, indentLevelString, out, np );
-
-			printExpectedVariables( indentLevelStringForOpDetail + singleBase );
-			printQueryPlanningInfo( indentLevelStringForOpDetail + singleBase );
+			if ( gpAsString2.length() > 88 ) {
+				// shorten the string
+				final String s = gpAsString2.substring(0, 40) + "[...]" + gpAsString2.substring( gpAsString2.length()-40 );
+				props.add( "pattern (" + gp.hashCode() +  "): " + s );
+				graphPattern = gp;
+				fullStringForGraphPattern = gpAsString2;
+			}
+			else {
+				// the string is short enough, no need to shorten it
+				props.add( "pattern: " + gpAsString2 );
+				graphPattern = gp;
+				fullStringForGraphPattern = null;
+			}
 		}
 	}
 


### PR DESCRIPTION
… based on the new `PlanPrinter` that yesterday's PR #486 added to `hefquin-base`. This makes the code of these printers significantly easier to read, and also easier to extend in the future.

/cc @keski 

