### PR TITLE
Add ExecOpHashBasedMinus and tests

### DIFF
--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashBasedMinus.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashBasedMinus.java
@@ -7,6 +7,11 @@ import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 
+/**
+ * To be used for MINUS clauses. This operator extends {@link ExecOpHashJoin2} to
+ * calculate solution mappings in the left-hand side that are not compatible with
+ * the solutions on the right-hand side.
+ */
 public class ExecOpHashBasedMinus extends ExecOpHashJoin2
 {
 	public ExecOpHashBasedMinus( final boolean mayReduce,

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashBasedMinus.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashBasedMinus.java
@@ -1,0 +1,32 @@
+package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
+
+import java.util.Iterator;
+import java.util.List;
+
+import se.liu.ida.hefquin.base.data.SolutionMapping;
+import se.liu.ida.hefquin.base.query.ExpectedVariables;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
+
+public class ExecOpHashBasedMinus extends ExecOpHashJoin2
+{
+	public ExecOpHashBasedMinus( final boolean useOuterJoinSemantics,
+	                             final boolean mayReduce,
+	                             final ExpectedVariables inputVars1,
+	                             final ExpectedVariables inputVars2,
+	                             final boolean collectExceptions,
+	                             final QueryPlanningInfo qpInfo ) {
+		super(useOuterJoinSemantics, mayReduce, inputVars1, inputVars2, collectExceptions, qpInfo);
+	}
+
+	@Override
+	protected void produceOutput( final SolutionMapping inputSolMap,
+	                              final List<SolutionMapping> output) {
+		final Iterable<SolutionMapping> joinPartners = index.getJoinPartners(inputSolMap);
+		final Iterator<SolutionMapping> it = joinPartners.iterator();
+
+		if ( ! it.hasNext() ) {
+			output.add(inputSolMap);
+		}
+	}
+
+}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashBasedMinus.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashBasedMinus.java
@@ -9,13 +9,12 @@ import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 
 public class ExecOpHashBasedMinus extends ExecOpHashJoin2
 {
-	public ExecOpHashBasedMinus( final boolean useOuterJoinSemantics,
-	                             final boolean mayReduce,
+	public ExecOpHashBasedMinus( final boolean mayReduce,
 	                             final ExpectedVariables inputVars1,
 	                             final ExpectedVariables inputVars2,
 	                             final boolean collectExceptions,
 	                             final QueryPlanningInfo qpInfo ) {
-		super(useOuterJoinSemantics, mayReduce, inputVars1, inputVars2, collectExceptions, qpInfo);
+		super(true, mayReduce, inputVars1, inputVars2, collectExceptions, qpInfo);
 	}
 
 	@Override

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashBasedMinusTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashBasedMinusTest.java
@@ -1,0 +1,181 @@
+package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.Var;
+import org.junit.Test;
+
+import se.liu.ida.hefquin.base.data.SolutionMapping;
+import se.liu.ida.hefquin.base.data.utils.SolutionMappingUtils;
+import se.liu.ida.hefquin.base.query.ExpectedVariables;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.CollectingIntermediateResultElementSink;
+import se.liu.ida.hefquin.engine.queryproc.ExecutionException;
+
+public class ExecOpHashBasedMinusTest
+{
+	@Test
+	public void subtract() throws ExecutionException {
+		final Var var1 = Var.alloc("v1");
+		final Var var2 = Var.alloc("v2");
+		final Var var3 = Var.alloc("v3");
+
+		final Node x1 = NodeFactory.createURI("http://example.org/x1");
+		final Node x2 = NodeFactory.createURI("http://example.org/x2");
+		final Node y1 = NodeFactory.createURI("http://example.org/y1");
+		final Node y2 = NodeFactory.createURI("http://example.org/y2");
+		final Node y3 = NodeFactory.createURI("http://example.org/y3");
+
+		final List<SolutionMapping> input1 = new ArrayList<>();
+		input1.add( SolutionMappingUtils.createSolutionMapping(
+				var1, x1,
+				var2, y1) );
+
+		// Remaining solution mapping after the subtraction.
+		input1.add( SolutionMappingUtils.createSolutionMapping(
+				var1, x2,
+				var2, y2) );
+
+		final List<SolutionMapping> input2 = new ArrayList<>();
+		input2.add( SolutionMappingUtils.createSolutionMapping(
+				var1, x1,
+				var2, y1) );
+
+		Set<Var> varsCertain1 = new HashSet<>();
+		varsCertain1.add(var1);
+		varsCertain1.add(var2);
+		Set<Var> varsPossible1 = new HashSet<>();
+
+		Set<Var> varsCertain2 = new HashSet<>();
+		varsCertain2.add(var1);
+		varsCertain2.add(var2);
+		Set<Var> varsPossible2 = new HashSet<>();
+
+		ExpectedVariables[] inputVars = getExpectedVariables(varsCertain1, varsPossible1, varsCertain2, varsPossible2);
+
+		final Iterator<SolutionMapping> it = runTest(input1, input2, false, false, inputVars);
+
+		assertTrue( it.hasNext() );
+		final SolutionMapping sm = it.next();
+		assertEquals( x2, sm.asJenaBinding().get(var1) );
+		assertEquals( y2, sm.asJenaBinding().get(var2) );
+
+		assertFalse( it.hasNext() );
+	}
+
+	@Test
+	public void emptySubtractionResult() throws ExecutionException  {
+		final Var var1 = Var.alloc("v1");
+		final Var var2 = Var.alloc("v2");
+
+		final Node x1 = NodeFactory.createURI("http://example.org/x1");
+		final Node x2 = NodeFactory.createURI("http://example.org/x2");
+		final Node y1 = NodeFactory.createURI("http://example.org/y1");
+		final Node y2 = NodeFactory.createURI("http://example.org/y2");
+
+		final List<SolutionMapping> input1 = new ArrayList<>();
+		input1.add( SolutionMappingUtils.createSolutionMapping(
+				var1, x1,
+				var2, y1) );
+
+		final List<SolutionMapping> input2 = new ArrayList<>();
+		input2.add( SolutionMappingUtils.createSolutionMapping(
+				var1, x1,
+				var2, y1) );
+
+		Set<Var> varsCertain1 = new HashSet<>();
+		varsCertain1.add(var1);
+		varsCertain1.add(var2);
+		Set<Var> varsPossible1 = new HashSet<>();
+
+		Set<Var> varsCertain2 = new HashSet<>();
+		varsCertain2.add(var1);
+		varsCertain2.add(var2);
+		Set<Var> varsPossible2 = new HashSet<>();
+
+		ExpectedVariables[] inputVars = getExpectedVariables(varsCertain1, varsPossible1, varsCertain2, varsPossible2);
+
+		final Iterator<SolutionMapping> it = runTest(input1, input2, false, false, inputVars);
+
+		assertFalse( it.hasNext() );
+	}
+
+	/**
+	 * Sends second input first.
+	 */
+	protected Iterator<SolutionMapping> runTest(
+			final List<SolutionMapping> input1,
+			final List<SolutionMapping> input2,
+			final boolean sendAllSolMapsSeparately,
+			final boolean useOuterJoinSemantics,
+			final ExpectedVariables... inputVars ) throws ExecutionException
+	{
+		final CollectingIntermediateResultElementSink sink = new CollectingIntermediateResultElementSink();
+
+		final ExecOpHashBasedMinus op = createExecOpForTest( useOuterJoinSemantics, inputVars );
+
+		if ( sendAllSolMapsSeparately == true ) {
+			for ( final SolutionMapping sm : input2 ) {
+				op.processInputFromChild2(sm, sink, null);
+			}
+		}
+		else {
+			op.processInputFromChild2(input2, sink, null);
+		}
+
+		op.wrapUpForChild2(sink, null);
+
+		if ( sendAllSolMapsSeparately == true ) {
+			for ( final SolutionMapping sm : input1 ) {
+				op.processInputFromChild1(sm, sink, null);
+			}
+		}
+		else {
+			op.processInputFromChild1(input1, sink, null);
+		}
+
+		op.wrapUpForChild1(sink, null);
+
+		return sink.getCollectedSolutionMappings().iterator();
+	}
+
+	protected ExpectedVariables[] getExpectedVariables(
+			final Set<Var> varsCertain1,
+			final Set<Var> varsPossible1,
+			final Set<Var> varsCertain2,
+			final Set<Var> varsPossible2)
+	{
+		final ExpectedVariables[] inputVars = new ExpectedVariables[2];
+		inputVars[0] = new ExpectedVariables() {
+			public Set<Var> getCertainVariables() { return varsCertain1;}
+			public Set<Var> getPossibleVariables() { return varsPossible1;}
+		};
+		inputVars[1] = new ExpectedVariables() {
+			public Set<Var> getCertainVariables() { return varsCertain2;}
+			public Set<Var> getPossibleVariables() { return varsPossible2;}
+		};
+		return inputVars;
+	}
+
+	protected ExecOpHashBasedMinus createExecOpForTest(
+			final boolean useOuterJoinSemantics,
+			final ExpectedVariables... inputVars ) {
+		assert inputVars.length == 2;
+
+		return new ExecOpHashBasedMinus( useOuterJoinSemantics,
+		                                 false,            // mayReduce
+		                                 inputVars[0], inputVars[1],
+		                                 false,    // collectExceptions
+		                                 null );              // qpInfo
+	}
+
+}

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashBasedMinusTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashBasedMinusTest.java
@@ -196,15 +196,4 @@ public class ExecOpHashBasedMinusTest
 		return inputVars;
 	}
 
-	protected ExecOpHashBasedMinus createExecOpForTest(
-			final boolean useOuterJoinSemantics,
-			final ExpectedVariables... inputVars ) {
-		assert inputVars.length == 2;
-
-		return new ExecOpHashBasedMinus( false,            // mayReduce
-		                                 inputVars[0], inputVars[1],
-		                                 false,    // collectExceptions
-		                                 null );              // qpInfo
-	}
-
 }

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashBasedMinusTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashBasedMinusTest.java
@@ -4,8 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -25,9 +23,12 @@ public class ExecOpHashBasedMinusTest
 {
 	@Test
 	public void subtract() throws ExecutionException {
+		// Check that the operator correctly subtracts solution
+		// mappings from the left-hand side.
+
+		// Set up
 		final Var var1 = Var.alloc("v1");
 		final Var var2 = Var.alloc("v2");
-		final Var var3 = Var.alloc("v3");
 
 		final Node x1 = NodeFactory.createURI("http://example.org/x1");
 		final Node x2 = NodeFactory.createURI("http://example.org/x2");
@@ -35,35 +36,27 @@ public class ExecOpHashBasedMinusTest
 		final Node y2 = NodeFactory.createURI("http://example.org/y2");
 		final Node y3 = NodeFactory.createURI("http://example.org/y3");
 
-		final List<SolutionMapping> input1 = new ArrayList<>();
-		input1.add( SolutionMappingUtils.createSolutionMapping(
-				var1, x1,
-				var2, y1) );
+		final List<SolutionMapping> input1 = List.of(
+			SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1),
+			// Remaining solution mapping after the subtraction.
+			SolutionMappingUtils.createSolutionMapping(var1, x2, var2, y2)
+		);
 
-		// Remaining solution mapping after the subtraction.
-		input1.add( SolutionMappingUtils.createSolutionMapping(
-				var1, x2,
-				var2, y2) );
+		final List<SolutionMapping> input2 = List.of(
+			SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1)
+		);
 
-		final List<SolutionMapping> input2 = new ArrayList<>();
-		input2.add( SolutionMappingUtils.createSolutionMapping(
-				var1, x1,
-				var2, y1) );
-
-		Set<Var> varsCertain1 = new HashSet<>();
-		varsCertain1.add(var1);
-		varsCertain1.add(var2);
-		Set<Var> varsPossible1 = new HashSet<>();
-
-		Set<Var> varsCertain2 = new HashSet<>();
-		varsCertain2.add(var1);
-		varsCertain2.add(var2);
-		Set<Var> varsPossible2 = new HashSet<>();
+		final Set<Var> varsCertain1 = Set.of(var1, var2);
+		final Set<Var> varsPossible1 = Set.of();
+		final Set<Var> varsCertain2 = Set.of(var1, var2);
+		final Set<Var> varsPossible2 = Set.of();
 
 		final ExpectedVariables[] inputVars = getExpectedVariables(varsCertain1, varsPossible1, varsCertain2, varsPossible2);
 
-		final Iterator<SolutionMapping> it = runTest(input1, input2, false, false, inputVars);
+		// Test
+		final Iterator<SolutionMapping> it = runTest(input1, input2, false, inputVars);
 
+		// Check
 		assertTrue( it.hasNext() );
 		final SolutionMapping sm = it.next();
 		assertEquals( x2, sm.asJenaBinding().get(var1) );
@@ -73,7 +66,12 @@ public class ExecOpHashBasedMinusTest
 	}
 
 	@Test
-	public void emptySubtractionResult() throws ExecutionException  {
+	public void emptySubtractionResult() throws ExecutionException {
+		// Check that the operator correctly produces an empty
+		// result if all solution mappings from the left-hand
+		// side are subtracted.
+
+		// Set up
 		final Var var1 = Var.alloc("v1");
 		final Var var2 = Var.alloc("v2");
 
@@ -82,30 +80,63 @@ public class ExecOpHashBasedMinusTest
 		final Node y1 = NodeFactory.createURI("http://example.org/y1");
 		final Node y2 = NodeFactory.createURI("http://example.org/y2");
 
-		final List<SolutionMapping> input1 = new ArrayList<>();
-		input1.add( SolutionMappingUtils.createSolutionMapping(
-				var1, x1,
-				var2, y1) );
+		final List<SolutionMapping> input1 = List.of(
+			SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1)
+		);
 
-		final List<SolutionMapping> input2 = new ArrayList<>();
-		input2.add( SolutionMappingUtils.createSolutionMapping(
-				var1, x1,
-				var2, y1) );
+		final List<SolutionMapping> input2 = List.of(
+			SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1)
+		);
 
-		Set<Var> varsCertain1 = new HashSet<>();
-		varsCertain1.add(var1);
-		varsCertain1.add(var2);
-		Set<Var> varsPossible1 = new HashSet<>();
-
-		Set<Var> varsCertain2 = new HashSet<>();
-		varsCertain2.add(var1);
-		varsCertain2.add(var2);
-		Set<Var> varsPossible2 = new HashSet<>();
+		final Set<Var> varsCertain1 = Set.of(var1, var2);
+		final Set<Var> varsPossible1 = Set.of();
+		final Set<Var> varsCertain2 = Set.of(var1, var2);
+		final Set<Var> varsPossible2 = Set.of();
 
 		ExpectedVariables[] inputVars = getExpectedVariables(varsCertain1, varsPossible1, varsCertain2, varsPossible2);
 
-		final Iterator<SolutionMapping> it = runTest(input1, input2, false, false, inputVars);
+		// Test
+		final Iterator<SolutionMapping> it = runTest(input1, input2, false, inputVars);
 
+		// Check
+		assertFalse( it.hasNext() );
+	}
+
+	@Test
+	public void oneCommonVariable() throws ExecutionException {
+		// Test where the two inputs have only one common variable,
+		// which is sufficient to make the solution mapping from
+		// the left-hand side be subtracted.
+
+		// Set up
+		final Var var1 = Var.alloc("v1");
+		final Var var2 = Var.alloc("v2");
+		final Var var3 = Var.alloc("v3");
+
+		final Node x1 = NodeFactory.createURI("http://example.org/x1");
+		final Node x2 = NodeFactory.createURI("http://example.org/x2");
+		final Node y1 = NodeFactory.createURI("http://example.org/y1");
+		final Node y2 = NodeFactory.createURI("http://example.org/y2");
+
+		final List<SolutionMapping> input1 = List.of(
+			SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1)
+		);
+
+		final List<SolutionMapping> input2 = List.of(
+			SolutionMappingUtils.createSolutionMapping(var1, x1, var3, y1)
+		);
+
+		final Set<Var> varsCertain1 = Set.of(var1, var2);
+		final Set<Var> varsPossible1 = Set.of();
+		final Set<Var> varsCertain2 = Set.of(var1, var3);
+		final Set<Var> varsPossible2 = Set.of();
+
+		ExpectedVariables[] inputVars = getExpectedVariables(varsCertain1, varsPossible1, varsCertain2, varsPossible2);
+
+		// Test
+		final Iterator<SolutionMapping> it = runTest(input1, input2, false, inputVars);
+
+		// Check
 		assertFalse( it.hasNext() );
 	}
 
