### PR TITLE
Improve cardinality estimator (Part 1)

### DIFF
--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
@@ -304,6 +304,7 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 			qpInfo.addProperty( QueryPlanProperty.cardinality(0, Quality.ACCURATE) );
 			qpInfo.addProperty( QueryPlanProperty.maxCardinality(0, Quality.ACCURATE) );
 			qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.ACCURATE) );
+			return;
 		}
 
 		qpInfo.addProperty( qpInfoSubPlan.getProperty(CARDINALITY) );

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
@@ -294,9 +294,9 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		final QueryPlanningInfo qpInfoSubPlan = currentSubPlan.getSubPlan(0).getQueryPlanningInfo();
 		final QueryPlanProperty crdSubPlan = qpInfoSubPlan.getProperty(CARDINALITY);
 
+		// If the input plan is guaranteed to produce an empty result, then
+		// the result of the BIND operator is guaranteed to be empty as well.
 		if ( handleGuaranteedEmpty(qpInfo, crdSubPlan) ) {
-			// If the input plan is guaranteed to produce an empty result,
-			// then the result of the BIND operator is guaranteed to be empty as well.
 			return;
 		}
 
@@ -443,7 +443,7 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 
 		if ( handleGuaranteedEmpty(qpInfo, crd) ) {
 			// If the input plan is guaranteed to produce an empty result,
-			// then the result of the L2g operator is guaranteed to be empty as well.
+			// then the result of the l2g operator is guaranteed to be empty as well.
 			return;
 		}
 
@@ -479,7 +479,7 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 
 		if ( handleGuaranteedEmpty(qpInfo, crd) ) {
 			// If the input plan is guaranteed to produce an empty result,
-			// then the result of the G2l operator is guaranteed to be empty as well.
+			// then the result of the g2l operator is guaranteed to be empty as well.
 			return;
 		}
 
@@ -530,7 +530,8 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 			// then the result of the DEDUP operator is guaranteed to be empty as well.
 			return;
 		}
-		else if ( crdIn.getValue() == 0 || crdIn.getValue() == 1 ) {
+
+		if ( crdIn.getValue() == 0 || crdIn.getValue() == 1 ) {
 			crdValue = crdIn.getValue();
 			crdQuality = crdIn.getQuality();
 		}
@@ -570,11 +571,10 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 			// then the result of the PROJECT operator is guaranteed to be empty as well.
 			return;
 		}
-		else {
-			qpInfo.addProperty( qpInfoSubPlan.getProperty(CARDINALITY) );
-			qpInfo.addProperty( qpInfoSubPlan.getProperty(MAX_CARDINALITY) );
-			qpInfo.addProperty( qpInfoSubPlan.getProperty(MIN_CARDINALITY) );
-		}
+
+		qpInfo.addProperty( qpInfoSubPlan.getProperty(CARDINALITY) );
+		qpInfo.addProperty( qpInfoSubPlan.getProperty(MAX_CARDINALITY) );
+		qpInfo.addProperty( qpInfoSubPlan.getProperty(MIN_CARDINALITY) );
 	}
 
 	@Override
@@ -661,7 +661,7 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 			minQuality = pickWorse( minQuality, minX.getQuality() );
 		}
 
-		// If all of the subplans under the UNION is guaranteed to produce an empty result,
+		// If each of the subplans under the UNION is guaranteed to produce the empty result,
 		// then the result of the UNION operator is guaranteed to be empty as well.
 		if ( allEmpty ) {
 			final QueryPlanningInfo qpInfo = currentSubPlan.getQueryPlanningInfo();

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
@@ -621,10 +621,13 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.MIN_OR_MAX_POSSIBLE) );
 	}
 
+	/**
+	 * Checks whether the given cardinality property guarantees that the query plan
+	 * will produce an empty result. If so, it updates the provided {@link QueryPlanningInfo}
+	 * with accurate cardinality properties (min, max and exact cardinality all set to 0).
+	 */
 	public boolean checkAndSetIfGuaranteedEmpty( final QueryPlanningInfo qpInfo, final QueryPlanProperty crd ) {
 		if ( crd.getValue() == 0 && crd.getQuality() == Quality.ACCURATE ) {
-			// If the input plan is guaranteed to produce an empty result,
-			// then the result of the output is guaranteed to be empty as well.
 			qpInfo.addProperty( QueryPlanProperty.cardinality(0, Quality.ACCURATE) );
 			qpInfo.addProperty( QueryPlanProperty.maxCardinality(0, Quality.ACCURATE) );
 			qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.ACCURATE) );

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
@@ -296,6 +296,15 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 	public void visit( final LogicalOpBind op ) {
 		final QueryPlanningInfo qpInfo = currentSubPlan.getQueryPlanningInfo();
 		final QueryPlanningInfo qpInfoSubPlan = currentSubPlan.getSubPlan(0).getQueryPlanningInfo();
+		final QueryPlanProperty crdSubPlan = qpInfoSubPlan.getProperty(CARDINALITY);
+
+		if ( crdSubPlan.getValue() == 0 && crdSubPlan.getQuality() == Quality.ACCURATE ) {
+			// If the input plan is guaranteed to produce an empty result,
+			// then the result of the BIND operator is guaranteed to be empty as well.
+			qpInfo.addProperty( QueryPlanProperty.cardinality(0, Quality.ACCURATE) );
+			qpInfo.addProperty( QueryPlanProperty.maxCardinality(0, Quality.ACCURATE) );
+			qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.ACCURATE) );
+		}
 
 		qpInfo.addProperty( qpInfoSubPlan.getProperty(CARDINALITY) );
 		qpInfo.addProperty( qpInfoSubPlan.getProperty(MAX_CARDINALITY) );
