### PR TITLE
Apply the filter to the solution mapping of LogicalOpFixedSolMap

### DIFF
--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/utils/SolutionMappingUtils.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/utils/SolutionMappingUtils.java
@@ -11,7 +11,12 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.query.QuerySolution;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.binding.*;
+import org.apache.jena.sparql.expr.Expr;
+import org.apache.jena.sparql.expr.ExprList;
+import org.apache.jena.sparql.expr.NodeValue;
+import org.apache.jena.sparql.expr.VariableNotBoundException;
 import org.apache.jena.sparql.serializer.SerializationContext;
+import org.apache.jena.sparql.util.ExprUtils;
 import org.apache.jena.sparql.util.FmtUtils;
 
 import se.liu.ida.hefquin.base.data.SolutionMapping;
@@ -84,6 +89,35 @@ public class SolutionMappingUtils
 		b.add(var2, node2);
 		b.add(var3, node3);
 		return new SolutionMappingImpl(b.build());
+	}
+
+	/**
+	 * Returns true if the given solution mapping satisfies all of the filter
+	 * expressions of this operator and, thus, can be passed on to the output.
+	 */
+	public static boolean checkSolutionMapping( final SolutionMapping sm, final ExprList filterExpressions ) {
+		final Binding b = sm.asJenaBinding();
+		for ( final Expr e : filterExpressions.getList() ) {
+			final NodeValue evaluationResult;
+			try {
+				evaluationResult = ExprUtils.eval(e, b);
+			}
+			catch ( final VariableNotBoundException ex ) {
+				// If evaluating the filter expression based on the given
+				// solution mapping results in this error, then this solution
+				// mapping does not satisfy the filter condition.
+				return false;
+			}
+
+			if( evaluationResult.equals(NodeValue.FALSE) ) {
+				return false;
+			}
+			else if ( ! evaluationResult.equals(NodeValue.TRUE) ) {
+				throw new IllegalArgumentException("The result of the eval is neither TRUE nor FALSE!");
+			}
+		}
+
+		return true;
 	}
 
 	/**
@@ -302,7 +336,7 @@ public class SolutionMappingUtils
 		}
 		return output.build();
 	}
-	
+
 	/**
 	 * Restricts the given solution mapping to the given set of variables.
 	 * Hence, the returned solution mapping will be compatible with the

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/utils/SolutionMappingUtils.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/utils/SolutionMappingUtils.java
@@ -92,8 +92,8 @@ public class SolutionMappingUtils
 	}
 
 	/**
-	 * Returns true if the given solution mapping satisfies all of the filter
-	 * expressions of this operator and, thus, can be passed on to the output.
+	 * Returns true if, for every expression in the given list, the result of
+	 * evaluating the expression based on the given solution mapping is true.
 	 */
 	public static boolean checkSolutionMapping( final SolutionMapping sm, final ExprList filterExpressions ) {
 		final Binding b = sm.asJenaBinding();

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpFilter.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpFilter.java
@@ -4,14 +4,11 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.ExprList;
-import org.apache.jena.sparql.expr.NodeValue;
-import org.apache.jena.sparql.expr.VariableNotBoundException;
-import org.apache.jena.sparql.util.ExprUtils;
 
 import se.liu.ida.hefquin.base.data.SolutionMapping;
+import se.liu.ida.hefquin.base.data.utils.SolutionMappingUtils;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
 import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
@@ -51,7 +48,7 @@ public class ExecOpFilter extends UnaryExecutableOpBaseWithoutBlocking
 	                         final IntermediateResultElementSink sink,
 	                         final ExecutionContext execCxt ) {
 		// Check whether the given solution mapping satisfies each of the filter expressions
-		if ( checkSolutionMapping(inputSolMap) == true ) {
+		if ( SolutionMappingUtils.checkSolutionMapping(inputSolMap, filterExpressions) == true ) {
 			sink.send(inputSolMap);
 			numberOfOutputMappingsProduced++;
 		}
@@ -72,7 +69,7 @@ public class ExecOpFilter extends UnaryExecutableOpBaseWithoutBlocking
 		while ( firstOutput == null && cnt < maxBatchSize && inputSolMaps.hasNext() ) {
 			final SolutionMapping inputSolMap = inputSolMaps.next();
 			cnt++;
-			if ( checkSolutionMapping(inputSolMap) == true ) {
+			if ( SolutionMappingUtils.checkSolutionMapping(inputSolMap, filterExpressions) == true ) {
 				firstOutput = inputSolMap;
 			}
 		}
@@ -86,7 +83,7 @@ public class ExecOpFilter extends UnaryExecutableOpBaseWithoutBlocking
 		while ( cnt < maxBatchSize && inputSolMaps.hasNext() ) {
 			final SolutionMapping inputSolMap = inputSolMaps.next();
 			cnt++;
-			if ( checkSolutionMapping(inputSolMap) == true ) {
+			if ( SolutionMappingUtils.checkSolutionMapping(inputSolMap, filterExpressions) == true ) {
 				// We found another output solution mapping. Check whether
 				// we have already created the list; if not, create it now
 				// and add earlier-found first output solution mapping to it.
@@ -128,35 +125,6 @@ public class ExecOpFilter extends UnaryExecutableOpBaseWithoutBlocking
 		final ExecutableOperatorStatsImpl s = super.createStats();
 		s.put( "numberOfOutputMappingsProduced",  Long.valueOf(numberOfOutputMappingsProduced) );
 		return s;
-	}
-
-	/**
-	 * Returns true if the given solution mapping satisfies all of the filter
-	 * expressions of this operator and, thus, can be passed on to the output.
-	 */
-	protected boolean checkSolutionMapping( final SolutionMapping inputSolMap ) {
-		final Binding sm = inputSolMap.asJenaBinding();
-		for ( final Expr e : filterExpressions.getList() ) {
-			final NodeValue evaluationResult;
-			try {
-				evaluationResult = ExprUtils.eval(e, sm);
-			}
-			catch ( final VariableNotBoundException ex ) {
-				// If evaluating the filter expression based on the given
-				// solution mapping results in this error, then this solution
-				// mapping does not satisfy the filter condition.
-				return false;
-			}
-
-			if( evaluationResult.equals(NodeValue.FALSE) ) {
-				return false;
-			}
-			else if ( ! evaluationResult.equals(NodeValue.TRUE) ) {
-				throw new IllegalArgumentException("The result of the eval is neither TRUE nor FALSE!");
-			}
-		}
-
-		return true;
 	}
 
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
@@ -13,13 +13,10 @@ import org.apache.jena.cdt.CompositeDatatypeList;
 import org.apache.jena.cdt.CompositeDatatypeMap;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.ARQConstants;
-import org.apache.jena.sparql.engine.binding.Binding;
-import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.ExprFunction;
 import org.apache.jena.sparql.expr.NodeValue;
-import org.apache.jena.sparql.expr.VariableNotBoundException;
-import org.apache.jena.sparql.util.ExprUtils;
 
+import se.liu.ida.hefquin.base.data.utils.SolutionMappingUtils;
 import se.liu.ida.hefquin.engine.queryplan.base.QueryPlan;
 import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanProperty;
 import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
@@ -245,7 +242,7 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		// If the filter is above a fixed solution mapping operator, evaluate
 		// the filter condition for the fixed solution mapping of that operator.
 		if ( currentSubPlan.getSubPlan(0).getRootOperator() instanceof LogicalOpFixedSolMap childOp ) {
-			if ( evaluateFilter(op, childOp) ) {
+			if ( SolutionMappingUtils.checkSolutionMapping(childOp.getSolutionMapping(), op.getFilterExpressions()) ) {
 				qpInfo.addProperty( QueryPlanProperty.cardinality(1, Quality.ACCURATE) );
 				qpInfo.addProperty( QueryPlanProperty.maxCardinality(1, Quality.ACCURATE) );
 				qpInfo.addProperty( QueryPlanProperty.minCardinality(1, Quality.ACCURATE) );
@@ -651,32 +648,6 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		qpInfo.addProperty( QueryPlanProperty.cardinality(crdValue, crdQuality) );
 		qpInfo.addProperty( QueryPlanProperty.maxCardinality(maxValue, maxQuality) );
 		qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.MIN_OR_MAX_POSSIBLE) );
-	}
-
-
-	protected boolean evaluateFilter( final LogicalOpFilter filterOp, final LogicalOpFixedSolMap fixedSolMapOp ) {
-		final Binding sm = fixedSolMapOp.getSolutionMapping().asJenaBinding();
-			for ( final Expr e : filterOp.getFilterExpressions().getList() ) {
-				final NodeValue evaluationResult;
-				try {
-					evaluationResult = ExprUtils.eval(e, sm);
-				}
-				catch ( final VariableNotBoundException ex ) {
-					// If evaluating the filter expression based on the given
-					// solution mapping results in this error, then this solution
-					// mapping does not satisfy the filter condition.
-					return false;
-				}
-
-				if( evaluationResult.equals(NodeValue.FALSE) ) {
-					return false;
-				}
-				else if ( ! evaluationResult.equals(NodeValue.TRUE) ) {
-					throw new IllegalArgumentException("The result of the eval is neither TRUE nor FALSE!");
-				}
-			}
-
-		return true;
 	}
 
 	public static int addWithoutExceedingMax( final int x, final int y ) {

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
@@ -13,8 +13,12 @@ import org.apache.jena.cdt.CompositeDatatypeList;
 import org.apache.jena.cdt.CompositeDatatypeMap;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.ARQConstants;
+import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.ExprFunction;
 import org.apache.jena.sparql.expr.NodeValue;
+import org.apache.jena.sparql.expr.VariableNotBoundException;
+import org.apache.jena.sparql.util.ExprUtils;
 
 import se.liu.ida.hefquin.engine.queryplan.base.QueryPlan;
 import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanProperty;
@@ -238,9 +242,25 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		// TODO: perhaps we can be smarter here and somehow estimate the
 		// selectivity of the filter expression.
 
-		qpInfo.addProperty( QueryPlanProperty.copyWithReducedQuality(crd) );
-		qpInfo.addProperty( QueryPlanProperty.copyWithReducedQuality(max) );
-		qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.MIN_OR_MAX_POSSIBLE) );
+		// If the filter is above a fixed solution mapping operator, evaluate
+		// the filter condition for the fixed solution mapping of that operator.
+		if ( currentSubPlan.getSubPlan(0).getRootOperator() instanceof LogicalOpFixedSolMap childOp ) {
+			if ( evaluateFilter(op, childOp) ) {
+				qpInfo.addProperty( QueryPlanProperty.cardinality(1, Quality.ACCURATE) );
+				qpInfo.addProperty( QueryPlanProperty.maxCardinality(1, Quality.ACCURATE) );
+				qpInfo.addProperty( QueryPlanProperty.minCardinality(1, Quality.ACCURATE) );
+			}
+			else {
+				qpInfo.addProperty( QueryPlanProperty.cardinality(0, Quality.ACCURATE) );
+				qpInfo.addProperty( QueryPlanProperty.maxCardinality(0, Quality.ACCURATE) );
+				qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.ACCURATE) );
+			}
+		}
+		else {
+			qpInfo.addProperty( QueryPlanProperty.copyWithReducedQuality(crd) );
+			qpInfo.addProperty( QueryPlanProperty.copyWithReducedQuality(max) );
+			qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.MIN_OR_MAX_POSSIBLE) );
+		}
 	}
 
 	@Override
