### PR TITLE
Remove provenance from DataRetrievalResponse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Changed
 - Refactoring the code of the logical plan rewriting rules to use the visitor pattern ([#560](https://github.com/LiUSemWeb/HeFQUIN/pull/560), [#569](https://github.com/LiUSemWeb/HeFQUIN/pull/569), [#571](https://github.com/LiUSemWeb/HeFQUIN/pull/571), [#575](https://github.com/LiUSemWeb/HeFQUIN/pull/575)).
 - Separation of logical and physical plans for mapping algebra ([#581](https://github.com/LiUSemWeb/HeFQUIN/pull/581)).
+- Removes unused provenance-related methods from DataRetrievalResponse ([#582](https://github.com/LiUSemWeb/HeFQUIN/pull/582)).
 
 
 ## [0.0.10] - 2026-03-25

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/CardinalityEstimationUnavailableError.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/CardinalityEstimationUnavailableError.java
@@ -1,32 +1,23 @@
 package se.liu.ida.hefquin.federation.access;
 
-import se.liu.ida.hefquin.federation.FederationMember;
-
 public class CardinalityEstimationUnavailableError extends FederationAccessException
 {
 	private static final long serialVersionUID = 1L;
 
 	public CardinalityEstimationUnavailableError( final String message,
-	                                              final Throwable cause,
-	                                              final DataRetrievalRequest req,
-	                                              final FederationMember fm ) {
-		super( message, cause, req, fm );
+	                                              final Throwable cause ) {
+		super( message, cause, null, null );
 	}
 
-	public CardinalityEstimationUnavailableError( final String message,
-	                                              final DataRetrievalRequest req,
-	                                              final FederationMember fm ) {
-		super( message, req, fm );
+	public CardinalityEstimationUnavailableError( final String message ) {
+		super( message, null, null );
 	}
 
-	public CardinalityEstimationUnavailableError( final Throwable cause,
-	                                              final DataRetrievalRequest req,
-	                                              final FederationMember fm ) {
-		super( cause, req, fm );
+	public CardinalityEstimationUnavailableError( final Throwable cause ) {
+		super( cause, null, null );
 	}
 
-	public CardinalityEstimationUnavailableError( final DataRetrievalRequest req,
-	                                              final FederationMember fm ) {
-		super( req, fm );
+	public CardinalityEstimationUnavailableError() {
+		super( null, null );
 	}
 }

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/DataRetrievalResponse.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/DataRetrievalResponse.java
@@ -3,20 +3,8 @@ package se.liu.ida.hefquin.federation.access;
 import java.time.Duration;
 import java.util.Date;
 
-import se.liu.ida.hefquin.federation.FederationMember;
-
 public interface DataRetrievalResponse<T>
 {
-	/**
-	 * Returns the federation member where this response comes from.
-	 */
-	FederationMember getFederationMember();
-
-	/**
-	 * Returns the request that has been issued to obtain this response.
-	 */
-	DataRetrievalRequest getRequest();
-
 	/**
 	 * Returns the time at which the corresponding data retrieval
 	 * request (see {@link #getRequest()}) was started.

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/UnsupportedOperationDueToRetrievalError.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/UnsupportedOperationDueToRetrievalError.java
@@ -1,54 +1,41 @@
 package se.liu.ida.hefquin.federation.access;
 
-import se.liu.ida.hefquin.federation.FederationMember;
-
 public class UnsupportedOperationDueToRetrievalError extends FederationAccessException
 {
 	private static final long serialVersionUID = 1L;
 	protected final Integer errorCode;
 
 	public UnsupportedOperationDueToRetrievalError( final Integer errorCode,
-	                                                final String message,
-	                                                final DataRetrievalRequest req,
-	                                                final FederationMember fm ) {
-		super( message, req, fm );
+	                                                final String message ) {
+		super( message, null, null );
 		this.errorCode = errorCode;
 	}
 
 	public UnsupportedOperationDueToRetrievalError( final Integer errorCode,
 	                                                final String message,
-	                                                final Throwable cause,
-	                                                final DataRetrievalRequest req,
-	                                                final FederationMember fm ) {
-		super( message, cause, req, fm );
+	                                                final Throwable cause ) {
+		super( message, cause, null, null );
 		this.errorCode = errorCode;
 	}
 
 	public UnsupportedOperationDueToRetrievalError( final String message,
-	                                                final Throwable cause,
-	                                                final DataRetrievalRequest req,
-	                                                final FederationMember fm ) {
-		super( message, cause, req, fm );
+	                                                final Throwable cause ) {
+		super( message, cause, null, null );
 		this.errorCode = null;
 	}
 
-	public UnsupportedOperationDueToRetrievalError( final String message,
-	                                                final DataRetrievalRequest req,
-	                                                final FederationMember fm ) {
-		super( message, req, fm );
+	public UnsupportedOperationDueToRetrievalError( final String message ) {
+		super( message, null, null );
 		this.errorCode = null;
 	}
 
-	public UnsupportedOperationDueToRetrievalError( final Throwable cause,
-	                                                final DataRetrievalRequest req,
-	                                                final FederationMember fm ) {
-		super( cause, req, fm );
+	public UnsupportedOperationDueToRetrievalError( final Throwable cause ) {
+		super( cause, null, null );
 		this.errorCode = null;
 	}
 
-	public UnsupportedOperationDueToRetrievalError( final DataRetrievalRequest req,
-	                                                final FederationMember fm ) {
-		super( req, fm );
+	public UnsupportedOperationDueToRetrievalError() {
+		super( null, null );
 		this.errorCode = null;
 	}
 

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerBase1.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerBase1.java
@@ -208,9 +208,7 @@ public abstract class FederationAccessManagerBase1 implements FederationAccessMa
 			}
 			else {
 				final CardinalityEstimationUnavailableError e = new CardinalityEstimationUnavailableError(
-					"Cardinality estimation is unavailable due to missing metadata triples.",
-					null,  // unknown request,
-					null   // unknown federation member
+					"Cardinality estimation is unavailable due to missing metadata triples."
 				);
 				return new CardinalityResponseImplWithoutCardinality(e, tpfResp);
 			}

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerBase1.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerBase1.java
@@ -170,10 +170,10 @@ public abstract class FederationAccessManagerBase1 implements FederationAccessMa
 				cardinality = extractCardinality( smResp );
 			}
 			catch ( final UnsupportedOperationDueToRetrievalError | IllegalArgumentException e ) {
-				return new CardinalityResponseImplWithoutCardinality( e, smResp, smResp.getRequest() );
+				return new CardinalityResponseImplWithoutCardinality(e, smResp);
 			}
 
-			return new CardinalityResponseImpl( smResp, smResp.getRequest(), cardinality );
+			return new CardinalityResponseImpl(smResp, cardinality);
 		}
 
 		protected Integer extractCardinality( final SolMapsResponse smResp ) throws UnsupportedOperationDueToRetrievalError {
@@ -204,15 +204,15 @@ public abstract class FederationAccessManagerBase1 implements FederationAccessMa
 			final Integer cardinality = tpfResp.getCardinalityEstimate();
 			if ( cardinality != null ) {
 				final int c = cardinality;
-				return new CardinalityResponseImpl( tpfResp, tpfResp.getRequest(), c );
+				return new CardinalityResponseImpl(tpfResp, c);
 			}
 			else {
 				final CardinalityEstimationUnavailableError e = new CardinalityEstimationUnavailableError(
 					"Cardinality estimation is unavailable due to missing metadata triples.",
-					tpfResp.getRequest(),
-					tpfResp.getFederationMember()
+					null,  // unknown request,
+					null   // unknown federation member
 				);
-				return new CardinalityResponseImplWithoutCardinality( e, tpfResp, tpfResp.getRequest() );
+				return new CardinalityResponseImplWithoutCardinality(e, tpfResp);
 			}
 		}
 	}

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerWithChronicleMapCache.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerWithChronicleMapCache.java
@@ -83,8 +83,6 @@ public class FederationAccessManagerWithChronicleMapCache extends FederationAcce
 		if ( cachedEntry != null ) {
 			cacheHitsSPARQLCardinality++;
 			final CardinalityResponse cr = new CachedCardinalityResponseImpl( cachedEntry.getObject(),
-			                                                                  fm,
-			                                                                  req,
 			                                                                  requestStartTime,
 			                                                                  requestEndTime );
 			return CompletableFuture.completedFuture( cr );
@@ -113,8 +111,6 @@ public class FederationAccessManagerWithChronicleMapCache extends FederationAcce
 		if ( cachedEntry != null ) {
 			cacheHitsTPFCardinality++;
 			final CardinalityResponse cr = new CachedCardinalityResponseImpl( cachedEntry.getObject(),
-			                                                                  fm,
-			                                                                  req,
 			                                                                  requestStartTime,
 			                                                                  requestEndTime );
 			return CompletableFuture.completedFuture( cr );
@@ -143,8 +139,6 @@ public class FederationAccessManagerWithChronicleMapCache extends FederationAcce
 		if ( cachedEntry != null ) {
 			cacheHitsTPFCardinality++;
 			final CardinalityResponse cr = new CachedCardinalityResponseImpl( cachedEntry.getObject(),
-			                                                                  fm,
-			                                                                  req,
 			                                                                  requestStartTime,
 			                                                                  requestEndTime );
 			return CompletableFuture.completedFuture( cr );
@@ -173,8 +167,6 @@ public class FederationAccessManagerWithChronicleMapCache extends FederationAcce
 		if ( cachedEntry != null ) {
 			cacheHitsTPFCardinality++;
 			final CardinalityResponse cr = new CachedCardinalityResponseImpl( cachedEntry.getObject(),
-			                                                                  fm,
-			                                                                  req,
 			                                                                  requestStartTime,
 			                                                                  requestEndTime );
 			return CompletableFuture.completedFuture( cr );

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/cache/PersistableCardinalityCacheImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/cache/PersistableCardinalityCacheImpl.java
@@ -14,9 +14,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 
 import se.liu.ida.hefquin.base.datastructures.PersistableCache;
-import se.liu.ida.hefquin.federation.FederationMember;
 import se.liu.ida.hefquin.federation.access.CardinalityResponse;
-import se.liu.ida.hefquin.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.federation.access.UnsupportedOperationDueToRetrievalError;
 
 /**
@@ -202,16 +200,6 @@ public class PersistableCardinalityCacheImpl<K> implements PersistableCache<K, C
 		}
 
 		@Override
-		public FederationMember getFederationMember() {
-			throw new UnsupportedOperationException( "Method 'getFederationMember' is not implemented." );
-		}
-
-		@Override
-		public DataRetrievalRequest getRequest() {
-			throw new UnsupportedOperationException( "Method 'getRequest' is not implemented." );
-		}
-
-		@Override
 		public Date getRequestStartTime() {
 			throw new UnsupportedOperationException( "Method 'getRequestStartTime' is not implemented." );
 		}
@@ -227,8 +215,8 @@ public class PersistableCardinalityCacheImpl<K> implements PersistableCache<K, C
 				throw new UnsupportedOperationDueToRetrievalError(
 					getErrorStatusCode(),
 					getErrorDescription(),
-					getRequest(),
-					getFederationMember()
+					null,  // unknown request
+					null   // unknown federation member
 				);
 			}
 			return cardinality;

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/cache/PersistableCardinalityCacheImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/cache/PersistableCardinalityCacheImpl.java
@@ -213,11 +213,8 @@ public class PersistableCardinalityCacheImpl<K> implements PersistableCache<K, C
 		public Integer getResponseData() throws UnsupportedOperationDueToRetrievalError {
 			if( isError() ){
 				throw new UnsupportedOperationDueToRetrievalError(
-					getErrorStatusCode(),
-					getErrorDescription(),
-					null,  // unknown request
-					null   // unknown federation member
-				);
+						getErrorStatusCode(),
+						getErrorDescription() );
 			}
 			return cardinality;
 		}

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/reqproc/GraphQLRequestProcessorImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/reqproc/GraphQLRequestProcessorImpl.java
@@ -47,6 +47,6 @@ public class GraphQLRequestProcessorImpl implements GraphQLRequestProcessor {
 			throw new FederationAccessException("Issuing a request to a GraphQL endpoint caused an exception.", e, req, fm);
 		}
 
-		return new JSONResponseImpl(jsonObj, fm, req, startTime);
+		return new JSONResponseImpl(jsonObj, startTime);
 	}
 }

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/reqproc/Neo4jRequestProcessorImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/reqproc/Neo4jRequestProcessorImpl.java
@@ -33,6 +33,6 @@ public class Neo4jRequestProcessorImpl implements Neo4jRequestProcessor
                     + fm.getURL() + "' caused an exception.", ex, req, fm);
         }
 
-        return new RecordsResponseImpl(result, fm, req, requestStartTime);
+        return new RecordsResponseImpl(result, requestStartTime);
     }
 }

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/reqproc/RESTRequestProcessorImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/reqproc/RESTRequestProcessorImpl.java
@@ -78,7 +78,7 @@ public class RESTRequestProcessorImpl implements RESTRequestProcessor
 		}
 		catch ( final HttpException e ) {
 			if ( e.getStatusCode() > 0 )
-				return new StringResponseImpl( "", fm, req,
+				return new StringResponseImpl( "",
 				                               requestStartTime,
 				                               e.getStatusCode(),
 				                               e.getMessage() );
@@ -86,7 +86,7 @@ public class RESTRequestProcessorImpl implements RESTRequestProcessor
 				throw new FederationAccessException( "Unexpected response for request to REST API (requested URI: <" + uri.toString() + ">, message: " + e.getMessage() + ")", e, req, fm );
 		}
 
-		return new StringResponseImpl(body, fm, req, requestStartTime);
+		return new StringResponseImpl(body, requestStartTime);
 	}
 
 }

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/reqproc/SPARQLRequestProcessorImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/reqproc/SPARQLRequestProcessorImpl.java
@@ -90,7 +90,7 @@ public class SPARQLRequestProcessorImpl implements SPARQLRequestProcessor
 
 		result.close();
 
-		return new SolMapsResponseImpl(solMaps, fm, req, requestStartTime);
+		return new SolMapsResponseImpl(solMaps, requestStartTime);
 	}
 
 	protected SolMapsResponse performRequestWithRDFConnection( final SPARQLRequest req,
@@ -129,7 +129,7 @@ public class SPARQLRequestProcessorImpl implements SPARQLRequestProcessor
 			throw new FederationAccessException("Closing the connection to the SPARQL endpoint at '" + fm.getURL() + "' caused an exception.", ex, req, fm);
 		}
 
-		return new SolMapsResponseImpl(sink.solMaps, fm, req, requestStartTime);
+		return new SolMapsResponseImpl(sink.solMaps, requestStartTime);
 	}
 
 

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/CachedCardinalityResponseImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/CachedCardinalityResponseImpl.java
@@ -2,86 +2,70 @@ package se.liu.ida.hefquin.federation.access.impl.response;
 
 import java.util.Date;
 
-import se.liu.ida.hefquin.federation.FederationMember;
 import se.liu.ida.hefquin.federation.access.CardinalityResponse;
-import se.liu.ida.hefquin.federation.access.DataRetrievalRequest;
 
 public class CachedCardinalityResponseImpl extends DataRetrievalResponseBase<Integer> implements CardinalityResponse
 {
 	/**
-	 * Constructs a response with the given cardinality, federation member, request, and request start time. The
-	 * retrieval end time is automatically set to the current time at the moment of construction. This constructor
-	 * assumes no error occurred.
+	 * Constructs a response with the given cardinality and request start
+	 * time. The retrieval end time is automatically set to the current
+	 * time at the moment of construction. This constructor assumes no
+	 * error occurred.
 	 *
 	 * @param cardinality      the data contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 */
 	public CachedCardinalityResponseImpl( final int cardinality,
-	                                      final FederationMember fm,
-	                                      final DataRetrievalRequest request,
 	                                      final Date requestStartTime ) {
-		super( cardinality, fm, request, requestStartTime );
+		super(cardinality, requestStartTime);
 	}
 
 	/**
-	 * Constructs a response with the given cardinality, federation member, request, request start time, and request end
-	 * time. This constructor assumes no error occurred.
+	 * Constructs a response with the given cardinality, request start time,
+	 * and request end time. This constructor assumes no error occurred.
 	 *
 	 * @param cardinality      the data contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
 	 */
 	public CachedCardinalityResponseImpl( final int cardinality,
-	                                      final FederationMember fm,
-	                                      final DataRetrievalRequest request,
 	                                      final Date requestStartTime,
 	                                      final Date retrievalEndTime ) {
-		super( cardinality, fm, request, requestStartTime, retrievalEndTime );
+		super(cardinality, requestStartTime, retrievalEndTime);
 	}
 
 	/**
-	 * Constructs a response with the given cardinality, federation member, request, request start time, and error
-	 * details. The retrieval end time is automatically set to the current time at the moment of construction.
+	 * Constructs a response with the given cardinality, request start time,
+	 * and error details. The retrieval end time is automatically set to the
+	 * current time at the moment of construction.
 	 *
 	 * @param cardinality      the data contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
 	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
 	 */
 	public CachedCardinalityResponseImpl( final int cardinality,
-	                                      final FederationMember fm,
-	                                      final DataRetrievalRequest request,
 	                                      final Date requestStartTime,
 	                                      final Integer errorStatusCode,
 	                                      final String errorDescription ) {
-		super( cardinality, fm, request, requestStartTime, errorStatusCode, errorDescription );
+		super(cardinality, requestStartTime, errorStatusCode, errorDescription);
 	}
 
 	/**
-	 * Constructs a response with the given cardinality, federation member, request, request start time, retrieval end
-	 * time, and error details.
+	 * Constructs a response with the given cardinality, request start time,
+	 * retrieval end time, and error details.
 	 *
 	 * @param cardinality      the data contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
 	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
 	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
 	 */
 	public CachedCardinalityResponseImpl( final int cardinality,
-	                                      final FederationMember fm,
-	                                      final DataRetrievalRequest request,
 	                                      final Date requestStartTime,
 	                                      final Date retrievalEndTime,
 	                                      final Integer errorStatusCode,
 	                                      final String errorDescription ) {
-		super( cardinality, fm, request, requestStartTime, retrievalEndTime, errorStatusCode, errorDescription );
+		super(cardinality, requestStartTime, retrievalEndTime, errorStatusCode, errorDescription);
 	}
 }

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/CardinalityResponseImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/CardinalityResponseImpl.java
@@ -107,11 +107,8 @@ public class CardinalityResponseImpl implements CardinalityResponse
 	public Integer getResponseData() throws UnsupportedOperationDueToRetrievalError {
 		if ( wrappedResponse.isError() ) {
 			throw new UnsupportedOperationDueToRetrievalError(
-				getErrorStatusCode(),
-				getErrorDescription(),
-				null,  // unknown request
-				null   // unknown federation member
-			);
+					getErrorStatusCode(),
+					getErrorDescription() );
 		}
 		return cardinality;
 	}

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/CardinalityResponseImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/CardinalityResponseImpl.java
@@ -3,34 +3,27 @@ package se.liu.ida.hefquin.federation.access.impl.response;
 import java.time.Duration;
 import java.util.Date;
 
-import se.liu.ida.hefquin.federation.FederationMember;
 import se.liu.ida.hefquin.federation.access.CardinalityResponse;
-import se.liu.ida.hefquin.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.federation.access.DataRetrievalResponse;
 import se.liu.ida.hefquin.federation.access.UnsupportedOperationDueToRetrievalError;
 
 public class CardinalityResponseImpl implements CardinalityResponse
 {
 	protected final DataRetrievalResponse<?> wrappedResponse;
-	protected final DataRetrievalRequest request;
 	protected final int cardinality;
 
 	/**
-	 * Constructs a cardinality response that wraps the given data retrieval response and associates it with a request
-	 * and a cardinality value.
+	 * Constructs a cardinality response that wraps the given data
+	 * retrieval response and associates it with a cardinality value.
 	 *
 	 * @param wrappedResponse the wrapped data retrieval response (must not be null)
-	 * @param request         the original data retrieval request (must not be null)
 	 * @param cardinality     the cardinality of the request
 	 */
 	public CardinalityResponseImpl( final DataRetrievalResponse<?> wrappedResponse,
-	                                final DataRetrievalRequest request,
 	                                final int cardinality ) {
 		assert wrappedResponse != null;
-		assert request != null;
 
 		this.wrappedResponse = wrappedResponse;
-		this.request = request;
 		this.cardinality = cardinality;
 	}
 
@@ -41,26 +34,6 @@ public class CardinalityResponseImpl implements CardinalityResponse
 	 */
 	public DataRetrievalResponse<?> getWrappedResponse() {
 		return wrappedResponse;
-	}
-
-	/**
-	 * Returns the federation member associated with the wrapped response.
-	 *
-	 * @return the corresponding federation member
-	 */
-	@Override
-	public FederationMember getFederationMember() {
-		return wrappedResponse.getFederationMember();
-	}
-
-	/**
-	 * Returns the data retrieval request associated with this response.
-	 *
-	 * @return the associated {@link DataRetrievalRequest}
-	 */
-	@Override
-	public DataRetrievalRequest getRequest() {
-		return request;
 	}
 
 	/**
@@ -136,8 +109,8 @@ public class CardinalityResponseImpl implements CardinalityResponse
 			throw new UnsupportedOperationDueToRetrievalError(
 				getErrorStatusCode(),
 				getErrorDescription(),
-				getRequest(),
-				getFederationMember()
+				null,  // unknown request
+				null   // unknown federation member
 			);
 		}
 		return cardinality;

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/CardinalityResponseImplWithoutCardinality.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/CardinalityResponseImplWithoutCardinality.java
@@ -14,16 +14,15 @@ public class CardinalityResponseImplWithoutCardinality extends CardinalityRespon
 	protected final Exception exception;
 
 	/**
-	 * Constructs a {@code CardinalityResponseImplWithoutCardinality} with the given exception.
+	 * Constructs a {@code CardinalityResponseImplWithoutCardinality} with
+	 * the given exception.
 	 *
 	 * @param exception       the exception that caused the absence of cardinality/cardinality estimate
 	 * @param wrappedResponse the original data retrieval response
-	 * @param request         the original data retrieval request
 	 */
 	public CardinalityResponseImplWithoutCardinality( final Exception exception,
-	                                                  final DataRetrievalResponse<?> wrappedResponse,
-	                                                  final DataRetrievalRequest request ) {
-		super( wrappedResponse, request, Integer.MAX_VALUE );
+	                                                  final DataRetrievalResponse<?> wrappedResponse ) {
+		super( wrappedResponse, Integer.MAX_VALUE );
 		this.exception = exception;
 	}
 

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/DataRetrievalResponseBase.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/DataRetrievalResponseBase.java
@@ -2,128 +2,86 @@ package se.liu.ida.hefquin.federation.access.impl.response;
 
 import java.util.Date;
 
-import se.liu.ida.hefquin.federation.FederationMember;
-import se.liu.ida.hefquin.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.federation.access.DataRetrievalResponse;
 import se.liu.ida.hefquin.federation.access.UnsupportedOperationDueToRetrievalError;
 
 public abstract class DataRetrievalResponseBase<T> implements DataRetrievalResponse<T>
 {
 	protected final T data;
-	private final FederationMember fm;
-	private final DataRetrievalRequest request;
 	private final Date requestStartTime;
 	private final Date retrievalEndTime;
 	protected final Integer errorStatusCode;
 	protected final String errorDescription;
 
 	/**
-	 * Constructs a response with the given data, federation member, request, and request start time. The retrieval end
-	 * time is automatically set to the current time at the moment of construction. This constructor assumes no error
+	 * Constructs a response with the given data and request start time.
+	 * The retrieval end time is automatically set to the current time at
+	 * the moment of construction. This constructor assumes no error
 	 * occurred.
 	 *
 	 * @param data             the data contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 */
 	protected DataRetrievalResponseBase( final T data,
-	                                     final FederationMember fm,
-	                                     final DataRetrievalRequest request,
 	                                     final Date requestStartTime ) {
-		this( data, fm, request, requestStartTime, null, null );
+		this(data, requestStartTime, null, null);
 	}
 
 	/**
-	 * Constructs a response with the given data, federation member, request, request start time, and request end time.
-	 * This constructor assumes no error occurred.
+	 * Constructs a response with the given data, request start time, and
+	 * request end time. This constructor assumes no error occurred.
 	 *
 	 * @param data             the data contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
 	 */
 	protected DataRetrievalResponseBase( final T data,
-	                                     final FederationMember fm,
-	                                     final DataRetrievalRequest request,
 	                                     final Date requestStartTime,
 	                                     final Date retrievalEndTime ) {
-		this( data, fm, request, requestStartTime, retrievalEndTime, null, null );
+		this(data, requestStartTime, retrievalEndTime, null, null);
 	}
 
 	/**
-	 * Constructs a response with the given data, federation member, request, request start time, and error details. The
-	 * retrieval end time is automatically set to the current time at the moment of construction.
+	 * Constructs a response with the given data, request start time, and
+	 * error details. The retrieval end time is automatically set to the
+	 * current time at the moment of construction.
 	 *
 	 * @param data             the data contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
 	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
 	 */
 	protected DataRetrievalResponseBase( final T data,
-	                                     final FederationMember fm,
-	                                     final DataRetrievalRequest request,
 	                                     final Date requestStartTime,
 	                                     final Integer errorStatusCode,
 	                                     final String errorDescription ) {
-		this( data, fm, request, requestStartTime, new Date(), errorStatusCode, errorDescription );
+		this(data, requestStartTime, new Date(), errorStatusCode, errorDescription);
 	}
 
 	/**
-	 * Constructs a response with the given data, federation member, request, request start time, retrieval end time,
-	 * and error details.
+	 * Constructs a response with the given data, request start time,
+	 * retrieval end time, and error details.
 	 *
 	 * @param data             the data contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
 	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
 	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
 	 */
 	protected DataRetrievalResponseBase( final T data,
-	                                     final FederationMember fm,
-	                                     final DataRetrievalRequest request,
 	                                     final Date requestStartTime,
 	                                     final Date retrievalEndTime,
 	                                     final Integer errorStatusCode,
 	                                     final String errorDescription ) {
 		assert data != null;
-		assert fm != null;
-		assert request != null;
 		assert requestStartTime != null;
 		assert retrievalEndTime != null;
 
 		this.data = data;
-		this.fm = fm;
-		this.request = request;
 		this.requestStartTime = requestStartTime;
 		this.retrievalEndTime = retrievalEndTime;
 		this.errorStatusCode = errorStatusCode;
 		this.errorDescription = errorDescription;
-	}
-
-	/**
-	 * Returns the federation member from which this response originates.
-	 *
-	 * @return the corresponding federation member
-	 */
-	@Override
-	public FederationMember getFederationMember() {
-		return fm;
-	}
-
-	/**
-	 * Returns the data retrieval request that led to this response.
-	 *
-	 * @return the associated data retrieval request
-	 */
-	@Override
-	public DataRetrievalRequest getRequest() {
-		return request;
 	}
 
 	/**
@@ -179,8 +137,8 @@ public abstract class DataRetrievalResponseBase<T> implements DataRetrievalRespo
 			throw new UnsupportedOperationDueToRetrievalError(
 				getErrorStatusCode(),
 				getErrorDescription(),
-				getRequest(),
-				getFederationMember()
+				null,  // unknown request
+				null   // unknown federation member
 			);
 		}
 		return data;

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/DataRetrievalResponseBase.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/DataRetrievalResponseBase.java
@@ -135,11 +135,8 @@ public abstract class DataRetrievalResponseBase<T> implements DataRetrievalRespo
 	public T getResponseData() throws UnsupportedOperationDueToRetrievalError {
 		if ( isError() ) {
 			throw new UnsupportedOperationDueToRetrievalError(
-				getErrorStatusCode(),
-				getErrorDescription(),
-				null,  // unknown request
-				null   // unknown federation member
-			);
+					getErrorStatusCode(),
+					getErrorDescription() );
 		}
 		return data;
 	}

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/JSONResponseImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/JSONResponseImpl.java
@@ -4,86 +4,70 @@ import java.util.Date;
 
 import org.apache.jena.atlas.json.JsonObject;
 
-import se.liu.ida.hefquin.federation.FederationMember;
-import se.liu.ida.hefquin.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.federation.access.JSONResponse;
 
 public class JSONResponseImpl extends DataRetrievalResponseBase<JsonObject> implements JSONResponse
 {
 	/**
-	 * Constructs a response with the given JSON object, federation member, request, and request start time. The
-	 * retrieval end time is automatically set to the current time at the moment of construction. This constructor
-	 * assumes no error occurred.
+	 * Constructs a response with the given JSON object and request start
+	 * time. The retrieval end time is automatically set to the current
+	 * time at the moment of construction. This constructor assumes no
+	 * error occurred.
 	 *
 	 * @param jsonObject       the JSON object contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the data retrieval request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 */
 	public JSONResponseImpl( final JsonObject jsonObject,
-	                         final FederationMember fm,
-	                         final DataRetrievalRequest request,
 	                         final Date requestStartTime ) {
-		super( jsonObject, fm, request, requestStartTime );
+		super(jsonObject, requestStartTime);
 	}
 
 	/**
-	 * Constructs a response with the given JSON object, federation member, request, request start time, and retrieval
-	 * end time. This constructor assumes no error occurred.
+	 * Constructs a response with the given JSON object, request start time,
+	 * and retrieval end time. This constructor assumes no error occurred.
 	 *
 	 * @param jsonObject       the JSON object contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the data retrieval request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
 	 */
 	public JSONResponseImpl( final JsonObject jsonObject,
-	                         final FederationMember fm,
-	                         final DataRetrievalRequest request,
 	                         final Date requestStartTime,
 	                         final Date retrievalEndTime ) {
-		super( jsonObject, fm, request, requestStartTime, retrievalEndTime );
+		super(jsonObject, requestStartTime, retrievalEndTime);
 	}
 
 	/**
-	 * Constructs a response with the given JSON object, federation member, request, request start time, and error
-	 * details. The retrieval end time is automatically set to the current time at the moment of construction.
+	 * Constructs a response with the given JSON object, request start time,
+	 * and error details. The retrieval end time is automatically set to the
+	 * current time at the moment of construction.
 	 *
 	 * @param jsonObject       the JSON object contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the data retrieval request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
 	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
 	 */
 	public JSONResponseImpl( final JsonObject jsonObject,
-	                         final FederationMember fm,
-	                         final DataRetrievalRequest request,
 	                         final Date requestStartTime,
 	                         final Integer errorStatusCode,
 	                         final String errorDescription ) {
-		super( jsonObject, fm, request, requestStartTime, errorStatusCode, errorDescription );
+		super(jsonObject, requestStartTime, errorStatusCode, errorDescription);
 	}
 
 	/**
-	 * Constructs a response with the given JSON object, federation member, request, request start time, retireval end
-	 * time, and error details.
+	 * Constructs a response with the given JSON object, request start time,
+	 * retrieval end time, and error details.
 	 *
 	 * @param jsonObject       the JSON object contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the data retrieval request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
 	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
 	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
 	 */
 	public JSONResponseImpl( final JsonObject jsonObject,
-	                         final FederationMember fm,
-	                         final DataRetrievalRequest request,
 	                         final Date requestStartTime,
 	                         final Date retrievalEndTime,
 	                         final Integer errorStatusCode,
 	                         final String errorDescription ) {
-		super( jsonObject, fm, request, requestStartTime, retrievalEndTime, errorStatusCode, errorDescription );
+		super(jsonObject, requestStartTime, retrievalEndTime, errorStatusCode, errorDescription);
 	}
 }

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/RecordsResponseImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/RecordsResponseImpl.java
@@ -1,8 +1,6 @@
 package se.liu.ida.hefquin.federation.access.impl.response;
 
 import se.liu.ida.hefquin.engine.wrappers.lpg.data.TableRecord;
-import se.liu.ida.hefquin.federation.FederationMember;
-import se.liu.ida.hefquin.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.federation.access.RecordsResponse;
 
 import java.util.Date;
@@ -11,79 +9,64 @@ import java.util.List;
 public class RecordsResponseImpl extends DataRetrievalResponseBase<List<TableRecord>> implements RecordsResponse
 {
 	/**
-	 * Constructs a response with the given records, federation member, request, and request start time. The retrieval
-	 * end time is automatically set to the current time at the moment of construction. This constructor assumes no
-	 * error occurred.
+	 * Constructs a response with the given records and request start time.
+	 * The retrieval end time is automatically set to the current time at the
+	 * moment of construction. This constructor assumes no error occurred.
 	 *
 	 * @param records          the list of records contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the data retrieval request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 */
 	public RecordsResponseImpl( final List<TableRecord> records,
-	                            final FederationMember fm,
-	                            final DataRetrievalRequest request,
 	                            final Date requestStartTime ) {
-		super( records, fm, request, requestStartTime );
+		super(records, requestStartTime);
 	}
 
 	/**
-	 * Constructs a response with the given records, federation member, request, request start time, and retrieval end
-	 * time. This constructor assumes no error occurred.
+	 * Constructs a response with the given records, request start time,
+	 * and retrieval end time. This constructor assumes no error occurred.
 	 *
 	 * @param records          the list of records contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the data retrieval request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
 	 */
 	public RecordsResponseImpl( final List<TableRecord> records,
-	                            final FederationMember fm,
-	                            final DataRetrievalRequest request,
 	                            final Date requestStartTime,
 	                            final Date retrievalEndTime ) {
-		super( records, fm, request, requestStartTime, retrievalEndTime );
+		super(records, requestStartTime, retrievalEndTime);
 	}
 
 	/**
-	 * Constructs a response with the given records, federation member, request, request start time, and error details.
-	 * The retrieval end time is automatically set to the current time at the moment of construction.
+	 * Constructs a response with the given records, request start time,
+	 * and error details. The retrieval end time is automatically set to
+	 * the current time at the moment of construction.
 	 *
 	 * @param records          the list of records contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the data retrieval request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
 	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
 	 */
 	public RecordsResponseImpl( final List<TableRecord> records,
-	                            final FederationMember fm,
-	                            final DataRetrievalRequest request,
 	                            final Date requestStartTime,
 	                            final Integer errorStatusCode,
 	                            final String errorDescription ) {
-		super( records, fm, request, requestStartTime, errorStatusCode, errorDescription );
+		super(records, requestStartTime, errorStatusCode, errorDescription);
 	}
 
 	/**
-	 * Constructs a response with the given records, federation member, request, request start time, retrieval end time,
-	 * and error details.
+	 * Constructs a response with the given records, request start time,
+	 * retrieval end time, and error details.
 	 *
 	 * @param records          the list of records contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the data retrieval request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
 	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
 	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
 	 */
 	public RecordsResponseImpl( final List<TableRecord> records,
-	                            final FederationMember fm,
-	                            final DataRetrievalRequest request,
 	                            final Date requestStartTime,
 	                            final Date retrievalEndTime,
 	                            final Integer errorStatusCode,
 	                            final String errorDescription ) {
-		super( records, fm, request, requestStartTime, retrievalEndTime, errorStatusCode, errorDescription );
+		super(records, requestStartTime, retrievalEndTime, errorStatusCode, errorDescription);
 	}
 }

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/SolMapsResponseImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/SolMapsResponseImpl.java
@@ -4,86 +4,71 @@ import java.util.Date;
 import java.util.List;
 
 import se.liu.ida.hefquin.base.data.SolutionMapping;
-import se.liu.ida.hefquin.federation.FederationMember;
-import se.liu.ida.hefquin.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.federation.access.SolMapsResponse;
 
 public class SolMapsResponseImpl extends DataRetrievalResponseBase<Iterable<SolutionMapping>> implements SolMapsResponse
 {
 	/**
-	 * Constructs a response with the given solution mappings, federation member, request, and request start time. The
-	 * retrieval end time is automatically set to the current time at the moment of construction. This constructor
+	 * Constructs a response with the given solution mappings and request
+	 * start time. The retrieval end time is automatically set to the
+	 * current time at the moment of construction. This constructor
 	 * assumes no error occurred.
 	 *
 	 * @param solMaps          the list of solution mappings contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the data retrieval request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 */
 	public SolMapsResponseImpl( final List<SolutionMapping> solMaps,
-	                            final FederationMember fm,
-	                            final DataRetrievalRequest request,
 	                            final Date requestStartTime ) {
-		super( solMaps, fm, request, requestStartTime );
+		super(solMaps, requestStartTime);
 	}
 
 	/**
-	 * Constructs a response with the given solution mappings, federation member, request, request start time, and
-	 * retrieval end time. This constructor assumes no error occurred.
+	 * Constructs a response with the given solution mappings, request
+	 * start time, and retrieval end time. This constructor assumes no
+	 * error occurred.
 	 *
 	 * @param solMaps          the list of solution mappings contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the data retrieval request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
 	 */
 	public SolMapsResponseImpl( final List<SolutionMapping> solMaps,
-	                            final FederationMember fm,
-	                            final DataRetrievalRequest request,
 	                            final Date requestStartTime,
 	                            final Date retrievalEndTime ) {
-		super( solMaps, fm, request, requestStartTime, retrievalEndTime );
+		super(solMaps, requestStartTime, retrievalEndTime);
 	}
 
 	/**
-	 * Constructs a response with the given solution mappings, federation member, request, request start time, and error
-	 * details. The retrieval end time is automatically set to the current time at the moment of construction.
+	 * Constructs a response with the given solution mappings, request start
+	 * time, and error details. The retrieval end time is automatically set
+	 * to the current time at the moment of construction.
 	 *
 	 * @param solMaps          the list of solution mappings contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the data retrieval request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
 	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
 	 */
 	public SolMapsResponseImpl( final List<SolutionMapping> solMaps,
-	                            final FederationMember fm,
-	                            final DataRetrievalRequest request,
 	                            final Date requestStartTime,
 	                            final Integer errorStatusCode,
 	                            final String errorDescription ) {
-		super( solMaps, fm, request, requestStartTime, errorStatusCode, errorDescription );
+		super(solMaps, requestStartTime, errorStatusCode, errorDescription);
 	}
 
 	/**
-	 * Constructs a response with the given solution mappings, federation member, request, request start time, retrieval
-	 * end time, and error details.
+	 * Constructs a response with the given solution mappings, request start
+	 * time, retrieval end time, and error details.
 	 *
 	 * @param solMaps          the list of solution mappings contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the data retrieval request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
 	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
 	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
 	 */
 	public SolMapsResponseImpl( final List<SolutionMapping> solMaps,
-	                            final FederationMember fm,
-	                            final DataRetrievalRequest request,
 	                            final Date requestStartTime,
 	                            final Date retrievalEndTime,
 	                            final Integer errorStatusCode,
 	                            final String errorDescription ) {
-		super( solMaps, fm, request, requestStartTime, retrievalEndTime, errorStatusCode, errorDescription );
+		super(solMaps, requestStartTime, retrievalEndTime, errorStatusCode, errorDescription);
 	}
 }

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/StringResponseImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/StringResponseImpl.java
@@ -2,86 +2,69 @@ package se.liu.ida.hefquin.federation.access.impl.response;
 
 import java.util.Date;
 
-import se.liu.ida.hefquin.federation.FederationMember;
-import se.liu.ida.hefquin.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.federation.access.StringResponse;
 
 public class StringResponseImpl extends DataRetrievalResponseBase<String> implements StringResponse
 {
 	/**
-	 * Constructs a response with a string response, federation member, request, and request start time. The retrieval
-	 * end time is automatically set to the current time at the moment of construction. This constructor assumes no
-	 * error occurred.
+	 * Constructs a response with a string response and request start time.
+	 * The retrieval end time is automatically set to the current time at
+	 * the moment of construction. This constructor assumes no error occurred.
 	 *
 	 * @param response         the response string (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the data retrieval request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 */
 	public StringResponseImpl( final String response,
-	                           final FederationMember fm,
-	                           final DataRetrievalRequest request,
 	                           final Date requestStartTime ) {
-		super( response, fm, request, requestStartTime );
+		super(response, requestStartTime);
 	}
 
 	/**
-	 * Constructs a response with a string response, federation member, request, request start time, and retrieval end
-	 * time. This constructor assumes no error occurred.
+	 * Constructs a response with a string response, request start time,
+	 * and retrieval end time. This constructor assumes no error occurred.
 	 *
 	 * @param response         the response string (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the data retrieval request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
 	 */
 	public StringResponseImpl( final String response,
-	                           final FederationMember fm,
-	                           final DataRetrievalRequest request,
 	                           final Date requestStartTime,
 	                           final Date retrievalEndTime ) {
-		super( response, fm, request, requestStartTime, retrievalEndTime );
+		super(response, requestStartTime, retrievalEndTime);
 	}
 
 	/**
-	 * Constructs a response with a string response, federation member, request, request start time, and error details.
-	 * The retrieval end time is automatically set to the current time at the moment of construction.
+	 * Constructs a response with a string response, request start time,
+	 * and error details. The retrieval end time is automatically set to
+	 * the current time at the moment of construction.
 	 *
 	 * @param response         the response string (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the data retrieval request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
 	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
 	 */
 	public StringResponseImpl( final String response,
-	                           final FederationMember fm,
-	                           final DataRetrievalRequest request,
 	                           final Date requestStartTime,
 	                           final Integer errorStatusCode,
 	                           final String errorDescription ) {
-		super( response, fm, request, requestStartTime, errorStatusCode, errorDescription );
+		super(response, requestStartTime, errorStatusCode, errorDescription);
 	}
 
 	/**
-	 * Constructs a response with a string response, federation member, request, request start time, retrieval end time,
-	 * and error details.
+	 * Constructs a response with a string response, request start time,
+	 * retrieval end time, and error details.
 	 *
 	 * @param response         the response string (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the data retrieval request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
 	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
 	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
 	 */
 	public StringResponseImpl( final String response,
-	                           final FederationMember fm,
-	                           final DataRetrievalRequest request,
 	                           final Date requestStartTime,
 	                           final Date retrievalEndTime,
 	                           final Integer errorStatusCode,
 	                           final String errorDescription ) {
-		super( response, fm, request, requestStartTime, retrievalEndTime, errorStatusCode, errorDescription );
+		super(response, requestStartTime, retrievalEndTime, errorStatusCode, errorDescription);
 	}
 }

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/TPFResponseBuilder.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/TPFResponseBuilder.java
@@ -116,9 +116,16 @@ public class TPFResponseBuilder
 			}
 		}
 		if ( tripleCount < 0 )
-			return new TPFResponseImpl(matchingTriples, metadataTriples, nextPageURL, fm, request, requestStartTime);
+			return new TPFResponseImpl( matchingTriples,
+			                            metadataTriples,
+			                            nextPageURL,
+			                            requestStartTime );
 		else
-			return new TPFResponseImpl(matchingTriples, metadataTriples, nextPageURL, tripleCount, fm, request, requestStartTime);
+			return new TPFResponseImpl( matchingTriples,
+			                            metadataTriples,
+			                            nextPageURL,
+			                            tripleCount,
+			                            requestStartTime );
 	}
 
 	protected boolean tryExtractCountMetadataOrNextPageURL( final Triple t ) {

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/TPFResponseImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/TPFResponseImpl.java
@@ -5,8 +5,6 @@ import java.util.List;
 
 import se.liu.ida.hefquin.base.data.Triple;
 import se.liu.ida.hefquin.base.utils.ConcatenatingIterable;
-import se.liu.ida.hefquin.federation.FederationMember;
-import se.liu.ida.hefquin.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.federation.access.TPFResponse;
 import se.liu.ida.hefquin.federation.access.UnsupportedOperationDueToRetrievalError;
 
@@ -17,24 +15,21 @@ public class TPFResponseImpl extends DataRetrievalResponseBase<Iterable<Triple>>
 	protected final String nextPageURL;
 
 	/**
-	 * Constructs a response with the given matching triples, metadata triples, next page URL, federation member,
-	 * request, and request start time. The retrieval end time is automatically set to the current time at the moment of
-	 * construction. This constructor assumes no error occurred.
+	 * Constructs a response with the given matching triples, metadata
+	 * triples, next page URL, and request start time. The retrieval
+	 * end time is automatically set to the current time at the moment
+	 * of construction. This constructor assumes no error occurred.
 	 *
 	 * @param matchingTriples  the list of triples matching the request pattern (must not be null)
 	 * @param metadataTriples  the list of metadata triples (must not be null)
 	 * @param nextPageURL      the URL for the next page of results, or {@code null} if there is none
-	 * @param fm               the federation member from which the data was retrieved
-	 * @param request          the original data retrieval request
 	 * @param requestStartTime the timestamp when the request started
 	 */
 	public TPFResponseImpl( final List<Triple> matchingTriples,
 	                        final List<Triple> metadataTriples,
 	                        final String nextPageURL,
-	                        final FederationMember fm,
-	                        final DataRetrievalRequest request,
 	                        final Date requestStartTime ) {
-		super( matchingTriples, fm, request, requestStartTime );
+		super(matchingTriples, requestStartTime);
 
 		assert metadataTriples != null;
 
@@ -44,25 +39,22 @@ public class TPFResponseImpl extends DataRetrievalResponseBase<Iterable<Triple>>
 	}
 
 	/**
-	 * Constructs a response with the given matching triples, metadata triples, next page URL, federation member,
-	 * request, request start time, and retrieval end time. This constructor assumes no error occurred.
+	 * Constructs a response with the given matching triples, metadata
+	 * triples, next page URL, request start time, and retrieval end time.
+	 * This constructor assumes no error occurred.
 	 *
 	 * @param matchingTriples  the list of triples matching the request pattern (must not be null)
 	 * @param metadataTriples  the list of metadata triples (must not be null)
 	 * @param nextPageURL      the URL for the next page of results, or {@code null} if there is none
-	 * @param fm               the federation member from which the data was retrieved
-	 * @param request          the original data retrieval request
 	 * @param requestStartTime the timestamp when the request started
 	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
 	 */
 	public TPFResponseImpl( final List<Triple> matchingTriples,
 	                        final List<Triple> metadataTriples,
 	                        final String nextPageURL,
-	                        final FederationMember fm,
-	                        final DataRetrievalRequest request,
 	                        final Date requestStartTime,
 	                        final Date retrievalEndTime ) {
-		super( matchingTriples, fm, request, requestStartTime, retrievalEndTime );
+		super(matchingTriples, requestStartTime, retrievalEndTime);
 
 		assert metadataTriples != null;
 
@@ -72,26 +64,24 @@ public class TPFResponseImpl extends DataRetrievalResponseBase<Iterable<Triple>>
 	}
 
 	/**
-	 * Constructs a response with the given matching triples, metadata triples, next page URL, triple count, federation
-	 * member, request, and request start time. The retrieval end time is automatically set to the current time at the moment of
-	 * construction. This constructor assumes no error occurred.
+	 * Constructs a response with the given matching triples, metadata
+	 * triples, next page URL, triple count, and request start time.
+	 * The retrieval end time is automatically set to the current time
+	 * at the moment of construction. This constructor assumes no error
+	 * occurred.
 	 *
 	 * @param matchingTriples  the list of triples matching the request pattern (must not be null)
 	 * @param metadataTriples  the list of metadata triples (must not be null)
 	 * @param nextPageURL      the URL for the next page of results, or {@code null} if there is none
 	 * @param tripleCount      the triple count
-	 * @param fm               the federation member from which the data was retrieved
-	 * @param request          the original data retrieval request
 	 * @param requestStartTime the timestamp when the request started
 	 */
 	public TPFResponseImpl( final List<Triple> matchingTriples,
 	                        final List<Triple> metadataTriples,
 	                        final String nextPageURL,
 	                        final int tripleCount,
-	                        final FederationMember fm,
-	                        final DataRetrievalRequest request,
 	                        final Date requestStartTime ) {
-		super( matchingTriples, fm, request, requestStartTime );
+		super(matchingTriples, requestStartTime);
 
 		assert metadataTriples != null;
 		assert tripleCount >= 0;
@@ -102,15 +92,14 @@ public class TPFResponseImpl extends DataRetrievalResponseBase<Iterable<Triple>>
 	}
 
 	/**
-	 * Constructs a response with the given matching triples, metadata triples, next page URL, triple count, federation
-	 * member, request, request start time, and retrieval end time. This constructor assumes no error occurred.
+	 * Constructs a response with the given matching triples, metadata
+	 * triples, next page URL, triple count, request start time, and
+	 * retrieval end time. This constructor assumes no error occurred.
 	 *
 	 * @param matchingTriples  the list of triples matching the request pattern (must not be null)
 	 * @param metadataTriples  the list of metadata triples (must not be null)
 	 * @param nextPageURL      the URL for the next page of results, or {@code null} if there is none
 	 * @param tripleCount      the triple count
-	 * @param fm               the federation member from which the data was retrieved
-	 * @param request          the original data retrieval request
 	 * @param requestStartTime the timestamp when the request started
 	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
 	 */
@@ -118,11 +107,9 @@ public class TPFResponseImpl extends DataRetrievalResponseBase<Iterable<Triple>>
 	                        final List<Triple> metadataTriples,
 	                        final String nextPageURL,
 	                        final int tripleCount,
-	                        final FederationMember fm,
-	                        final DataRetrievalRequest request,
 	                        final Date requestStartTime,
 	                        final Date retrievalEndTime ) {
-		super( matchingTriples, fm, request, requestStartTime, retrievalEndTime );
+		super(matchingTriples, requestStartTime, retrievalEndTime);
 
 		assert metadataTriples != null;
 		assert tripleCount >= 0;
@@ -133,15 +120,14 @@ public class TPFResponseImpl extends DataRetrievalResponseBase<Iterable<Triple>>
 	}
 
 	/**
-	 * Constructs a response with the given matching triples, metadata triples, next page URL, federation member,
-	 * request, request start time, and error details. The retrieval end time is automatically set to the current time
+	 * Constructs a response with the given matching triples, metadata
+	 * triples, next page URL, request start time, and error details.
+	 * The retrieval end time is automatically set to the current time
 	 * at the moment of construction.
 	 *
 	 * @param matchingTriples  the list of triples matching the request pattern (must not be null)
 	 * @param metadataTriples  the list of metadata triples (must not be null)
 	 * @param nextPageURL      the URL for the next page of results, or {@code null} if there is none
-	 * @param fm               the federation member from which the data was retrieved
-	 * @param request          the original data retrieval request
 	 * @param requestStartTime the timestamp when the request started
 	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
 	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
@@ -149,12 +135,10 @@ public class TPFResponseImpl extends DataRetrievalResponseBase<Iterable<Triple>>
 	public TPFResponseImpl( final List<Triple> matchingTriples,
 	                        final List<Triple> metadataTriples,
 	                        final String nextPageURL,
-	                        final FederationMember fm,
-	                        final DataRetrievalRequest request,
 	                        final Date requestStartTime,
 	                        final int errorStatusCode,
 	                        final String errorDescription ) {
-		super( matchingTriples, fm, request, requestStartTime, errorStatusCode, errorDescription );
+		super(matchingTriples, requestStartTime, errorStatusCode, errorDescription);
 
 		assert metadataTriples != null;
 
@@ -164,14 +148,13 @@ public class TPFResponseImpl extends DataRetrievalResponseBase<Iterable<Triple>>
 	}
 
 	/**
-	 * Constructs a response with the given matching triples, metadata triples, next page URL, federation member,
-	 * request, request start time, retrieval end time, and error details.
+	 * Constructs a response with the given matching triples, metadata
+	 * triples, next page URL, request start time, retrieval end time,
+	 * and error details.
 	 *
 	 * @param matchingTriples  the list of triples matching the request pattern (must not be null)
 	 * @param metadataTriples  the list of metadata triples (must not be null)
 	 * @param nextPageURL      the URL for the next page of results, or {@code null} if there is none
-	 * @param fm               the federation member from which the data was retrieved
-	 * @param request          the original data retrieval request
 	 * @param requestStartTime the timestamp when the request started
 	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
 	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
@@ -180,13 +163,11 @@ public class TPFResponseImpl extends DataRetrievalResponseBase<Iterable<Triple>>
 	public TPFResponseImpl( final List<Triple> matchingTriples,
 	                        final List<Triple> metadataTriples,
 	                        final String nextPageURL,
-	                        final FederationMember fm,
-	                        final DataRetrievalRequest request,
 	                        final Date requestStartTime,
 	                        final Date retrievalEndTime,
 	                        final Integer errorStatusCode,
 	                        final String errorDescription ) {
-		super( matchingTriples, fm, request, requestStartTime, retrievalEndTime, errorStatusCode, errorDescription );
+		super(matchingTriples, requestStartTime, retrievalEndTime, errorStatusCode, errorDescription);
 
 		assert metadataTriples != null;
 
@@ -196,16 +177,15 @@ public class TPFResponseImpl extends DataRetrievalResponseBase<Iterable<Triple>>
 	}
 
 	/**
-	 * Constructs a response with the given matching triples, metadata triples, next page URL, triple count, federation
-	 * member, request, request start time, and error details. The retrieval end time is automatically set to the
-	 * current time at the moment of construction.
+	 * Constructs a response with the given matching triples, metadata
+	 * triples, next page URL, triple count, request start time, and
+	 * error details. The retrieval end time is automatically set to
+	 * the current time at the moment of construction.
 	 *
 	 * @param matchingTriples  the list of triples matching the request pattern (must not be null)
 	 * @param metadataTriples  the list of metadata triples (must not be null)
 	 * @param nextPageURL      the URL for the next page of results, or {@code null} if there is none
 	 * @param tripleCount      the triple count
-	 * @param fm               the federation member from which the data was retrieved
-	 * @param request          the original data retrieval request
 	 * @param requestStartTime the timestamp when the request started
 	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
 	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
@@ -214,12 +194,10 @@ public class TPFResponseImpl extends DataRetrievalResponseBase<Iterable<Triple>>
 	                        final List<Triple> metadataTriples,
 	                        final String nextPageURL,
 	                        final int tripleCount,
-	                        final FederationMember fm,
-	                        final DataRetrievalRequest request,
 	                        final Date requestStartTime,
 	                        final Integer errorStatusCode,
 	                        final String errorDescription ) {
-		super( matchingTriples, fm, request, requestStartTime, errorStatusCode, errorDescription );
+		super(matchingTriples, requestStartTime, errorStatusCode, errorDescription);
 
 		assert metadataTriples != null;
 		assert tripleCount >= 0;
@@ -230,15 +208,14 @@ public class TPFResponseImpl extends DataRetrievalResponseBase<Iterable<Triple>>
 	}
 
 	/**
-	 * Constructs a response with the given matching triples, metadata triples, next page URL, triple count, federation
-	 * member, request, request start time, retrieval end time, and error details.
+	 * Constructs a response with the given matching triples, metadata
+	 * triples, next page URL, triple count, request start time, retrieval
+	 * end time, and error details.
 	 *
 	 * @param matchingTriples  the list of triples matching the request pattern (must not be null)
 	 * @param metadataTriples  the list of metadata triples (must not be null)
 	 * @param nextPageURL      the URL for the next page of results, or {@code null} if there is none
 	 * @param tripleCount      the triple count
-	 * @param fm               the federation member from which the data was retrieved
-	 * @param request          the original data retrieval request
 	 * @param requestStartTime the timestamp when the request started
 	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
 	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
@@ -248,13 +225,11 @@ public class TPFResponseImpl extends DataRetrievalResponseBase<Iterable<Triple>>
 	                        final List<Triple> metadataTriples,
 	                        final String nextPageURL,
 	                        final int tripleCount,
-	                        final FederationMember fm,
-	                        final DataRetrievalRequest request,
 	                        final Date requestStartTime,
 	                        final Date retrievalEndTime,
 	                        final Integer errorStatusCode,
 	                        final String errorDescription ) {
-		super( matchingTriples, fm, request, requestStartTime, retrievalEndTime, errorStatusCode, errorDescription );
+		super(matchingTriples, requestStartTime, retrievalEndTime, errorStatusCode, errorDescription);
 
 		assert metadataTriples != null;
 		assert tripleCount >= 0;
@@ -296,8 +271,8 @@ public class TPFResponseImpl extends DataRetrievalResponseBase<Iterable<Triple>>
 			throw new UnsupportedOperationDueToRetrievalError(
 				getErrorStatusCode(),
 				getErrorDescription(),
-				getRequest(),
-				getFederationMember()
+				null,   // unknown request
+				null    // unknown federation member
 			);
 		}
 		return new ConcatenatingIterable<Triple>( getPayload(), getMetadata() );

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/TPFResponseImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/TPFResponseImpl.java
@@ -269,11 +269,8 @@ public class TPFResponseImpl extends DataRetrievalResponseBase<Iterable<Triple>>
 	public Iterable<Triple> getResponseData() throws UnsupportedOperationDueToRetrievalError {
 		if ( isError() ) {
 			throw new UnsupportedOperationDueToRetrievalError(
-				getErrorStatusCode(),
-				getErrorDescription(),
-				null,   // unknown request
-				null    // unknown federation member
-			);
+					getErrorStatusCode(),
+					getErrorDescription() );
 		}
 		return new ConcatenatingIterable<Triple>( getPayload(), getMetadata() );
 	}

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/TriplesResponseImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/response/TriplesResponseImpl.java
@@ -4,86 +4,69 @@ import java.util.Date;
 import java.util.List;
 
 import se.liu.ida.hefquin.base.data.Triple;
-import se.liu.ida.hefquin.federation.FederationMember;
-import se.liu.ida.hefquin.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.federation.access.TriplesResponse;
 
 public class TriplesResponseImpl extends DataRetrievalResponseBase<Iterable<Triple>> implements TriplesResponse
 {
 	/**
-	 * Constructs a response with the given triples, federation member, request, and request start time. The retrieval
-	 * end time is automatically set to the current time at the moment of construction. This constructor assumes no
-	 * error occurred.
+	 * Constructs a response with the given triples and request start time.
+	 * The retrieval end time is automatically set to the current time at
+	 * the moment of construction. This constructor assumes no error occurred.
 	 *
 	 * @param triples          the list of triples contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the data retrieval request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 */
 	public TriplesResponseImpl( final List<Triple> triples,
-	                            final FederationMember fm,
-	                            final DataRetrievalRequest request,
 	                            final Date requestStartTime ) {
-		super( triples, fm, request, requestStartTime );
+		super(triples, requestStartTime);
 	}
 
 	/**
-	 * Constructs a response with the given triples, federation member, request, request start time, and the retrieval
-	 * end time. This constructor assumes no error occurred.
+	 * Constructs a response with the given triples, request start time, and
+	 * the retrieval end time. This constructor assumes no error occurred.
 	 *
 	 * @param triples          the list of triples contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the data retrieval request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
 	 */
 	public TriplesResponseImpl( final List<Triple> triples,
-	                         final FederationMember fm,
-	                         final DataRetrievalRequest request,
-	                         final Date requestStartTime,
-	                         final Date retrievalEndTime ) {
-		super( triples, fm, request, requestStartTime, retrievalEndTime );
+	                            final Date requestStartTime,
+	                            final Date retrievalEndTime ) {
+		super(triples, requestStartTime, retrievalEndTime);
 	}
 
 	/**
-	 * Constructs a response with the given triples, federation member, request, request start time, and error details.
-	 * The retrieval end time is automatically set to the current time at the moment of construction.
+	 * Constructs a response with the given triples, request start time,
+	 * and error details. The retrieval end time is automatically set to
+	 * the current time at the moment of construction.
 	 *
 	 * @param triples          the list of triples contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the data retrieval request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
 	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
 	 */
 	public TriplesResponseImpl( final List<Triple> triples,
-	                            final FederationMember fm,
-	                            final DataRetrievalRequest request,
 	                            final Date requestStartTime,
 	                            final Integer errorStatusCode,
 	                            final String errorDescription ) {
-		super( triples, fm, request, requestStartTime, errorStatusCode, errorDescription );
+		super(triples, requestStartTime, errorStatusCode, errorDescription);
 	}
 
 	/**
-	 * Constructs a response with the given triples, federation member, request, request start time, retireval end time,
-	 * and error details.
+	 * Constructs a response with the given triples, request start time,
+	 * retrieval end time, and error details.
 	 *
 	 * @param triples          the list of triples contained in this response (must not be {@code null})
-	 * @param fm               the federation member from which this response originates (must not be {@code null})
-	 * @param request          the data retrieval request associated with this response (must not be {@code null})
 	 * @param requestStartTime the time at which the request was initiated (must not be {@code null})
 	 * @param retrievalEndTime the time at which the retrieval of this response was completed (must not be {@code null})
 	 * @param errorStatusCode  the HTTP status code representing an error, or {@code null} if no error occurred
 	 * @param errorDescription a short description of the error, or {@code null} if no error occurred
 	 */
 	public TriplesResponseImpl( final List<Triple> triples,
-	                            final FederationMember fm,
-	                            final DataRetrievalRequest request,
 	                            final Date requestStartTime,
 	                            final Date retrievalEndTime,
 	                            final Integer errorStatusCode,
 	                            final String errorDescription ) {
-		super( triples, fm, request, requestStartTime, retrievalEndTime, errorStatusCode, errorDescription );
+		super(triples, requestStartTime, retrievalEndTime, errorStatusCode, errorDescription);
 	}
 }

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/AsyncFederationAccessManagerImplTest.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/AsyncFederationAccessManagerImplTest.java
@@ -1,7 +1,5 @@
 package se.liu.ida.hefquin.federation.access.impl;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.concurrent.CompletableFuture;
@@ -72,10 +70,7 @@ public class AsyncFederationAccessManagerImplTest extends FederationTestBase
 		final FederationAccessManager fedAccessMgr = createFedAccessMgrForTests(execServiceForFedAccess, SLEEP_MILLIES);
 
 		final CompletableFuture<TPFResponse> fr = fedAccessMgr.issueRequest(req, fm);
-		final TPFResponse resp = fr.get();
-
-		assertEquals( req, resp.getRequest() );
-		assertEquals( fm, resp.getFederationMember() );
+		fr.get();
 	}
 
 	@Test
@@ -91,10 +86,7 @@ public class AsyncFederationAccessManagerImplTest extends FederationTestBase
 		final FederationAccessManager fedAccessMgr = createFedAccessMgrForTests(execServiceForFedAccess, SLEEP_MILLIES);
 
 		final CompletableFuture<TPFResponse> fr = fedAccessMgr.issueRequest(req, fm);
-		final TPFResponse resp = fr.get();
-
-		assertEquals( req, resp.getRequest() );
-		assertEquals( fm, resp.getFederationMember() );
+		fr.get();
 	}
 
 	@Test
@@ -114,18 +106,13 @@ public class AsyncFederationAccessManagerImplTest extends FederationTestBase
 		final long startTime = new Date().getTime();
 
 		final CompletableFuture<TPFResponse> fr1 = fedAccessMgr.issueRequest(req1, fm1);
-		final TPFResponse r1 = fr1.get();
+		fr1.get();
 
 		final CompletableFuture<TPFResponse> fr2 = fedAccessMgr.issueRequest(req2, fm2);
-		final TPFResponse r2 = fr2.get();
+		fr2.get();
 
 		final long endTime = new Date().getTime();
 		if ( PRINT_TIME ) System.out.println( "twoRequestsInSequence \t milliseconds passed: " + (endTime - startTime) );
-
-		assertEquals( req1, r1.getRequest() );
-		assertEquals( req2, r2.getRequest() );
-		assertEquals( fm1, r1.getFederationMember() );
-		assertEquals( fm2, r2.getFederationMember() );
 	}
 
 	@Test
@@ -147,16 +134,11 @@ public class AsyncFederationAccessManagerImplTest extends FederationTestBase
 		final CompletableFuture<TPFResponse> fr1 = fedAccessMgr.issueRequest(req1, fm1);
 		final CompletableFuture<TPFResponse> fr2 = fedAccessMgr.issueRequest(req2, fm2);
 
-		final TPFResponse r1 = fr1.get();
-		final TPFResponse r2 = fr2.get();
+		fr1.get();
+		fr2.get();
 
 		final long endTime = new Date().getTime();
 		if ( PRINT_TIME ) System.out.println( "twoRequestsInParallel \t milliseconds passed: " + (endTime - startTime) );
-
-		assertEquals( req1, r1.getRequest() );
-		assertEquals( req2, r2.getRequest() );
-		assertEquals( fm1, r1.getFederationMember() );
-		assertEquals( fm2, r2.getFederationMember() );
 	}
 
 	@Test
@@ -255,7 +237,7 @@ public class AsyncFederationAccessManagerImplTest extends FederationTestBase
 		@Override
 		public SolMapsResponse performRequest( final SPARQLRequest req, final SPARQLEndpoint fm ) {
 			sleep();
-			return new SolMapsResponseImpl( new ArrayList<>(), fm, req, new Date() );
+			return new SolMapsResponseImpl( new ArrayList<>(), new Date() );
 		}
 	}
 