@@ -116,12 +147,11 @@ public class ExecOpHashBasedMinusTest
 			final List<SolutionMapping> input1,
 			final List<SolutionMapping> input2,
 			final boolean sendAllSolMapsSeparately,
-			final boolean useOuterJoinSemantics,
 			final ExpectedVariables... inputVars ) throws ExecutionException
 	{
 		final CollectingIntermediateResultElementSink sink = new CollectingIntermediateResultElementSink();
 
-		final ExecOpHashBasedMinus op = createExecOpForTest( useOuterJoinSemantics, inputVars );
+		final ExecOpHashBasedMinus op = new ExecOpHashBasedMinus(sendAllSolMapsSeparately, inputVars[0], inputVars[1], sendAllSolMapsSeparately, null);
 
 		if ( sendAllSolMapsSeparately == true ) {
 			for ( final SolutionMapping sm : input2 ) {
@@ -171,8 +201,7 @@ public class ExecOpHashBasedMinusTest
 			final ExpectedVariables... inputVars ) {
 		assert inputVars.length == 2;
 
-		return new ExecOpHashBasedMinus( useOuterJoinSemantics,
-		                                 false,            // mayReduce
+		return new ExecOpHashBasedMinus( false,            // mayReduce
 		                                 inputVars[0], inputVars[1],
 		                                 false,    // collectExceptions
 		                                 null );              // qpInfo

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashBasedMinusTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashBasedMinusTest.java
@@ -60,7 +60,7 @@ public class ExecOpHashBasedMinusTest
 		varsCertain2.add(var2);
 		Set<Var> varsPossible2 = new HashSet<>();
 
-		ExpectedVariables[] inputVars = getExpectedVariables(varsCertain1, varsPossible1, varsCertain2, varsPossible2);
+		final ExpectedVariables[] inputVars = getExpectedVariables(varsCertain1, varsPossible1, varsCertain2, varsPossible2);
 
 		final Iterator<SolutionMapping> it = runTest(input1, input2, false, false, inputVars);
 


### PR DESCRIPTION
Addresses the executable operator part of #564.

Tests are admittedly minimal. I initially planned to try out cases where
1) subtraction was performed on an empty solution mapping.
2) subtraction was performed with an empty solution mapping as subtrahend
but both cases seem to fail the assertion of row 59 in `SolutionMappingsHashTable`.