@@ -594,6 +614,31 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.MIN_OR_MAX_POSSIBLE) );
 	}
 
+
+	protected boolean evaluateFilter( final LogicalOpFilter filterOp, final LogicalOpFixedSolMap fixedSolMapOp ) {
+		final Binding sm = fixedSolMapOp.getSolutionMapping().asJenaBinding();
+			for ( final Expr e : filterOp.getFilterExpressions().getList() ) {
+				final NodeValue evaluationResult;
+				try {
+					evaluationResult = ExprUtils.eval(e, sm);
+				}
+				catch ( final VariableNotBoundException ex ) {
+					// If evaluating the filter expression based on the given
+					// solution mapping results in this error, then this solution
+					// mapping does not satisfy the filter condition.
+					return false;
+				}
+
+				if( evaluationResult.equals(NodeValue.FALSE) ) {
+					return false;
+				}
+				else if ( ! evaluationResult.equals(NodeValue.TRUE) ) {
+					throw new IllegalArgumentException("The result of the eval is neither TRUE nor FALSE!");
+				}
+			}
+
+		return true;
+	}
 
 	public static int addWithoutExceedingMax( final int x, final int y ) {
 		if ( x == Integer.MAX_VALUE || y == Integer.MAX_VALUE )

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDown.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDown.java
@@ -6,10 +6,14 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.sparql.expr.E_LogicalAnd;
 import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.ExprList;
 import org.apache.jena.sparql.expr.ExprVars;
+import org.apache.jena.sparql.expr.NodeValue;
+import org.apache.jena.sparql.expr.VariableNotBoundException;
+import org.apache.jena.sparql.util.ExprUtils;
 
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
@@ -114,9 +118,14 @@ public class FilterPushDown implements HeuristicForLogicalOptimization
 
 		@Override
 		public void visit( final LogicalOpFixedSolMap op ) {
-			// The filter cannot be pushed under this operator.
-			// (but it may be removed altogether TODO #572)
-			createdPlan = inputPlan;
+			// The filter cannot be pushed under this operator, but if it satisfies the filter condition,
+			// then simply remove the filter operator and return the subplan under the filter as new plan;
+			// otherwise, keep the filter operator as it is, which will lead to an empty result when evaluated.
+			final boolean evaluateFilter = evaluateFilter(filterOp, op);
+			if ( evaluateFilter ) {
+				createdPlan = inputPlan.getSubPlan(0);
+			}
+			else createdPlan = inputPlan;
 		}
 
 		@Override
@@ -833,6 +842,31 @@ public class FilterPushDown implements HeuristicForLogicalOptimization
 				null,
 				newPlanUnderFilter );
 		return newPlan;