@@ -267,13 +249,13 @@ public class AsyncFederationAccessManagerImplTest extends FederationTestBase
 		@Override
 		public TPFResponse performRequest( final TPFRequest req, final TPFServer fm ) {
 			sleep();
-			return new TPFResponseImpl( new ArrayList<>(), new ArrayList<>(), "dummy next page", fm, req, new Date() );
+			return new TPFResponseImpl( new ArrayList<>(), new ArrayList<>(), "dummy next page", new Date() );
 		}
 
 		@Override
 		public TPFResponse performRequest( final TPFRequest req, final BRTPFServer fm ) {
 			sleep();
-			return new TPFResponseImpl( new ArrayList<>(), new ArrayList<>(), "dummy next page", fm, req, new Date() );
+			return new TPFResponseImpl( new ArrayList<>(), new ArrayList<>(), "dummy next page", new Date() );
 		}
 	}
 

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerBase1Test.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerBase1Test.java
@@ -61,7 +61,6 @@ public class FederationAccessManagerBase1Test extends FederationTestBase
 
 		final CardinalityResponse r = fedAccessMgr.issueCardinalityRequest( req, fm ).get();
 
-		assertEquals( fm, r.getFederationMember() );
 		assertEquals( card, r.getCardinality() );
 	}
 
@@ -80,7 +79,6 @@ public class FederationAccessManagerBase1Test extends FederationTestBase
 
 		final CardinalityResponse r = fedAccessMgr.issueCardinalityRequest( req, fm ).get();
 