@@ -310,7 +319,16 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		// Before considering the general case, we consider a few special
 		// cases for which we may be more accurate than in the general case.
 
-		// Special case 1: if the expression of the UNFOLD clause is
+		// Special case 1: if the input plan is guaranteed to produce an empty result,
+		// then the result of the UNFOLD operator is guaranteed to be empty as well.
+		if ( qpInfoSubPlan.getProperty(CARDINALITY).getValue() == 0 && qpInfoSubPlan.getProperty(CARDINALITY).getQuality() == Quality.ACCURATE ) {
+			qpInfo.addProperty( QueryPlanProperty.cardinality(0, Quality.ACCURATE) );
+			qpInfo.addProperty( QueryPlanProperty.maxCardinality(0, Quality.ACCURATE) );
+			qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.ACCURATE) );
+			return;
+		}
+
+		// Special case 2: if the expression of the UNFOLD clause is
 		// a constant that is *not* a well-formed cdt:List or cdt:Map
 		// literal, then we know that the output cardinality will be
 		// the same as the input cardinality.
@@ -337,7 +355,7 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 				return;
 			}
 
-			// Special case 2: if the expression is a well-formed cdt:List
+			// Special case 3: if the expression is a well-formed cdt:List
 			// or cdt:Map literal, then we can use the size of the list/map
 			// for estimating the output cardinality.
 			final int size;
@@ -379,7 +397,7 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 			}
 		}
 
-		// Special case 3: if the expression of the UNFOLD clause is
+		// Special case 4: if the expression of the UNFOLD clause is
 		// function call using the cdt:List or the cdt:Map constructor
 		// function and there are no arguments for this function call,
 		// then we know that the produced list/map will be empty and,