+	}
+
+	protected boolean evaluateFilter( final LogicalOpFilter filterOp, final LogicalOpFixedSolMap childOp ) {
+		final Binding sm = childOp.getSolutionMapping().asJenaBinding();
+		for ( final Expr e : filterOp.getFilterExpressions().getList() ) {
+			final NodeValue evaluationResult;
+			try {
+				evaluationResult = ExprUtils.eval(e, sm);
+			}
+			catch ( final VariableNotBoundException ex ) {
+				// If evaluating the filter expression based on the given
+				// solution mapping results in this error, then this solution
+				// mapping does not satisfy the filter condition.
+				return false;
+			}
+
+			if( evaluationResult.equals(NodeValue.FALSE) ) {
+				return false;
+			}
+			else if ( ! evaluationResult.equals(NodeValue.TRUE) ) {
+				throw new IllegalArgumentException("The result of the eval is neither TRUE nor FALSE!");
+			}
+		}
+
+		return true;
 	}
 
 	protected ExprList splitConjunctions( final ExprList l ) {

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDown.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDown.java
@@ -6,15 +6,12 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.jena.sparql.core.Var;
-import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.sparql.expr.E_LogicalAnd;
 import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.ExprList;
 import org.apache.jena.sparql.expr.ExprVars;
-import org.apache.jena.sparql.expr.NodeValue;
-import org.apache.jena.sparql.expr.VariableNotBoundException;
-import org.apache.jena.sparql.util.ExprUtils;
 
+import se.liu.ida.hefquin.base.data.utils.SolutionMappingUtils;
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalOperator;
@@ -118,11 +115,12 @@ public class FilterPushDown implements HeuristicForLogicalOptimization
 
 		@Override
 		public void visit( final LogicalOpFixedSolMap op ) {
-			// The filter cannot be pushed under this operator, but if it satisfies the filter condition,
-			// then simply remove the filter operator and return the subplan under the filter as new plan;
-			// otherwise, keep the filter operator as it is, which will lead to an empty result when evaluated.
-			final boolean evaluateFilter = evaluateFilter(filterOp, op);
-			if ( evaluateFilter ) {
+			// The filter cannot be pushed below this operator. However, since the
+			// root operator of the subplan is a FixedSolMap with a known solution
+			// mapping, we can evaluate the filter expression directly on that mapping.
+			// - If the mapping satisfies the filter condition, the filter can be removed.
+			// - Otherwise, the filter is kept, which will result in an empty output during execution.
+			if ( SolutionMappingUtils.checkSolutionMapping(op.getSolutionMapping(), filterOp.getFilterExpressions()) == true ) {
 				createdPlan = inputPlan.getSubPlan(0);
 			}
 			else createdPlan = inputPlan;
@@ -862,31 +860,6 @@ public class FilterPushDown implements HeuristicForLogicalOptimization
 				null,
 				newPlanUnderFilter );
 		return newPlan;
-	}
-
-	protected boolean evaluateFilter( final LogicalOpFilter filterOp, final LogicalOpFixedSolMap childOp ) {
-		final Binding sm = childOp.getSolutionMapping().asJenaBinding();
-		for ( final Expr e : filterOp.getFilterExpressions().getList() ) {
-			final NodeValue evaluationResult;
-			try {
-				evaluationResult = ExprUtils.eval(e, sm);
-			}
-			catch ( final VariableNotBoundException ex ) {
-				// If evaluating the filter expression based on the given
-				// solution mapping results in this error, then this solution
-				// mapping does not satisfy the filter condition.
-				return false;
-			}
-
-			if( evaluationResult.equals(NodeValue.FALSE) ) {
-				return false;
-			}
-			else if ( ! evaluationResult.equals(NodeValue.TRUE) ) {
-				throw new IllegalArgumentException("The result of the eval is neither TRUE nor FALSE!");
-			}
-		}
-
-		return true;
 	}
 
 	protected ExprList splitConjunctions( final ExprList l ) {

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDownTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDownTest.java
@@ -581,7 +581,6 @@ public class FilterPushDownTest extends EngineTestBase
 		final LogicalPlan result = new FilterPushDown().apply(filterPlan);
 
 		// check
-		assertTrue( result.getRootOperator() instanceof LogicalOpFixedSolMap );
 		assertEquals( fixedSolMapPlan, result );
 	}
 
@@ -611,9 +610,7 @@ public class FilterPushDownTest extends EngineTestBase
 		final LogicalPlan result = new FilterPushDown().apply(filterPlan);
 
 		// check
-		assertTrue( result.getRootOperator() instanceof LogicalOpFilter );
-		assertTrue( result.getSubPlan(0).getRootOperator() instanceof LogicalOpFixedSolMap );
-		assertEquals( fixedSolMapPlan, result.getSubPlan(0) );
+		assertEquals( filterPlan, result );
 	}
 
 }

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDownTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDownTest.java
@@ -499,6 +499,7 @@ public class FilterPushDownTest extends EngineTestBase
 		assertTrue( subResult1.getRootOperator() instanceof LogicalOpFilter );
 	}
 