-		assertEquals( fm, r.getFederationMember() );
 		assertEquals( card, r.getCardinality() );
 	}
 
@@ -112,8 +110,6 @@ public class FederationAccessManagerBase1Test extends FederationTestBase
 			System.out.println( "twoCardinalityRequestsInParallel \t milliseconds passed: " + (endTime - startTime) );
 		}
 
-		assertEquals( fm1, r1.getFederationMember() );
-		assertEquals( fm2, r2.getFederationMember() );
 		assertEquals( card, r1.getCardinality() );
 		assertEquals( card, r2.getCardinality() );
 	}
@@ -146,8 +142,6 @@ public class FederationAccessManagerBase1Test extends FederationTestBase
 			System.out.println( "twoCardinalityRequestsInSequence \t milliseconds passed: " + (endTime - startTime) );
 		}
 
-		assertEquals( fm1, r1.getFederationMember() );
-		assertEquals( fm2, r2.getFederationMember() );
 		assertEquals( card, r1.getCardinality() );
 		assertEquals( card, r2.getCardinality() );
 	}
@@ -275,9 +269,9 @@ public class FederationAccessManagerBase1Test extends FederationTestBase
 			final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping( countVar, countNode );
 			final SolMapsResponse r;
 			if ( ! simulateError ) {
-				r = new SolMapsResponseImpl( Arrays.asList(sm), fm, req, new Date() );
+				r = new SolMapsResponseImpl( Arrays.asList(sm), new Date() );
 			} else {
-				r = new SolMapsResponseImpl( Arrays.asList(sm), fm, req, new Date(), 400, "Response error" );
+				r = new SolMapsResponseImpl( Arrays.asList(sm), new Date(), 400, "Response error" );
 			}
 
 			return CompletableFuture.supplyAsync( () -> {
@@ -301,8 +295,6 @@ public class FederationAccessManagerBase1Test extends FederationTestBase
 				r = new TPFResponseImpl( Collections.emptyList(),
 				                         Collections.emptyList(),
 				                         null,
-				                         fm,
-				                         req,
 				                         new Date() ) {
 					@Override
 					public Integer getCardinalityEstimate() {
@@ -314,8 +306,6 @@ public class FederationAccessManagerBase1Test extends FederationTestBase
 				r = new TPFResponseImpl( Collections.emptyList(),
 				                         Collections.emptyList(),
 				                         null,
-				                         fm,
-				                         req,
 				                         new Date(),
 				                         400,
 				                         "Response error" );

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerWithCacheTest.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerWithCacheTest.java
@@ -1,7 +1,5 @@
 package se.liu.ida.hefquin.federation.access.impl;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.Date;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -62,18 +60,13 @@ public class FederationAccessManagerWithCacheTest extends FederationTestBase
 		final long startTime = new Date().getTime();
 
 		final CompletableFuture<TPFResponse> fr1 = fedAccessMgr.issueRequest(req1, fm1);
-		final TPFResponse r1 = fr1.get();
+		fr1.get();
 
 		final CompletableFuture<TPFResponse> fr2 = fedAccessMgr.issueRequest(req1, fm2);
-		final TPFResponse r2 = fr2.get();
+		fr2.get();
 
 		final long endTime = new Date().getTime();
 		if ( PRINT_TIME ) System.out.println( "twoRequestsInSequence \t milliseconds passed: " + (endTime - startTime) );
-
-		assertEquals( req1, r1.getRequest() );
-		assertEquals( req1, r2.getRequest() );
-		assertEquals( fm1, r1.getFederationMember() );
-		assertEquals( fm2, r2.getFederationMember() );
 	}
 
 	@Test
@@ -94,16 +87,11 @@ public class FederationAccessManagerWithCacheTest extends FederationTestBase
 		final CompletableFuture<TPFResponse> fr1 = fedAccessMgr.issueRequest(req1, fm1);
 		final CompletableFuture<TPFResponse> fr2 = fedAccessMgr.issueRequest(req1, fm2);
 
-		final TPFResponse r1 = fr1.get();
-		final TPFResponse r2 = fr2.get();
+		fr1.get();
+		fr2.get();
 
 		final long endTime = new Date().getTime();
 		if ( PRINT_TIME ) System.out.println( "twoRequestsInParallel \t milliseconds passed: " + (endTime - startTime) );
-
-		assertEquals( req1, r1.getRequest() );
-		assertEquals( req1, r2.getRequest() );
-		assertEquals( fm1, r1.getFederationMember() );
-		assertEquals( fm2, r2.getFederationMember() );
 	}
 
 	@Test

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerWithChronicleMapCacheTest.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerWithChronicleMapCacheTest.java
@@ -790,7 +790,7 @@ public class FederationAccessManagerWithChronicleMapCacheTest extends Federation
 
 			// Wrap in a list and return the response
 			List<SolutionMapping> mockResult = Collections.singletonList( solMap );
-			return new SolMapsResponseImpl( mockResult, fm, req, new Date() );
+			return new SolMapsResponseImpl( mockResult, new Date() );
 		}
 	}
 