@@ -388,14 +406,14 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		if ( fct != null ) {
 			final String fctIRI = fct.getFunctionIRI();
 
-			final boolean case3Found;
+			final boolean case4Found;
 			if (    ! fctIRI.equals(ARQConstants.CDTFunctionLibraryURI + "List")
 			     && ! fctIRI.equals(ARQConstants.CDTFunctionLibraryURI + "Map") )
-				case3Found = false;
+				case4Found = false;
 			else
-				case3Found = fct.getArgs().isEmpty();
+				case4Found = fct.getArgs().isEmpty();
 
-			if ( case3Found ) {
+			if ( case4Found ) {
 				qpInfo.addProperty( QueryPlanProperty.cardinality(0, Quality.ACCURATE) );
 				qpInfo.addProperty( QueryPlanProperty.maxCardinality(0, Quality.ACCURATE) );
 				qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.ACCURATE) );

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
@@ -258,33 +258,38 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 	@Override
 	public void visit( final LogicalOpFilter op ) {
 		final QueryPlanningInfo qpInfo = currentSubPlan.getQueryPlanningInfo();
-		final QueryPlanningInfo qpInfoSubPlan = currentSubPlan.getSubPlan(0).getQueryPlanningInfo();
 
+		// Special case: If the filter is on top of a fixed solution mapping
+		// operator, then we can accurately determine the cardinality.
+		// To this end, we evaluate the filter conditions based on the (fixed)
+		// solution mapping of the child operator. If this evaluation results in
+		// 'true' for every filter condition, then the solution mapping will pass
+		// the filter and, thus, the result of the filter plan is guaranteed to
+		// have a cardinality of 1. Otherwise, the solution mapping will not pass
+		// the filter and, thus, the cardinality will be 0.
+		final QueryPlan subPlanUnderFilter = currentSubPlan.getSubPlan(0);
+		if ( subPlanUnderFilter.getRootOperator() instanceof LogicalOpFixedSolMap smOp ) {
+			final boolean evalResult = SolutionMappingUtils.checkSolutionMapping( smOp.getSolutionMapping(),
+			                                                                      op.getFilterExpressions() );
+			final int crd = ( evalResult == true ) ? 1 : 0;
+
+			qpInfo.addProperty( QueryPlanProperty.cardinality(crd, Quality.ACCURATE) );
+			qpInfo.addProperty( QueryPlanProperty.maxCardinality(crd, Quality.ACCURATE) );
+			qpInfo.addProperty( QueryPlanProperty.minCardinality(crd, Quality.ACCURATE) );
+			return;
+		}
+
+		// Now we cover all non-special cases. For the moment, we simply copy
+		// the cardinality estimate of the subplan, pretending the filter does not
+		// have any effect. TODO: perhaps we can be smarter here and somehow
+		// estimate the selectivity of the filter expressions.
+		final QueryPlanningInfo qpInfoSubPlan = subPlanUnderFilter.getQueryPlanningInfo();
 		final QueryPlanProperty crd = qpInfoSubPlan.getProperty(CARDINALITY);
 		final QueryPlanProperty max = qpInfoSubPlan.getProperty(MAX_CARDINALITY);
 
-		// TODO: perhaps we can be smarter here and somehow estimate the
-		// selectivity of the filter expression.
-
-		// If the filter is above a fixed solution mapping operator, evaluate
-		// the filter condition for the fixed solution mapping of that operator.
-		if ( currentSubPlan.getSubPlan(0).getRootOperator() instanceof LogicalOpFixedSolMap childOp ) {
-			if ( SolutionMappingUtils.checkSolutionMapping(childOp.getSolutionMapping(), op.getFilterExpressions()) ) {
-				qpInfo.addProperty( QueryPlanProperty.cardinality(1, Quality.ACCURATE) );
-				qpInfo.addProperty( QueryPlanProperty.maxCardinality(1, Quality.ACCURATE) );
-				qpInfo.addProperty( QueryPlanProperty.minCardinality(1, Quality.ACCURATE) );
-			}
-			else {
-				qpInfo.addProperty( QueryPlanProperty.cardinality(0, Quality.ACCURATE) );
-				qpInfo.addProperty( QueryPlanProperty.maxCardinality(0, Quality.ACCURATE) );
-				qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.ACCURATE) );
-			}
-		}
-		else {
-			qpInfo.addProperty( QueryPlanProperty.copyWithReducedQuality(crd) );
-			qpInfo.addProperty( QueryPlanProperty.copyWithReducedQuality(max) );
-			qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.MIN_OR_MAX_POSSIBLE) );
-		}
+		qpInfo.addProperty( QueryPlanProperty.copyWithReducedQuality(crd) );
+		qpInfo.addProperty( max );
+		qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.MIN_OR_MAX_POSSIBLE) );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
@@ -451,7 +451,14 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		final QueryPlanProperty max = qpInfoSubPlan.getProperty(MAX_CARDINALITY);
 		final QueryPlanProperty min = qpInfoSubPlan.getProperty(MIN_CARDINALITY);
 
-		if ( op.getVocabularyMapping().isEquivalenceOnly() ) {
+		if ( crd.getValue() == 0 && crd.getQuality() == Quality.ACCURATE ) {
+			// If the input plan is guaranteed to produce an empty result,
+			// then the result of the L2g operator is guaranteed to be empty as well.
+			qpInfo.addProperty( QueryPlanProperty.cardinality(0, Quality.ACCURATE) );
+			qpInfo.addProperty( QueryPlanProperty.maxCardinality(0, Quality.ACCURATE) );
+			qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.ACCURATE) );
+		}
+		else if ( op.getVocabularyMapping().isEquivalenceOnly() ) {
 			// If the vocabulary mapping contains only equivalence
 			// rules, applying this vocabulary mapping to a set of
 			// solution mappings cannot result in fewer or more
@@ -481,7 +488,14 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		final QueryPlanProperty max = qpInfoSubPlan.getProperty(MAX_CARDINALITY);
 		final QueryPlanProperty min = qpInfoSubPlan.getProperty(MIN_CARDINALITY);
 
-		if ( op.getVocabularyMapping().isEquivalenceOnly() ) {
+		if ( crd.getValue() == 0 && crd.getQuality() == Quality.ACCURATE ) {
+			// If the input plan is guaranteed to produce an empty result,
+			// then the result of the G2l operator is guaranteed to be empty as well.
+			qpInfo.addProperty( QueryPlanProperty.cardinality(0, Quality.ACCURATE) );
+			qpInfo.addProperty( QueryPlanProperty.maxCardinality(0, Quality.ACCURATE) );
+			qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.ACCURATE) );
+		}
+		else if ( op.getVocabularyMapping().isEquivalenceOnly() ) {
 			// If the vocabulary mapping contains only equivalence
 			// rules, applying this vocabulary mapping to a set of
 			// solution mappings cannot result in fewer or more

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
@@ -141,6 +141,18 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		final int crdValue = crd1.getValue();
 		final int maxValue = multiplyWithoutExceedingMax( max1.getValue(), max2.getValue() );
 
+		// Check first whether we have a case in which the left subplan is
+		// guaranteed to produce an empty result. If so, we can stop
+		// here because the join cardinality is then guaranteed to be
+		// zero as well.
+		if ( crdValue == 0 && crd1.getQuality() == Quality.ACCURATE ) {
+			final QueryPlanningInfo qpInfo = currentSubPlan.getQueryPlanningInfo();
+			qpInfo.addProperty( QueryPlanProperty.cardinality(0, Quality.ACCURATE) );
+			qpInfo.addProperty( QueryPlanProperty.maxCardinality(0, Quality.ACCURATE) );
+			qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.ACCURATE) );
+			return;
+		}
+
 		final Quality crdQuality;
 		if ( crd1.getQuality() == Quality.ACCURATE )
 			crdQuality = Quality.ESTIMATE_BASED_ON_ACCURATES;