+	@Test
 	public void pushFilterUnderMinus() {
 		// a filter on top of a minus of two triple pattern requests,
 		// where the filter is expected to push into the first request
@@ -581,7 +582,7 @@ public class FilterPushDownTest extends EngineTestBase
 
 		// check
 		assertTrue( result.getRootOperator() instanceof LogicalOpFixedSolMap );
-		assertEquals( sm, ((LogicalOpFixedSolMap) result.getRootOperator()).getSolutionMapping() );
+		assertEquals( fixedSolMapPlan, result );
 	}
 
 	@Test
@@ -612,7 +613,7 @@ public class FilterPushDownTest extends EngineTestBase
 		// check
 		assertTrue( result.getRootOperator() instanceof LogicalOpFilter );
 		assertTrue( result.getSubPlan(0).getRootOperator() instanceof LogicalOpFixedSolMap );
-		assertEquals( sm, ((LogicalOpFixedSolMap) result.getSubPlan(0).getRootOperator()).getSolutionMapping() );
+		assertEquals( fixedSolMapPlan, result.getSubPlan(0) );
 	}
 
 }

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDownTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDownTest.java
@@ -5,10 +5,13 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
 
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.core.VarExprList;
 import org.apache.jena.sparql.expr.E_Bound;
 import org.apache.jena.sparql.expr.E_Equals;