@@ -820,8 +820,6 @@ public class FederationAccessManagerWithChronicleMapCacheTest extends Federation
 			final TPFResponse r = new TPFResponseImpl( Collections.emptyList(),
 			                                           Collections.emptyList(),
 			                                           null,
-			                                           fm,
-			                                           req,
 			                                           new Date() ) {
 				final int cardinalityEstimate = cardinality;
 
@@ -840,8 +838,6 @@ public class FederationAccessManagerWithChronicleMapCacheTest extends Federation
 			final TPFResponse r = new TPFResponseImpl( Collections.emptyList(),
 			                                           Collections.emptyList(),
 			                                           null,
-			                                           fm,
-			                                           req,
 			                                           new Date() ) {
 				final int cardinalityEstimate = cardinality;
 
@@ -881,8 +877,6 @@ public class FederationAccessManagerWithChronicleMapCacheTest extends Federation
 			final TPFResponse r = new TPFResponseImpl( Collections.emptyList(),
 			                                           Collections.emptyList(),
 			                                           null,
-			                                           fm,
-			                                           req,
 			                                           new Date() ) {
 				final int cardinalityEstimate = cardinality;
 

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerWithPersistedDiskCacheTest.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerWithPersistedDiskCacheTest.java
@@ -706,7 +706,7 @@ public class FederationAccessManagerWithPersistedDiskCacheTest extends Federatio
 
 			// Wrap in a list and return the response
 			List<SolutionMapping> mockResult = Collections.singletonList( solMap );
-			return new SolMapsResponseImpl( mockResult, fm, req, new Date() );
+			return new SolMapsResponseImpl( mockResult, new Date() );
 		}
 	}
 
@@ -736,8 +736,6 @@ public class FederationAccessManagerWithPersistedDiskCacheTest extends Federatio
 			final TPFResponse r = new TPFResponseImpl( Collections.emptyList(),
 			                                           Collections.emptyList(),
 			                                           null,
-			                                           fm,
-			                                           req,
 			                                           new Date() ) {
 				final int cardinalityEstimate = card;
 
@@ -756,8 +754,6 @@ public class FederationAccessManagerWithPersistedDiskCacheTest extends Federatio
 			final TPFResponse r = new TPFResponseImpl( Collections.emptyList(),
 			                                           Collections.emptyList(),
 			                                           null,
-			                                           fm,
-			                                           req,
 			                                           new Date() ) {
 				final int cardinalityEstimate = card;
 
@@ -797,8 +793,6 @@ public class FederationAccessManagerWithPersistedDiskCacheTest extends Federatio
 			final TPFResponse r = new TPFResponseImpl( Collections.emptyList(),
 			                                           Collections.emptyList(),
 			                                           null,
-			                                           fm,
-			                                           req,
 			                                           new Date() ) {
 				final int cardinalityEstimate = card;
 

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/reqproc/GraphQLRequestProcessorImplTest.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/reqproc/GraphQLRequestProcessorImplTest.java
@@ -1,7 +1,5 @@
 package se.liu.ida.hefquin.federation.access.impl.reqproc;
 
-import static org.junit.Assert.assertEquals;
-
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -21,7 +19,6 @@ import se.liu.ida.hefquin.engine.wrappers.graphql.query.impl.GraphQLQueryImpl;
 import se.liu.ida.hefquin.federation.FederationTestBase;
 import se.liu.ida.hefquin.federation.access.FederationAccessException;
 import se.liu.ida.hefquin.federation.access.GraphQLRequest;
-import se.liu.ida.hefquin.federation.access.JSONResponse;
 import se.liu.ida.hefquin.federation.access.impl.req.GraphQLRequestImpl;
 import se.liu.ida.hefquin.federation.members.GraphQLEndpoint;
 import se.liu.ida.hefquin.federation.members.impl.GraphQLEndpointImpl;
@@ -100,10 +97,7 @@ public class GraphQLRequestProcessorImplTest extends FederationTestBase
             final GraphQLRequest req = new GraphQLRequestImpl(query);
             final GraphQLEndpoint fm = new GraphQLEndpointTest();
             final GraphQLRequestProcessor processor = new GraphQLRequestProcessorImpl(3000, 3000);
-            final JSONResponse response = processor.performRequest(req, fm);
-			
-            assertEquals(fm, response.getFederationMember());
-            assertEquals(req, response.getRequest());
+            processor.performRequest(req, fm);
         }
     }
 }

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/reqproc/Neo4jRequestProcessorImplTest.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/reqproc/Neo4jRequestProcessorImplTest.java
@@ -5,11 +5,8 @@ import org.junit.Test;
 import se.liu.ida.hefquin.federation.FederationTestBase;
 import se.liu.ida.hefquin.federation.access.FederationAccessException;
 import se.liu.ida.hefquin.federation.access.Neo4jRequest;
-import se.liu.ida.hefquin.federation.access.RecordsResponse;
 import se.liu.ida.hefquin.federation.access.impl.req.Neo4jRequestImpl;
 import se.liu.ida.hefquin.federation.members.Neo4jServer;
-
-import static org.junit.Assert.assertEquals;
 
 public class Neo4jRequestProcessorImplTest extends FederationTestBase {
 
@@ -23,10 +20,7 @@ public class Neo4jRequestProcessorImplTest extends FederationTestBase {
 
             final Neo4jRequestProcessor processor = new Neo4jRequestProcessorImpl();
 
-            final RecordsResponse response = processor.performRequest(req, fm);
-
-            assertEquals( fm, response.getFederationMember() );
-            assertEquals( req, response.getRequest() );
+            processor.performRequest(req, fm);
         }
     }
 

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/reqproc/SPARQLRequestProcessorImplTest.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/reqproc/SPARQLRequestProcessorImplTest.java
@@ -122,10 +122,6 @@ public class SPARQLRequestProcessorImplTest extends FederationTestBase
 		// executing the tested method
 		final SolMapsResponse resp = recProc.performRequest(req, fm);
 
-		// checking
-		assertEquals( fm, resp.getFederationMember() );
-		assertEquals( req, resp.getRequest() );
-
 		return resp.getResponseData().iterator();
 	}
 

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/reqproc/TPFRequestProcessorImplTest.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/reqproc/TPFRequestProcessorImplTest.java
@@ -130,10 +130,6 @@ public class TPFRequestProcessorImplTest extends FederationTestBase
 		// performing the tested operation
 		final TPFResponse resp = proc.performRequest(req, tpfServer);
 