@@ -455,7 +467,13 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 
 		final int crdValue;
 		final Quality crdQuality;
-		if ( crdIn.getValue() == 0 || crdIn.getValue() == 1 ) {
+		if ( crdIn.getValue() == 0 && crdIn.getQuality() == Quality.ACCURATE ) {
+			// If the input plan is guaranteed to produce an empty result,
+			// then the result of the DEDUP operator is guaranteed to be empty as well.
+			crdValue = 0;
+			crdQuality = Quality.ACCURATE;
+		}
+		else if ( crdIn.getValue() == 0 || crdIn.getValue() == 1 ) {
 			crdValue = crdIn.getValue();
 			crdQuality = crdIn.getQuality();
 		}
@@ -488,10 +506,20 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 	public void visit( final LogicalOpProject op ) {
 		final QueryPlanningInfo qpInfo = currentSubPlan.getQueryPlanningInfo();
 		final QueryPlanningInfo qpInfoSubPlan = currentSubPlan.getSubPlan(0).getQueryPlanningInfo();
+		final QueryPlanProperty crdSubPlan = qpInfoSubPlan.getProperty(CARDINALITY);
 
-		qpInfo.addProperty( qpInfoSubPlan.getProperty(CARDINALITY) );
-		qpInfo.addProperty( qpInfoSubPlan.getProperty(MAX_CARDINALITY) );
-		qpInfo.addProperty( qpInfoSubPlan.getProperty(MIN_CARDINALITY) );
+		if ( crdSubPlan.getValue() == 0 && crdSubPlan.getQuality() == Quality.ACCURATE ) {
+			// If the input plan is guaranteed to produce an empty result,
+			// then the result of the PROJECT operator is guaranteed to be empty as well.
+			qpInfo.addProperty( QueryPlanProperty.cardinality(0, Quality.ACCURATE) );
+			qpInfo.addProperty( QueryPlanProperty.maxCardinality(0, Quality.ACCURATE) );
+			qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.ACCURATE) );
+		}
+		else {
+			qpInfo.addProperty( qpInfoSubPlan.getProperty(CARDINALITY) );
+			qpInfo.addProperty( qpInfoSubPlan.getProperty(MAX_CARDINALITY) );
+			qpInfo.addProperty( qpInfoSubPlan.getProperty(MIN_CARDINALITY) );
+		}
 	}
 
 	@Override
@@ -509,7 +537,13 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		final QueryPlanProperty lhsMaxCrd = qpInfoSubPlan1.getProperty(MAX_CARDINALITY);
 		final QueryPlanProperty rhsCrd = qpInfoSubPlan2.getProperty(CARDINALITY);
 
-		if ( rhsCrd.getValue() == 0 && rhsCrd.getQuality() == Quality.ACCURATE ) {
+		if ( lhsCrd.getValue() == 0 && lhsCrd.getQuality() == Quality.ACCURATE ) {
+			// If the first input plan is guaranteed to produce an empty result,
+			// then the result of the MINUS operator is guaranteed to be empty as well.
+			crdValue = 0;
+			crdQuality = Quality.ACCURATE;
+		}
+		else if ( rhsCrd.getValue() == 0 && rhsCrd.getQuality() == Quality.ACCURATE ) {
 			// If the second input plan is guaranteed to produce an empty result,
 			// then the result of the MINUS operator is guaranteed to be the same as the first input plan.
 			crdValue = lhsCrd.getValue();
@@ -541,11 +575,16 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		Quality maxQuality = Quality.ACCURATE;
 		Quality minQuality = Quality.ACCURATE;
 
+		boolean allEmpty = true;
 		for ( int x = 0; x < currentSubPlan.numberOfSubPlans(); x++ ) {
 			final QueryPlanningInfo qpInfoSubPlanX = currentSubPlan.getSubPlan(x).getQueryPlanningInfo();
 			final QueryPlanProperty crdX = qpInfoSubPlanX.getProperty(CARDINALITY);
 			final QueryPlanProperty maxX = qpInfoSubPlanX.getProperty(MAX_CARDINALITY);
 			final QueryPlanProperty minX = qpInfoSubPlanX.getProperty(MIN_CARDINALITY);
+
+			if ( crdX.getValue() != 0 || crdX.getQuality() != Quality.ACCURATE ) {
+				allEmpty = false;
+			}
 
 			crdValue = addWithoutExceedingMax( crdValue, crdX.getValue() );
 			maxValue = addWithoutExceedingMax( maxValue, maxX.getValue() );
@@ -554,6 +593,16 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 			crdQuality = pickWorse( crdQuality, crdX.getQuality() );
 			maxQuality = pickWorse( maxQuality, maxX.getQuality() );
 			minQuality = pickWorse( minQuality, minX.getQuality() );
+		}
+
+		// If all of the subplans under the UNION is guaranteed to produce an empty result,
+		// then the result of the UNION operator is guaranteed to be empty as well.
+		if ( allEmpty ) {
+			final QueryPlanningInfo qpInfo = currentSubPlan.getQueryPlanningInfo();
+			qpInfo.addProperty( QueryPlanProperty.cardinality(0, Quality.ACCURATE) );
+			qpInfo.addProperty( QueryPlanProperty.maxCardinality(0, Quality.ACCURATE) );
+			qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.ACCURATE) );
+			return;
 		}
 
 		final QueryPlanningInfo qpInfo = currentSubPlan.getQueryPlanningInfo();

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
@@ -144,26 +144,26 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		// optional input). This may be a gross underestimation!
 		// TODO: There is probably a slightly better approach.
 