+import org.apache.jena.sparql.expr.E_IsBlank;
 import org.apache.jena.sparql.expr.E_IsIRI;
 import org.apache.jena.sparql.expr.E_LogicalNot;
 import org.apache.jena.sparql.expr.Expr;
@@ -21,6 +24,8 @@ import org.apache.jena.sparql.syntax.ElementGroup;
 import org.apache.jena.sparql.syntax.ElementTriplesBlock;
 import org.junit.Test;
 
+import se.liu.ida.hefquin.base.data.SolutionMapping;
+import se.liu.ida.hefquin.base.data.utils.SolutionMappingUtils;
 import se.liu.ida.hefquin.base.query.TriplePattern;
 import se.liu.ida.hefquin.base.query.impl.TriplePatternImpl;
 import se.liu.ida.hefquin.base.query.utils.QueryPatternUtils;
@@ -30,6 +35,7 @@ import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanUtils;
 import se.liu.ida.hefquin.engine.queryplan.logical.UnaryLogicalOp;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpBind;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFilter;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFixedSolMap;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayUnion;
@@ -490,6 +496,67 @@ public class FilterPushDownTest extends EngineTestBase
 
 		final LogicalPlan subResult1 = result.getSubPlan(0);
 		assertTrue( subResult1.getRootOperator() instanceof LogicalOpFilter );
