### PR TITLE
Adds logical & physical plan without result

### DIFF
--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalPlanWithoutResult.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalPlanWithoutResult.java
@@ -1,0 +1,48 @@
+package se.liu.ida.hefquin.engine.queryplan.logical.impl;
+
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import org.apache.jena.sparql.core.Var;
+
+import se.liu.ida.hefquin.base.query.ExpectedVariables;
+import se.liu.ida.hefquin.engine.queryplan.base.impl.BaseForQueryPlan;
+import se.liu.ida.hefquin.engine.queryplan.logical.LogicalOperator;
+import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlan;
+
+/**
+ * This class represents a logical plan that produces the empty result.
+ */
+public class LogicalPlanWithoutResult extends BaseForQueryPlan
+                                      implements LogicalPlan
+{
+	public static LogicalPlan getInstance() { return instance; }
+
+	protected static final LogicalPlan instance = new LogicalPlanWithoutResult();
+
+	public static final ExpectedVariables expVars = new ExpectedVariables() {
+		@Override
+		public Set<Var> getCertainVariables() { return Set.of(); }
+
+		@Override
+		public Set<Var> getPossibleVariables() { return Set.of(); }
+	};
+
+	protected LogicalPlanWithoutResult() {}
+
+	@Override
+	public int numberOfSubPlans() { return 0; }
+
+	@Override
+	public ExpectedVariables getExpectedVariables() { return expVars; }
+
+	@Override
+	public LogicalOperator getRootOperator() throws NoSuchElementException {
+		throw new NoSuchElementException();
+	}
+
+	@Override
+	public LogicalPlan getSubPlan( final int i ) throws NoSuchElementException {
+		throw new NoSuchElementException();
+	}
+}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalPlanWithoutResult.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalPlanWithoutResult.java
@@ -1,0 +1,40 @@
+package se.liu.ida.hefquin.engine.queryplan.physical.impl;
+
+import java.util.NoSuchElementException;
+
+import se.liu.ida.hefquin.base.query.ExpectedVariables;
+import se.liu.ida.hefquin.engine.queryplan.base.impl.BaseForQueryPlan;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalPlanWithoutResult;
+import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalOperator;
+import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
+
+/**
+ * This class represents a physical plan that produces the empty result.
+ */
+public class PhysicalPlanWithoutResult extends BaseForQueryPlan
+                                       implements PhysicalPlan
+{
+	public static PhysicalPlan getInstance() { return instance; }
+
+	protected static final PhysicalPlan instance = new PhysicalPlanWithoutResult();
+
+	protected PhysicalPlanWithoutResult() {}
+
+	@Override
+	public int numberOfSubPlans() { return 0; }
+
+	@Override
+	public ExpectedVariables getExpectedVariables() {
+		return LogicalPlanWithoutResult.expVars;
+	}
+
+	@Override
+	public PhysicalOperator getRootOperator() throws NoSuchElementException {
+		throw new NoSuchElementException();
+	}
+
+	@Override
+	public PhysicalPlan getSubPlan( final int i ) throws NoSuchElementException {
+		throw new NoSuchElementException();
+	}
+}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedLogicalPlanPrinterImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedLogicalPlanPrinterImpl.java
@@ -69,6 +69,10 @@ public class TextBasedLogicalPlanPrinterImpl extends BaseForTextBasedPlanPrinter
 	}
 
 	public ExtPrintablePlan createPrintablePlan( final LogicalPlan lp ) {
+		if ( lp instanceof LogicalPlanWithoutResult ) {
+			return new ExtPrintablePlan( "empty plan", null, null, null, null );
+		}
+
 		final LogicalOperator rootOp = lp.getRootOperator();
 
 		rootOp.visit(snc);

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedPhysicalPlanPrinterImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedPhysicalPlanPrinterImpl.java
@@ -16,6 +16,7 @@ import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanWithNaryRoot;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanWithNullaryRoot;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanWithUnaryRoot;
 import se.liu.ida.hefquin.engine.queryplan.physical.impl.*;
+import se.liu.ida.hefquin.engine.queryplan.utils.BaseForTextBasedPlanPrinters.ExtPrintablePlan;
 
 /**
  * Internally, the functionality of this class is implemented based on
@@ -59,6 +60,10 @@ public class TextBasedPhysicalPlanPrinterImpl extends BaseForTextBasedPlanPrinte
 	}
 
 	public ExtPrintablePlan createPrintablePlan( final PhysicalPlan p ) {
+		if ( p instanceof PhysicalPlanWithoutResult ) {
+			return new ExtPrintablePlan( "empty plan", null, null, null, null );
+		}
+
 		pe.graphPattern = null;
 		pe.fullStringForGraphPattern = null;
 		pe.rootOpString = null;

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/QueryProcessorImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/QueryProcessorImpl.java
@@ -10,6 +10,7 @@ import se.liu.ida.hefquin.base.utils.StatsPrinter;
 import se.liu.ida.hefquin.engine.QueryProcessingStatsAndExceptions;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutablePlan;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
+import se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalPlanWithoutResult;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionEngine;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionStats;
 import se.liu.ida.hefquin.engine.queryproc.QueryPlanCompiler;
@@ -61,23 +62,22 @@ public class QueryProcessorImpl implements QueryProcessor
 	{
 		final long t1 = System.currentTimeMillis();
 		final Pair<PhysicalPlan, QueryPlanningStats> qepAndStats = planner.createPlan(query, ctxt);
+		final PhysicalPlan qep = qepAndStats.object1;
 
 		final long t2 = System.currentTimeMillis();
 
 		final long t3, t4;
-		final ExecutablePlan prg;
 		final ExecutionStats execStats;
 		final List<Exception> exceptionsCaughtDuringExecution;
 
-		if ( ctxt.skipExecution() ) {
+		if ( ctxt.skipExecution() || qep instanceof PhysicalPlanWithoutResult ) {
 			t3 = System.currentTimeMillis();
 			t4 = System.currentTimeMillis();
-			prg = null;
 			execStats = null;
 			exceptionsCaughtDuringExecution = null;
 		}
 		else {
-			prg = planCompiler.compile(qepAndStats.object1);
+			final ExecutablePlan prg = planCompiler.compile(qepAndStats.object1);
 
 			if ( planner.getExecutablePlanPrinter() != null ) {
 				planner.getExecutablePlanPrinter().print( prg );

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/HeuristicsBasedLogicalOptimizerImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/HeuristicsBasedLogicalOptimizerImpl.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlan;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalPlanWithoutResult;
 import se.liu.ida.hefquin.engine.queryproc.LogicalOptimizationException;
 import se.liu.ida.hefquin.engine.queryproc.LogicalOptimizer;
 import se.liu.ida.hefquin.engine.queryproc.QueryProcContext;
@@ -63,6 +64,11 @@ public class HeuristicsBasedLogicalOptimizerImpl implements LogicalOptimizer
 		LogicalPlan resultPlan = inputPlan;
 		for ( final HeuristicForLogicalOptimization h : heuristics ) {
 			resultPlan = h.apply(resultPlan);
+
+			// If the plan has been rewritten into the plan that produces
+			// the empty result, then this plan can be returned immediately.
+			if ( resultPlan instanceof LogicalPlanWithoutResult )
+				return resultPlan;
 		}
 
 		return resultPlan;

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/planning/QueryPlannerImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/planning/QueryPlannerImpl.java
@@ -3,7 +3,9 @@ package se.liu.ida.hefquin.engine.queryproc.impl.planning;
 import se.liu.ida.hefquin.base.query.Query;
 import se.liu.ida.hefquin.base.utils.Pair;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlan;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalPlanWithoutResult;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
+import se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalPlanWithoutResult;
 import se.liu.ida.hefquin.engine.queryplan.utils.ExecutablePlanPrinter;
 import se.liu.ida.hefquin.engine.queryplan.utils.LogicalPlanPrinter;
 import se.liu.ida.hefquin.engine.queryplan.utils.PhysicalPlanPrinter;
@@ -81,8 +83,15 @@ public class QueryPlannerImpl implements QueryPlanner
 		if ( lplanPrinter != null ) {
 			lplanPrinter.print( lp, LogicalPlanStage.FINAL_LOGICAL_PLAN );
 		}
+
 		final long t3 = System.currentTimeMillis();
-		final Pair<PhysicalPlan, PhysicalOptimizationStats> planAndStats = poptimizer.optimize(lp, ctxt);
+
+		final Pair<PhysicalPlan, PhysicalOptimizationStats> planAndStats;
+		if ( lp instanceof LogicalPlanWithoutResult )
+			planAndStats = new Pair<>( PhysicalPlanWithoutResult.getInstance(),
+			                           null );  // no stats
+		else
+			planAndStats = poptimizer.optimize(lp, ctxt);
 
 		final long t4 = System.currentTimeMillis();
 


### PR DESCRIPTION
As a basis for #563 (especially for the second case described [in my comment](https://github.com/LiUSemWeb/HeFQUIN/issues/563#issuecomment-4246714477)), this PR adds `LogicalPlanWithoutResult` and `PhysicalPlanWithoutResult`, and extends the query processor as well as the plan printers to correctly handle these special kinds of plans.