-		// checking
-		assertEquals( req, resp.getRequest() );
-		assertEquals( tpfServer, resp.getFederationMember() );
-
 		return resp;
 	}
 

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/EngineTestBase.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/EngineTestBase.java
@@ -217,7 +217,7 @@ public abstract class EngineTestBase
 			} else {
 				result = getSolutions(req.getQueryPattern());
 			}
-			return new SolMapsResponseImpl( result, this, req, new Date() );
+			return new SolMapsResponseImpl( result, new Date() );
 		}
 
 	}
@@ -410,7 +410,7 @@ public abstract class EngineTestBase
 		public TPFResponseForTest( final List<Triple> matchingTriples,
 		                           final FederationMember fm,
 		                           final DataRetrievalRequest req ) {
-			super( matchingTriples, new ArrayList<Triple>(), null, fm, req, new Date() );
+			super( matchingTriples, new ArrayList<Triple>(), null, new Date() );
 		}
 
 		@Override
@@ -496,7 +496,8 @@ public abstract class EngineTestBase
 		{
 			final SolMapsResponse response;
 			if ( itSolMapsForResponse != null ) {
-				response = new SolMapsResponseImpl( itSolMapsForResponse.next(), fm, req, new Date() );
+				response = new SolMapsResponseImpl( itSolMapsForResponse.next(),
+				                                    new Date() );
 			}
 			else {
 				if (fm.getVocabularyMapping() != null) {
@@ -567,7 +568,8 @@ public abstract class EngineTestBase
 			else
 				throw new IllegalArgumentException();
 
-			final StringResponse response = new StringResponseImpl(data, fm, req, new Date());
+			final StringResponse response = new StringResponseImpl( data,
+			                                                        new Date() );
 			return CompletableFuture.completedFuture(response);
 		}
 

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/cardinality/CardinalityEstimationImplTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/cardinality/CardinalityEstimationImplTest.java
@@ -448,7 +448,7 @@ public class CardinalityEstimationImplTest extends EngineTestBase
 				@Override public Date getRequestStartTime() { return null; }
 				@Override public Integer getResponseData() throws UnsupportedOperationDueToRetrievalError {
 					if( isError() ){
-						throw new UnsupportedOperationDueToRetrievalError(req, fm);
+						throw new UnsupportedOperationDueToRetrievalError();
 					}
 					return c; }
 			};

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/cardinality/CardinalityEstimationImplTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/cardinality/CardinalityEstimationImplTest.java
@@ -23,7 +23,6 @@ import se.liu.ida.hefquin.engine.queryplan.utils.PhysicalPlanFactory;
 import se.liu.ida.hefquin.engine.queryproc.impl.poptimizer.CardinalityEstimation;
 import se.liu.ida.hefquin.federation.FederationMember;
 import se.liu.ida.hefquin.federation.access.CardinalityResponse;
-import se.liu.ida.hefquin.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.federation.access.FederationAccessException;
 import se.liu.ida.hefquin.federation.access.FederationAccessManager;
 import se.liu.ida.hefquin.federation.access.TPFRequest;
@@ -447,11 +446,9 @@ public class CardinalityEstimationImplTest extends EngineTestBase
 			final CardinalityResponse resp = new CardinalityResponse() {
 				@Override public Date getRetrievalEndTime() { return null; }
 				@Override public Date getRequestStartTime() { return null; }
-				@Override public DataRetrievalRequest getRequest() { return req; }
-				@Override public FederationMember getFederationMember() { return fm; }
 				@Override public Integer getResponseData() throws UnsupportedOperationDueToRetrievalError {
 					if( isError() ){
-						throw new UnsupportedOperationDueToRetrievalError( getRequest(), getFederationMember() );
+						throw new UnsupportedOperationDueToRetrievalError(req, fm);
 					}
 					return c; }
 			};


### PR DESCRIPTION
Removes `getRequest()` and `getFederationMember()` from `DataRetrievalResponse` as [I had proposed](https://github.com/LiUSemWeb/HeFQUIN/pull/546#pullrequestreview-4061850281) in PR #546.

@keski, once this PR is merged, you can continue working on PR #546.