+	}
+
+	@Test
+	public void pushFilterUnderFixedSolMapSatisfied() {
+		// a filter above a FixedSolMap where the filter evaluates to true
+		// under the fixed solution mapping; the filter is removed and only
+		// the FixedSolMap remains.
+
+		// set up
+		final Var var1 = Var.alloc("v1");
+		final Var var2 = Var.alloc("v2");
+
+		final Node x1 = NodeFactory.createURI("http://example.org/x1");
+		final Node y1 = NodeFactory.createURI("http://example.org/y1");
+
+		final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1);
+
+		final LogicalOpFixedSolMap fixedSolMap = new LogicalOpFixedSolMap(sm);
+		final LogicalPlan fixedSolMapPlan = new LogicalPlanWithNullaryRootImpl(fixedSolMap, null);
+
+		final Expr e = new E_IsIRI( new ExprVar(var1) );
+		final UnaryLogicalOp rootOp = new LogicalOpFilter(e, false);
+		final LogicalPlan filterPlan = new LogicalPlanWithUnaryRootImpl(rootOp, null, fixedSolMapPlan);
+
+		// test
+		final LogicalPlan result = new FilterPushDown().apply(filterPlan);
+
+		// check
+		assertTrue( result.getRootOperator() instanceof LogicalOpFixedSolMap );
+		assertEquals( sm, ((LogicalOpFixedSolMap) result.getRootOperator()).getSolutionMapping() );
+	}
+
+	@Test
+	public void pushFilterUnderFixedSolMapUnsatisfied() {
+		// a filter above a FixedSolMap where the filter evaluates to false
+		// under the fixed solution mapping; the filter is NOT removed
+		// and remains above the FixedSolMap.
+
+		// set up
+		final Var var1 = Var.alloc("v1");
+		final Var var2 = Var.alloc("v2");
+
+		final Node x1 = NodeFactory.createURI("http://example.org/x1");
+		final Node y1 = NodeFactory.createURI("http://example.org/y1");
+
+		final SolutionMapping sm = SolutionMappingUtils.createSolutionMapping(var1, x1, var2, y1);
+
+		final LogicalOpFixedSolMap fixedSolMap = new LogicalOpFixedSolMap(sm);
+		final LogicalPlan fixedSolMapPlan = new LogicalPlanWithNullaryRootImpl(fixedSolMap, null);
+
+		final Expr e = new E_IsBlank( new ExprVar(var1) );
+		final UnaryLogicalOp rootOp = new LogicalOpFilter(e, false);
+		final LogicalPlan filterPlan = new LogicalPlanWithUnaryRootImpl(rootOp, null, fixedSolMapPlan);
+
+		// test
+		final LogicalPlan result = new FilterPushDown().apply(filterPlan);
+
+		// check
+		assertTrue( result.getRootOperator() instanceof LogicalOpFilter );
+		assertTrue( result.getSubPlan(0).getRootOperator() instanceof LogicalOpFixedSolMap );
+		assertEquals( sm, ((LogicalOpFixedSolMap) result.getSubPlan(0).getRootOperator()).getSolutionMapping() );
 	}
 
 }


### PR DESCRIPTION
Closes #572.

There is some repeated code in `CardinalityEstimationWorkerImpl`, `FilterPushDown` and `ExecOpFilter`. The new `evaluateFilter( ... )` function does the same thing as `checkSolutionMapping` of `ExecOpFilter`.  Should I perhaps add this function to a new util file `FilterEvalUtil` and call that from the three files?

Furthermore, should the new tests I added also attempt to check the cardinality of the result?