### PR TITLE
Fix pipeline blocking behaviour of ExecOpDuplicateRemoval

### DIFF
--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpDuplicateRemoval.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpDuplicateRemoval.java
@@ -41,7 +41,7 @@ public class ExecOpDuplicateRemoval extends UnaryExecutableOpBase
 	@Override
 	protected void _concludeExecution( final IntermediateResultElementSink sink,
 	                                   final ExecutionContext execCxt ) {
-		// nothing to be done here
+		distinctSolMaps.clear();
 	}
 
 	@Override

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpDuplicateRemovalTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpDuplicateRemovalTest.java
@@ -36,6 +36,7 @@ public class ExecOpDuplicateRemovalTest
 
 		op.process(sm1, sink, null);
 		op.process(sm2, sink, null);
+		op.concludeExecution(sink, null);
 
 		final Iterator<SolutionMapping> it = sink.getCollectedSolutionMappings().iterator();
 
@@ -78,6 +79,7 @@ public class ExecOpDuplicateRemovalTest
 
 		op.process(sm1, sink, null);
 		op.process(sm2, sink, null);
+		op.concludeExecution(sink, null);
 
 		final Iterator<SolutionMapping> it = sink.getCollectedSolutionMappings().iterator();
 
@@ -109,6 +111,7 @@ public class ExecOpDuplicateRemovalTest
 		op.process(sm1, sink, null);
 		op.process(sm2, sink, null);
 		op.process(sm3, sink, null);
+		op.concludeExecution(sink, null);
 
 		final Iterator<SolutionMapping> it = sink.getCollectedSolutionMappings().iterator();
 


### PR DESCRIPTION
Closes #549.

I made two assumptions in my implementation:
1. that the number of numberOfOutputMappingsProduced should be incremented by 1 after the solution mapping has been sent to the sink.
2. the datatype of `numberOfDuplicates` is `long`. I wasn't sure if `int` was sufficient.