-		// The min.cardinality is 0 and the max.cardinality is the
-		// product of the max.cardinalities of the two input plans.
-
 		final QueryPlanningInfo qpInfoSubPlan1 = currentSubPlan.getSubPlan(0).getQueryPlanningInfo();
 		final QueryPlanProperty crd1 = qpInfoSubPlan1.getProperty(CARDINALITY);
 		final QueryPlanProperty max1 = qpInfoSubPlan1.getProperty(MAX_CARDINALITY);
+
+		// Check first whether we have a case in which the left subplan is
+		// guaranteed to produce an empty result. If so, we can stop
+		// here because the join cardinality is then guaranteed to be
+		// zero as well.
+		if ( checkAndSetIfGuaranteedEmpty(currentSubPlan.getQueryPlanningInfo(), crd1) ) {
+			return;
+		}
+
+		// The min.cardinality is 0 and the max.cardinality is the
+		// product of the max.cardinalities of the two input plans.
 
 		final QueryPlanningInfo qpInfoSubPlan2 = currentSubPlan.getSubPlan(1).getQueryPlanningInfo();
 		final QueryPlanProperty max2 = qpInfoSubPlan2.getProperty(MAX_CARDINALITY);
 
 		final int crdValue = crd1.getValue();
 		final int maxValue = multiplyWithoutExceedingMax( max1.getValue(), max2.getValue() );
-
-		// Check first whether we have a case in which the left subplan is
-		// guaranteed to produce an empty result. If so, we can stop
-		// here because the join cardinality is then guaranteed to be
-		// zero as well.
-		if ( handleGuaranteedEmpty(currentSubPlan.getQueryPlanningInfo(), crd1) ) {
-			return;
-		}
 
 		final Quality crdQuality;
 		if ( crd1.getQuality() == Quality.ACCURATE )
@@ -296,7 +296,7 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 
 		// If the input plan is guaranteed to produce an empty result, then
 		// the result of the BIND operator is guaranteed to be empty as well.
-		if ( handleGuaranteedEmpty(qpInfo, crdSubPlan) ) {
+		if ( checkAndSetIfGuaranteedEmpty(qpInfo, crdSubPlan) ) {
 			return;
 		}
 
@@ -315,7 +315,7 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 
 		// Special case 1: if the input plan is guaranteed to produce an empty result,
 		// then the result of the UNFOLD operator is guaranteed to be empty as well.
-		if ( handleGuaranteedEmpty(qpInfo, qpInfoSubPlan.getProperty(CARDINALITY)) ) {
+		if ( checkAndSetIfGuaranteedEmpty(qpInfo, qpInfoSubPlan.getProperty(CARDINALITY)) ) {
 			return;
 		}
 
@@ -441,7 +441,7 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		final QueryPlanProperty max = qpInfoSubPlan.getProperty(MAX_CARDINALITY);
 		final QueryPlanProperty min = qpInfoSubPlan.getProperty(MIN_CARDINALITY);
 
-		if ( handleGuaranteedEmpty(qpInfo, crd) ) {
+		if ( checkAndSetIfGuaranteedEmpty(qpInfo, crd) ) {
 			// If the input plan is guaranteed to produce an empty result,
 			// then the result of the l2g operator is guaranteed to be empty as well.
 			return;
@@ -477,7 +477,7 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		final QueryPlanProperty max = qpInfoSubPlan.getProperty(MAX_CARDINALITY);
 		final QueryPlanProperty min = qpInfoSubPlan.getProperty(MIN_CARDINALITY);
 
-		if ( handleGuaranteedEmpty(qpInfo, crd) ) {
+		if ( checkAndSetIfGuaranteedEmpty(qpInfo, crd) ) {
 			// If the input plan is guaranteed to produce an empty result,
 			// then the result of the g2l operator is guaranteed to be empty as well.
 			return;
@@ -523,14 +523,14 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		final QueryPlanProperty maxIn = qpInfoSubPlan.getProperty(MAX_CARDINALITY);
 		final QueryPlanProperty minIn = qpInfoSubPlan.getProperty(MIN_CARDINALITY);
 
-		final int crdValue;
-		final Quality crdQuality;
-		if ( handleGuaranteedEmpty(qpInfo, crdIn)) {
+		if ( checkAndSetIfGuaranteedEmpty(qpInfo, crdIn)) {
 			// If the input plan is guaranteed to produce an empty result,
 			// then the result of the DEDUP operator is guaranteed to be empty as well.
 			return;
 		}
 
+		final int crdValue;
+		final Quality crdQuality;
 		if ( crdIn.getValue() == 0 || crdIn.getValue() == 1 ) {
 			crdValue = crdIn.getValue();
 			crdQuality = crdIn.getQuality();
@@ -566,7 +566,7 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		final QueryPlanningInfo qpInfoSubPlan = currentSubPlan.getSubPlan(0).getQueryPlanningInfo();
 		final QueryPlanProperty crdSubPlan = qpInfoSubPlan.getProperty(CARDINALITY);
 
-		if ( handleGuaranteedEmpty(qpInfo, crdSubPlan) ) {
+		if ( checkAndSetIfGuaranteedEmpty(qpInfo, crdSubPlan) ) {
 			// If the input plan is guaranteed to produce an empty result,
 			// then the result of the PROJECT operator is guaranteed to be empty as well.
 			return;
@@ -590,15 +590,16 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 
 		final QueryPlanProperty lhsCrd = qpInfoSubPlan1.getProperty(CARDINALITY);
 		final QueryPlanProperty lhsMaxCrd = qpInfoSubPlan1.getProperty(MAX_CARDINALITY);
-		final QueryPlanProperty rhsCrd = qpInfoSubPlan2.getProperty(CARDINALITY);
 
-		if ( handleGuaranteedEmpty(currentSubPlan.getQueryPlanningInfo(), lhsCrd) )
+		if ( checkAndSetIfGuaranteedEmpty(currentSubPlan.getQueryPlanningInfo(), lhsCrd) )
 			// If the first input plan is guaranteed to produce an empty result,
 			// then the result of the MINUS operator is guaranteed to be empty as well.
 			return;
-		else if ( rhsCrd.getValue() == 0 && rhsCrd.getQuality() == Quality.ACCURATE ) {
-			// If the second input plan is guaranteed to produce an empty result,
-			// then the result of the MINUS operator is guaranteed to be the same as the first input plan.
+
+		// If the second input plan is guaranteed to produce an empty result,
+		// then the result of the MINUS operator is guaranteed to be the same as the first input plan.
+		final QueryPlanProperty rhsCrd = qpInfoSubPlan2.getProperty(CARDINALITY);
+		if ( rhsCrd.getValue() == 0 && rhsCrd.getQuality() == Quality.ACCURATE ) {
 			crdValue = lhsCrd.getValue();
 			crdQuality = lhsCrd.getQuality();
 		}
@@ -620,7 +621,7 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.MIN_OR_MAX_POSSIBLE) );
 	}
 
-	public boolean handleGuaranteedEmpty( final QueryPlanningInfo qpInfo, final QueryPlanProperty crd ) {
+	public boolean checkAndSetIfGuaranteedEmpty( final QueryPlanningInfo qpInfo, final QueryPlanProperty crd ) {
 		if ( crd.getValue() == 0 && crd.getQuality() == Quality.ACCURATE ) {
 			// If the input plan is guaranteed to produce an empty result,
 			// then the result of the output is guaranteed to be empty as well.
@@ -709,7 +710,7 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 			// guaranteed to produce an empty result. If so, we can stop
 			// here because the join cardinality is then guaranteed to be
 			// zero as well.
-			if ( handleGuaranteedEmpty(currentSubPlan.getQueryPlanningInfo(), crdX) ) {
+			if ( checkAndSetIfGuaranteedEmpty(currentSubPlan.getQueryPlanningInfo(), crdX) ) {
 				return;
 			}
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
@@ -161,11 +161,7 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		// guaranteed to produce an empty result. If so, we can stop
 		// here because the join cardinality is then guaranteed to be
 		// zero as well.
-		if ( crdValue == 0 && crd1.getQuality() == Quality.ACCURATE ) {
-			final QueryPlanningInfo qpInfo = currentSubPlan.getQueryPlanningInfo();
-			qpInfo.addProperty( QueryPlanProperty.cardinality(0, Quality.ACCURATE) );
-			qpInfo.addProperty( QueryPlanProperty.maxCardinality(0, Quality.ACCURATE) );
-			qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.ACCURATE) );
+		if ( handleGuaranteedEmpty(currentSubPlan.getQueryPlanningInfo(), crd1) ) {
 			return;
 		}
 
@@ -298,12 +294,9 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		final QueryPlanningInfo qpInfoSubPlan = currentSubPlan.getSubPlan(0).getQueryPlanningInfo();
 		final QueryPlanProperty crdSubPlan = qpInfoSubPlan.getProperty(CARDINALITY);
 
-		if ( crdSubPlan.getValue() == 0 && crdSubPlan.getQuality() == Quality.ACCURATE ) {
+		if ( handleGuaranteedEmpty(qpInfo, crdSubPlan) ) {
 			// If the input plan is guaranteed to produce an empty result,
 			// then the result of the BIND operator is guaranteed to be empty as well.
-			qpInfo.addProperty( QueryPlanProperty.cardinality(0, Quality.ACCURATE) );
-			qpInfo.addProperty( QueryPlanProperty.maxCardinality(0, Quality.ACCURATE) );
-			qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.ACCURATE) );
 			return;
 		}
 
@@ -322,10 +315,7 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 
 		// Special case 1: if the input plan is guaranteed to produce an empty result,
 		// then the result of the UNFOLD operator is guaranteed to be empty as well.
-		if ( qpInfoSubPlan.getProperty(CARDINALITY).getValue() == 0 && qpInfoSubPlan.getProperty(CARDINALITY).getQuality() == Quality.ACCURATE ) {
-			qpInfo.addProperty( QueryPlanProperty.cardinality(0, Quality.ACCURATE) );
-			qpInfo.addProperty( QueryPlanProperty.maxCardinality(0, Quality.ACCURATE) );
-			qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.ACCURATE) );
+		if ( handleGuaranteedEmpty(qpInfo, qpInfoSubPlan.getProperty(CARDINALITY)) ) {
 			return;
 		}
 
@@ -451,14 +441,13 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		final QueryPlanProperty max = qpInfoSubPlan.getProperty(MAX_CARDINALITY);
 		final QueryPlanProperty min = qpInfoSubPlan.getProperty(MIN_CARDINALITY);
 
-		if ( crd.getValue() == 0 && crd.getQuality() == Quality.ACCURATE ) {
+		if ( handleGuaranteedEmpty(qpInfo, crd) ) {
 			// If the input plan is guaranteed to produce an empty result,
 			// then the result of the L2g operator is guaranteed to be empty as well.
-			qpInfo.addProperty( QueryPlanProperty.cardinality(0, Quality.ACCURATE) );
-			qpInfo.addProperty( QueryPlanProperty.maxCardinality(0, Quality.ACCURATE) );
-			qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.ACCURATE) );
+			return;
 		}
-		else if ( op.getVocabularyMapping().isEquivalenceOnly() ) {
+
+		if ( op.getVocabularyMapping().isEquivalenceOnly() ) {
 			// If the vocabulary mapping contains only equivalence
 			// rules, applying this vocabulary mapping to a set of
 			// solution mappings cannot result in fewer or more
@@ -488,14 +477,13 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		final QueryPlanProperty max = qpInfoSubPlan.getProperty(MAX_CARDINALITY);
 		final QueryPlanProperty min = qpInfoSubPlan.getProperty(MIN_CARDINALITY);
 
-		if ( crd.getValue() == 0 && crd.getQuality() == Quality.ACCURATE ) {
+		if ( handleGuaranteedEmpty(qpInfo, crd) ) {
 			// If the input plan is guaranteed to produce an empty result,
 			// then the result of the G2l operator is guaranteed to be empty as well.
-			qpInfo.addProperty( QueryPlanProperty.cardinality(0, Quality.ACCURATE) );
-			qpInfo.addProperty( QueryPlanProperty.maxCardinality(0, Quality.ACCURATE) );
-			qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.ACCURATE) );
+			return;
 		}
-		else if ( op.getVocabularyMapping().isEquivalenceOnly() ) {
+
+		if ( op.getVocabularyMapping().isEquivalenceOnly() ) {
 			// If the vocabulary mapping contains only equivalence
 			// rules, applying this vocabulary mapping to a set of
 			// solution mappings cannot result in fewer or more
@@ -537,11 +525,10 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 
 		final int crdValue;
 		final Quality crdQuality;
-		if ( crdIn.getValue() == 0 && crdIn.getQuality() == Quality.ACCURATE ) {
+		if ( handleGuaranteedEmpty(qpInfo, crdIn)) {
 			// If the input plan is guaranteed to produce an empty result,
 			// then the result of the DEDUP operator is guaranteed to be empty as well.
-			crdValue = 0;
-			crdQuality = Quality.ACCURATE;
+			return;
 		}
 		else if ( crdIn.getValue() == 0 || crdIn.getValue() == 1 ) {
 			crdValue = crdIn.getValue();
@@ -578,12 +565,10 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		final QueryPlanningInfo qpInfoSubPlan = currentSubPlan.getSubPlan(0).getQueryPlanningInfo();
 		final QueryPlanProperty crdSubPlan = qpInfoSubPlan.getProperty(CARDINALITY);
 
-		if ( crdSubPlan.getValue() == 0 && crdSubPlan.getQuality() == Quality.ACCURATE ) {
+		if ( handleGuaranteedEmpty(qpInfo, crdSubPlan) ) {
 			// If the input plan is guaranteed to produce an empty result,
 			// then the result of the PROJECT operator is guaranteed to be empty as well.
-			qpInfo.addProperty( QueryPlanProperty.cardinality(0, Quality.ACCURATE) );
-			qpInfo.addProperty( QueryPlanProperty.maxCardinality(0, Quality.ACCURATE) );
-			qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.ACCURATE) );
+			return;
 		}
 		else {
 			qpInfo.addProperty( qpInfoSubPlan.getProperty(CARDINALITY) );
@@ -607,12 +592,10 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		final QueryPlanProperty lhsMaxCrd = qpInfoSubPlan1.getProperty(MAX_CARDINALITY);
 		final QueryPlanProperty rhsCrd = qpInfoSubPlan2.getProperty(CARDINALITY);
 
-		if ( lhsCrd.getValue() == 0 && lhsCrd.getQuality() == Quality.ACCURATE ) {
+		if ( handleGuaranteedEmpty(currentSubPlan.getQueryPlanningInfo(), lhsCrd) )
 			// If the first input plan is guaranteed to produce an empty result,
 			// then the result of the MINUS operator is guaranteed to be empty as well.
-			crdValue = 0;
-			crdQuality = Quality.ACCURATE;
-		}
+			return;
 		else if ( rhsCrd.getValue() == 0 && rhsCrd.getQuality() == Quality.ACCURATE ) {
 			// If the second input plan is guaranteed to produce an empty result,
 			// then the result of the MINUS operator is guaranteed to be the same as the first input plan.
@@ -635,6 +618,19 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 		qpInfo.addProperty( QueryPlanProperty.cardinality(crdValue, crdQuality) );
 		qpInfo.addProperty( QueryPlanProperty.maxCardinality(maxValue, maxQuality) );
 		qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.MIN_OR_MAX_POSSIBLE) );
+	}
+
+	public boolean handleGuaranteedEmpty( final QueryPlanningInfo qpInfo, final QueryPlanProperty crd ) {
+		if ( crd.getValue() == 0 && crd.getQuality() == Quality.ACCURATE ) {
+			// If the input plan is guaranteed to produce an empty result,
+			// then the result of the output is guaranteed to be empty as well.
+			qpInfo.addProperty( QueryPlanProperty.cardinality(0, Quality.ACCURATE) );
+			qpInfo.addProperty( QueryPlanProperty.maxCardinality(0, Quality.ACCURATE) );
+			qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.ACCURATE) );
+			return true;
+		}
+
+		return false;
 	}
 
 	public void addCardinalityForUnion() {
@@ -713,11 +709,7 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 			// guaranteed to produce an empty result. If so, we can stop
 			// here because the join cardinality is then guaranteed to be
 			// zero as well.
-			if ( crdX.getValue() == 0 && crdX.getQuality() == Quality.ACCURATE ) {
-				final QueryPlanningInfo qpInfo = currentSubPlan.getQueryPlanningInfo();
-				qpInfo.addProperty( QueryPlanProperty.cardinality(0, Quality.ACCURATE) );
-				qpInfo.addProperty( QueryPlanProperty.maxCardinality(0, Quality.ACCURATE) );
-				qpInfo.addProperty( QueryPlanProperty.minCardinality(0, Quality.ACCURATE) );
+			if ( handleGuaranteedEmpty(currentSubPlan.getQueryPlanningInfo(), crdX) ) {
 				return;
 			}
 

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/RemoveSubPlansWithEmptyResultsTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/RemoveSubPlansWithEmptyResultsTest.java
@@ -10,7 +10,6 @@ import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.core.VarExprList;
 import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.NodeValue;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import se.liu.ida.hefquin.base.query.TriplePattern;
@@ -355,7 +354,7 @@ public class RemoveSubPlansWithEmptyResultsTest extends EngineTestBase
 		assertEquals( 0, result.numberOfSubPlans() );
 	}
 
-	@Ignore("This test currently fails because the cardinality estimator degrades the cardinality quality (TODO #585).")
+	@Test
 	public void leftJoinWithEmptyLeftBranch() {
 		// Left join with empty left and non-empty right subplan.
 		// Result is empty and entire plan is removed.


### PR DESCRIPTION
First PR for #585.

This PR refactors the `Filter` operator (as suggested in the issue discussion thread).

It also introduces early-exit optimizations that set the cardinality to `0` with `Quality.ACCURATE` when the input is guaranteed to be empty. This is added for the following operators:
- `LeftJoin`
- `Union`
- `Dedup`
- `Minus`
- `Project`
- `Bind`
- `Unfold`
- `LocalToGlobal`
- `GlobalToLocal`  

