### PR TITLE
Add option to push projection variables and distinct into SPARQLRequest

### DIFF
--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/SPARQLRequest.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/SPARQLRequest.java
@@ -1,5 +1,9 @@
 package se.liu.ida.hefquin.federation.access;
 
+import java.util.Set;
+
+import org.apache.jena.sparql.core.Var;
+
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
 import se.liu.ida.hefquin.base.query.SPARQLQuery;
 import se.liu.ida.hefquin.base.query.impl.SPARQLQueryImpl;
@@ -13,6 +17,28 @@ public interface SPARQLRequest extends DataRetrievalRequest
 	 * accessed via the method {@link #getQuery()}.
 	 */
 	SPARQLGraphPattern getQueryPattern();
+
+	/**
+	 * Returns the set of variables that should be projected in the result.
+	 *
+	 * <p>If non-empty, this set represents a request-level projection that may
+	 * be applied when constructing the SPARQL query sent to an endpoint.
+	 * Implementations may ignore this information if applying it would not be
+	 * semantically safe (e.g., for queries with aggregation or expression-based
+	 * projections).</p>
+	 *
+	 */
+	Set<Var> getProjectionVars();
+
+	/**
+	 * Indicates whether the results of this request should be duplicate-free.
+	 *
+	 * <p>If {@code true}, the request processor may enforce this by issuing
+	 * a {@code DISTINCT} query to the endpoint (if supported).</p>
+	 *
+	 * @return {@code true} if duplicate elimination is requested; {@code false} otherwise
+	 */
+	boolean isDistinct();
 
 	/**
 	 * Returns the SPARQL query for which solutions

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/SPARQLRequest.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/SPARQLRequest.java
@@ -45,15 +45,11 @@ public interface SPARQLRequest extends DataRetrievalRequest
 	 * should be requested.
 	 */
 	default SPARQLQuery getQuery() {
-		return convertToQuery( getQueryPattern(),
-		                       getProjectionVars(),
-		                       isDistinct() );
+		return convertToQuery( getQueryPattern() );
 	}
 
-	static SPARQLQuery convertToQuery( final SPARQLGraphPattern pattern,
-	                                   final Set<Var> projectionVars,
-	                                   final boolean isDistinct ) {
-		return new SPARQLQueryImpl( pattern, projectionVars, isDistinct );
+	static SPARQLQuery convertToQuery( final SPARQLGraphPattern pattern ) {
+		return new SPARQLQueryImpl( pattern );
 	}
 
 }

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/SPARQLRequest.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/SPARQLRequest.java
@@ -31,10 +31,8 @@ public interface SPARQLRequest extends DataRetrievalRequest
 	Set<Var> getProjectionVars();
 
 	/**
-	 * Indicates whether the results of this request should be duplicate-free.
-	 *
-	 * <p>If {@code true}, the request processor may enforce this by issuing
-	 * a {@code DISTINCT} query to the endpoint (if supported).</p>
+	 * Returns {@code true} if this request <em>explicit</em> requires that the requested
+	 * result is duplicate free.
 	 *
 	 * @return {@code true} if duplicate elimination is requested; {@code false} otherwise
 	 */

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/SPARQLRequest.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/SPARQLRequest.java
@@ -19,14 +19,16 @@ public interface SPARQLRequest extends DataRetrievalRequest
 	SPARQLGraphPattern getQueryPattern();
 
 	/**
-	 * Returns the set of variables that should be projected in the result.
+	 * Returns the set of variables that should be projected in the result,
+	 * or {@code null} if no projection is specified for this request.
 	 *
-	 * <p>If non-empty, this set represents a request-level projection that may
-	 * be applied when constructing the SPARQL query sent to an endpoint.
-	 * Implementations may ignore this information if applying it would not be
-	 * semantically safe (e.g., for queries with aggregation or expression-based
-	 * projections).</p>
+	 * <p>If a non-null set is returned (including the empty set), then
+	 * projection is considered an explicit part of this request and must
+	 * be respected by components that can support it.</p>
 	 *
+	 * <p>Deciding whether such a projection can be safely applied or pushed
+	 * into a request is the responsibility of the query planning and
+	 * rewriting logic, not of this interface or its implementations.</p>
 	 */
 	Set<Var> getProjectionVars();
 
@@ -43,11 +45,15 @@ public interface SPARQLRequest extends DataRetrievalRequest
 	 * should be requested.
 	 */
 	default SPARQLQuery getQuery() {
-		return convertToQuery( getQueryPattern() );
+		return convertToQuery( getQueryPattern(),
+		                       getProjectionVars(),
+		                       isDistinct() );
 	}
 
-	static SPARQLQuery convertToQuery( final SPARQLGraphPattern pattern ) {
-		return new SPARQLQueryImpl( pattern );
+	static SPARQLQuery convertToQuery( final SPARQLGraphPattern pattern,
+	                                   final Set<Var> projectionVars,
+	                                   final boolean isDistinct ) {
+		return new SPARQLQueryImpl( pattern, projectionVars, isDistinct );
 	}
 
 }

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/SPARQLRequest.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/SPARQLRequest.java
@@ -33,7 +33,7 @@ public interface SPARQLRequest extends DataRetrievalRequest
 	Set<Var> getProjectionVars();
 
 	/**
-	 * Returns {@code true} if this request <em>explicit</em> requires that the requested
+	 * Returns {@code true} if this request <em>explicitly</em> requires that the requested
 	 * result is duplicate free.
 	 *
 	 * @return {@code true} if duplicate elimination is requested; {@code false} otherwise
@@ -45,11 +45,13 @@ public interface SPARQLRequest extends DataRetrievalRequest
 	 * should be requested.
 	 */
 	default SPARQLQuery getQuery() {
-		return convertToQuery( getQueryPattern() );
+		return convertToQuery( getQueryPattern(), getProjectionVars(), isDistinct() );
 	}
 
-	static SPARQLQuery convertToQuery( final SPARQLGraphPattern pattern ) {
-		return new SPARQLQueryImpl( pattern );
+	static SPARQLQuery convertToQuery( final SPARQLGraphPattern pattern,
+	                                   final Set<Var> projectionVars,
+	                                   final boolean isDistinct ) {
+		return new SPARQLQueryImpl( pattern, projectionVars, isDistinct );
 	}
 
 }

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/SPARQLRequest.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/SPARQLRequest.java
@@ -38,20 +38,20 @@ public interface SPARQLRequest extends DataRetrievalRequest
 	 *
 	 * @return {@code true} if duplicate elimination is requested; {@code false} otherwise
 	 */
-	boolean isDistinct();
+	boolean getDistinctRequired();
 
 	/**
 	 * Returns the SPARQL query for which solutions
 	 * should be requested.
 	 */
 	default SPARQLQuery getQuery() {
-		return convertToQuery( getQueryPattern(), getProjectionVars(), isDistinct() );
+		return convertToQuery( getQueryPattern(), getProjectionVars(), getDistinctRequired() );
 	}
 
 	static SPARQLQuery convertToQuery( final SPARQLGraphPattern pattern,
 	                                   final Set<Var> projectionVars,
-	                                   final boolean isDistinct ) {
-		return new SPARQLQueryImpl( pattern, projectionVars, isDistinct );
+	                                   final boolean distinctRequired ) {
+		return new SPARQLQueryImpl( pattern, projectionVars, distinctRequired );
 	}
 
 }

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/BGPRequestImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/BGPRequestImpl.java
@@ -1,5 +1,10 @@
 package se.liu.ida.hefquin.federation.access.impl.req;
 
+import java.util.Collections;
+import java.util.Set;
+
+import org.apache.jena.sparql.core.Var;
+
 import se.liu.ida.hefquin.base.query.BGP;
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.federation.access.BGPRequest;
@@ -36,6 +41,16 @@ public class BGPRequestImpl implements BGPRequest
 	@Override
 	public String toString(){
 		return bgp.toString();
+	}
+
+	@Override
+	public Set<Var> getProjectionVars() {
+		return Collections.emptySet();
+	}
+
+	@Override
+	public boolean isDistinct() {
+		return false;
 	}
 
 }

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/BGPRequestImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/BGPRequestImpl.java
@@ -45,7 +45,7 @@ public class BGPRequestImpl implements BGPRequest
 
 	@Override
 	public Set<Var> getProjectionVars() {
-		return Collections.emptySet();
+		return null;
 	}
 
 	@Override

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/BGPRequestImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/BGPRequestImpl.java
@@ -1,6 +1,5 @@
 package se.liu.ida.hefquin.federation.access.impl.req;
 
-import java.util.Collections;
 import java.util.Set;
 
 import org.apache.jena.sparql.core.Var;

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/BGPRequestImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/BGPRequestImpl.java
@@ -48,7 +48,7 @@ public class BGPRequestImpl implements BGPRequest
 	}
 
 	@Override
-	public boolean isDistinct() {
+	public boolean getDistinctRequired() {
 		return false;
 	}
 

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImpl.java
@@ -1,7 +1,6 @@
 package se.liu.ida.hefquin.federation.access.impl.req;
 
-import java.util.Collections;
-import java.util.Objects;
+import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.jena.sparql.core.Var;
@@ -23,8 +22,22 @@ public class SPARQLRequestImpl implements SPARQLRequest
 		assert pattern != null;
 		this.pattern = pattern;
 		this.query = null;
-		this.projectionVars = Collections.emptySet();
+		this.projectionVars = null;
 		this.isDistinct = false;
+
+		// we materialize the ExpectedVariables in this case
+		// to avoid producing it again whenever it is used
+		expectedVars = pattern.getExpectedVariables();
+	}
+
+	public SPARQLRequestImpl( final SPARQLGraphPattern pattern,
+	                          final Set<Var> projectionVars,
+	                          final boolean distinct ) {
+		assert pattern != null;
+		this.pattern = pattern;
+		this.query = null;
+		this.projectionVars = projectionVars;
+		this.isDistinct = distinct;
 
 		// we materialize the ExpectedVariables in this case
 		// to avoid producing it again whenever it is used
@@ -35,22 +48,8 @@ public class SPARQLRequestImpl implements SPARQLRequest
 		assert query != null;
 		this.query = query;
 		this.pattern = null;
-		this.projectionVars = query.getProjectionVars();
-		this.isDistinct = query.isDistinct();
-
-		// we materialize the ExpectedVariables in this case
-		// to avoid producing it again whenever it is used
-		expectedVars = query.getExpectedVariables();
-	}
-
-	public SPARQLRequestImpl( final SPARQLQuery query,
-	                          final Set<Var> projectionVars,
-	                          final boolean distinct ) {
-		assert query != null;
-		this.query = query;
-		this.pattern = null;
-		this.projectionVars = projectionVars;
-		this.isDistinct = distinct;
+		this.projectionVars = new HashSet<>( query.asJenaQuery().getProjectVars() );
+		this.isDistinct = query.asJenaQuery().isDistinct();
 
 		// we materialize the ExpectedVariables in this case
 		// to avoid producing it again whenever it is used
@@ -64,18 +63,25 @@ public class SPARQLRequestImpl implements SPARQLRequest
 
 		final SPARQLRequest oo = (SPARQLRequest) o;
 
-		return Objects.equals( getQueryPattern(), oo.getQueryPattern() )
-			&& getProjectionVars().equals( oo.getProjectionVars() )
-			&& isDistinct() == oo.isDistinct();
+		if ( pattern == null ) {
+			return oo.getQueryPattern() == null
+			    && query.equals( oo.getQuery() )
+			    && getProjectionVars().equals(oo.getProjectionVars())
+			    && isDistinct() == oo.isDistinct();
+		}
+		else {
+			return pattern.equals( oo.getQueryPattern() )
+			    && getProjectionVars().equals(oo.getProjectionVars())
+			    && isDistinct() == oo.isDistinct();
+		}
 	}
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(
-			getQueryPattern(),
-			getProjectionVars(),
-			isDistinct()
-		);
+		if ( pattern == null )
+			return query.hashCode() ^ getProjectionVars().hashCode() ^ (isDistinct() ? 1 : 0);
+		else
+			return pattern.hashCode() ^ getProjectionVars().hashCode() ^ (isDistinct() ? 1 : 0);
 	}
 
 	@Override
@@ -98,7 +104,7 @@ public class SPARQLRequestImpl implements SPARQLRequest
 		if ( query != null )
 			return query;
 		else
-			return SPARQLRequest.convertToQuery( getQueryPattern() );
+			return SPARQLRequest.convertToQuery( getQueryPattern(), projectionVars, isDistinct );
 	}
 
 	@Override

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImpl.java
@@ -3,11 +3,13 @@ package se.liu.ida.hefquin.federation.access.impl.req;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.apache.jena.query.Query;
 import org.apache.jena.sparql.core.Var;
 
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
 import se.liu.ida.hefquin.base.query.SPARQLQuery;
+import se.liu.ida.hefquin.base.query.impl.SPARQLQueryImpl;
 import se.liu.ida.hefquin.federation.access.SPARQLRequest;
 
 public class SPARQLRequestImpl implements SPARQLRequest
@@ -101,10 +103,30 @@ public class SPARQLRequestImpl implements SPARQLRequest
 
 	@Override
 	public SPARQLQuery getQuery() {
-		if ( query != null )
-			return query;
-		else
-			return SPARQLRequest.convertToQuery( getQueryPattern(), projectionVars, isDistinct );
+		final SPARQLQuery baseQuery = query != null ? query : SPARQLRequest.convertToQuery( getQueryPattern() );
+
+		if ( getProjectionVars() == null && ! isDistinct() )
+			return baseQuery;
+
+		// Clone the query to avoid mutating the original request
+		final Query q = baseQuery.asJenaQuery().cloneQuery();
+
+		// Apply request-level projection if specified and safe.
+		// This replaces the SELECT clause with the given variables.
+		// Note: This is only done when it does not interfere with query semantics
+		// (e.g., no aggregation or grouping present).
+		if ( getProjectionVars() != null && isSafeToOverrideProjection(q) ) {
+			q.setQueryResultStar(false);
+			q.getProject().clear();
+			getProjectionVars().forEach(q::addResultVar);
+		}
+
+		// Apply DISTINCT if requested.
+		// This enforces duplicate elimination at the endpoint level.
+		if ( isDistinct() )
+			q.setDistinct( true );
+
+		return new SPARQLQueryImpl(q);
 	}
 
 	@Override
@@ -120,4 +142,40 @@ public class SPARQLRequestImpl implements SPARQLRequest
 			return "SPARQLRequest with pattern: " + pattern.toString();
 	}
 
+	/**
+	 * Determines whether it is semantically safe to override the projection
+	 * of the given query.
+	 *
+	 * <p>Overriding the projection means replacing the SELECT clause with a
+	 * new set of variables (e.g., for projection pushdown). This is only safe
+	 * for "simple" SELECT queries without features that depend on the original
+	 * projection.</p>
+	 *
+	 * <p>In particular, projection must not be overridden if the query contains:
+	 * <ul>
+	 *   <li>GROUP BY (projection affects grouping semantics)</li>
+	 *   <li>HAVING clauses (depends on grouped results)</li>
+	 *   <li>Aggregators (e.g., COUNT, SUM), which rely on specific projection expressions</li>
+	 * </ul>
+	 * </p>
+	 *
+	 * @param q the query to inspect
+	 * @return {@code true} if projection can be safely overridden; {@code false} otherwise
+	 */
+	protected static boolean isSafeToOverrideProjection(final Query q)
+	{
+		// Query must be SELECT type
+		if ( ! q.isSelectType() ) return false;
+
+		// Must not contain GROUP BY
+		if ( q.hasGroupBy() ) return false;
+
+		// Must not contain HAVING (optional but safe)
+		if ( q.hasHaving() ) return false;
+
+		// Must not have expressions in SELECT
+		if ( q.hasAggregators() ) return false;
+
+		return true;
+	}
 }

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImpl.java
@@ -1,5 +1,11 @@
 package se.liu.ida.hefquin.federation.access.impl.req;
 
+import java.util.Collections;
+import java.util.Objects;
+import java.util.Set;
+
+import org.apache.jena.sparql.core.Var;
+
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
 import se.liu.ida.hefquin.base.query.SPARQLQuery;
@@ -10,11 +16,15 @@ public class SPARQLRequestImpl implements SPARQLRequest
 	protected final SPARQLGraphPattern pattern;
 	protected final SPARQLQuery query;
 	protected final ExpectedVariables expectedVars;
+	protected final Set<Var> projectionVars;
+	protected final boolean isDistinct;
 
 	public SPARQLRequestImpl( final SPARQLGraphPattern pattern ) {
 		assert pattern != null;
 		this.pattern = pattern;
 		this.query = null;
+		this.projectionVars = Collections.emptySet();
+		this.isDistinct = false;
 
 		// we materialize the ExpectedVariables in this case
 		// to avoid producing it again whenever it is used
@@ -25,6 +35,22 @@ public class SPARQLRequestImpl implements SPARQLRequest
 		assert query != null;
 		this.query = query;
 		this.pattern = null;
+		this.projectionVars = query.getProjectionVars();
+		this.isDistinct = query.isDistinct();
+
+		// we materialize the ExpectedVariables in this case
+		// to avoid producing it again whenever it is used
+		expectedVars = query.getExpectedVariables();
+	}
+
+	public SPARQLRequestImpl( final SPARQLQuery query,
+	                          final Set<Var> projectionVars,
+	                          final boolean distinct ) {
+		assert query != null;
+		this.query = query;
+		this.pattern = null;
+		this.projectionVars = projectionVars;
+		this.isDistinct = distinct;
 
 		// we materialize the ExpectedVariables in this case
 		// to avoid producing it again whenever it is used
@@ -37,25 +63,34 @@ public class SPARQLRequestImpl implements SPARQLRequest
 			return false;
 
 		final SPARQLRequest oo = (SPARQLRequest) o;
-		if ( pattern == null ) {
-			return oo.getQueryPattern() == null && query.equals( oo.getQuery() );
-		}
-		else {
-			return pattern.equals( oo.getQueryPattern() );
-		}
+
+		return Objects.equals( getQueryPattern(), oo.getQueryPattern() )
+			&& getProjectionVars().equals( oo.getProjectionVars() )
+			&& isDistinct() == oo.isDistinct();
 	}
 
 	@Override
-	public int hashCode(){
-		if ( pattern == null )
-			return query.hashCode();
-		else
-			return pattern.hashCode();
+	public int hashCode() {
+		return Objects.hash(
+			getQueryPattern(),
+			getProjectionVars(),
+			isDistinct()
+		);
 	}
 
 	@Override
 	public SPARQLGraphPattern getQueryPattern() {
 		return pattern;
+	}
+
+	@Override
+	public Set<Var> getProjectionVars() {
+		return projectionVars;
+	}
+
+	@Override
+	public boolean isDistinct() {
+		return isDistinct;
 	}
 
 	@Override

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImpl.java
@@ -16,7 +16,7 @@ public class SPARQLRequestImpl implements SPARQLRequest
 {
 	protected final SPARQLGraphPattern pattern;
 	protected final Set<Var> projectionVars;
-	protected final boolean isDistinct;
+	protected final boolean distinctRequired;
 
 	protected final SPARQLQuery query;
 
@@ -28,12 +28,12 @@ public class SPARQLRequestImpl implements SPARQLRequest
 
 	public SPARQLRequestImpl( final SPARQLGraphPattern pattern,
 	                          final Set<Var> projectionVars,
-	                          final boolean distinct ) {
+	                          final boolean distinctRequired ) {
 		assert pattern != null;
 		this.pattern = pattern;
 		this.query = null;
 		this.projectionVars = projectionVars;
-		this.isDistinct = distinct;
+		this.distinctRequired = distinctRequired;
 
 		// we materialize the ExpectedVariables in this case
 		// to avoid producing it again whenever it is used
@@ -47,7 +47,7 @@ public class SPARQLRequestImpl implements SPARQLRequest
 
 		final Query jena = query.asJenaQuery();
 		this.projectionVars = jena.isQueryResultStar() ? null : new HashSet<>( jena.getProjectVars() );
-		this.isDistinct = jena.isDistinct();
+		this.distinctRequired = jena.isDistinct();
 
 		// we materialize the ExpectedVariables in this case
 		// to avoid producing it again whenever it is used
@@ -67,7 +67,7 @@ public class SPARQLRequestImpl implements SPARQLRequest
 		else {
 			return pattern.equals( oo.getQueryPattern() )
 			    && Objects.equals( getProjectionVars(), oo.getProjectionVars() )
-			    && isDistinct() == oo.isDistinct();
+			    && getDistinctRequired() == oo.getDistinctRequired();
 		}
 	}
 
@@ -76,9 +76,9 @@ public class SPARQLRequestImpl implements SPARQLRequest
 		if ( pattern == null )
 			return query.hashCode();
 		else if ( pattern != null && getProjectionVars() != null )
-			return pattern.hashCode() ^ getProjectionVars().hashCode() ^ (isDistinct() ? 1 : 0);
+			return pattern.hashCode() ^ getProjectionVars().hashCode() ^ (getDistinctRequired() ? 1 : 0);
 		else
-			return pattern.hashCode() ^ (isDistinct() ? 1 : 0);
+			return pattern.hashCode() ^ (getDistinctRequired() ? 1 : 0);
 	}
 
 	@Override
@@ -92,8 +92,8 @@ public class SPARQLRequestImpl implements SPARQLRequest
 	}
 
 	@Override
-	public boolean isDistinct() {
-		return isDistinct;
+	public boolean getDistinctRequired() {
+		return distinctRequired;
 	}
 
 	@Override
@@ -101,7 +101,7 @@ public class SPARQLRequestImpl implements SPARQLRequest
 		if ( query != null )
 			return query;
 		else
-			return SPARQLRequest.convertToQuery( getQueryPattern(), getProjectionVars(), isDistinct() );
+			return SPARQLRequest.convertToQuery( getQueryPattern(), getProjectionVars(), getDistinctRequired() );
 	}
 
 	@Override
@@ -116,6 +116,6 @@ public class SPARQLRequestImpl implements SPARQLRequest
 		else
 			return "SPARQLRequest with pattern: " + pattern.toString()
 			     + ", projection variables: " + projectionVars
-			     + ", distinct: " + isDistinct;
+			     + ", distinct required: " + distinctRequired;
 	}
 }

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImpl.java
@@ -62,14 +62,11 @@ public class SPARQLRequestImpl implements SPARQLRequest
 		final SPARQLRequest oo = (SPARQLRequest) o;
 
 		if ( pattern == null ) {
-			return oo.getQueryPattern() == null
-			    && query.equals( oo.getQuery() )
-			    && Objects.equals( getProjectionVars(), (oo.getProjectionVars()) )
-			    && isDistinct() == oo.isDistinct();
+			return oo.getQueryPattern() == null && query.equals( oo.getQuery() );
 		}
 		else {
 			return pattern.equals( oo.getQueryPattern() )
-			    && Objects.equals( getProjectionVars(), (oo.getProjectionVars()) )
+			    && Objects.equals( getProjectionVars(), oo.getProjectionVars() )
 			    && isDistinct() == oo.isDistinct();
 		}
 	}
@@ -115,12 +112,10 @@ public class SPARQLRequestImpl implements SPARQLRequest
 	@Override
 	public String toString(){
 		if ( query != null )
-			return "SPARQLRequest with query: " + query.toString()
-			     + ", projection variables: " + ( projectionVars == null ? "null" : projectionVars.toString() )
-			     + ", distinct: " + isDistinct;
+			return "SPARQLRequest with query: " + query.toString();
 		else
 			return "SPARQLRequest with pattern: " + pattern.toString()
-			     + ", projection variables: " + ( projectionVars == null ? "null" : projectionVars.toString() )
+			     + ", projection variables: " + projectionVars
 			     + ", distinct: " + isDistinct;
 	}
 }

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImpl.java
@@ -1,6 +1,7 @@
 package se.liu.ida.hefquin.federation.access.impl.req;
 
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.jena.query.Query;
@@ -9,7 +10,6 @@ import org.apache.jena.sparql.core.Var;
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
 import se.liu.ida.hefquin.base.query.SPARQLQuery;
-import se.liu.ida.hefquin.base.query.impl.SPARQLQueryImpl;
 import se.liu.ida.hefquin.federation.access.SPARQLRequest;
 
 public class SPARQLRequestImpl implements SPARQLRequest
@@ -44,8 +44,10 @@ public class SPARQLRequestImpl implements SPARQLRequest
 		assert query != null;
 		this.query = query;
 		this.pattern = null;
-		this.projectionVars = new HashSet<>( query.asJenaQuery().getProjectVars() );
-		this.isDistinct = query.asJenaQuery().isDistinct();
+
+		final Query jena = query.asJenaQuery();
+		this.projectionVars = jena.isQueryResultStar() ? null : new HashSet<>( jena.getProjectVars() );
+		this.isDistinct = jena.isDistinct();
 
 		// we materialize the ExpectedVariables in this case
 		// to avoid producing it again whenever it is used
@@ -62,12 +64,12 @@ public class SPARQLRequestImpl implements SPARQLRequest
 		if ( pattern == null ) {
 			return oo.getQueryPattern() == null
 			    && query.equals( oo.getQuery() )
-			    && getProjectionVars().equals(oo.getProjectionVars())
+			    && Objects.equals( getProjectionVars(), (oo.getProjectionVars()) )
 			    && isDistinct() == oo.isDistinct();
 		}
 		else {
 			return pattern.equals( oo.getQueryPattern() )
-			    && getProjectionVars().equals(oo.getProjectionVars())
+			    && Objects.equals( getProjectionVars(), (oo.getProjectionVars()) )
 			    && isDistinct() == oo.isDistinct();
 		}
 	}
@@ -76,8 +78,10 @@ public class SPARQLRequestImpl implements SPARQLRequest
 	public int hashCode() {
 		if ( pattern == null )
 			return query.hashCode();
-		else
+		else if ( pattern != null && getProjectionVars() != null )
 			return pattern.hashCode() ^ getProjectionVars().hashCode() ^ (isDistinct() ? 1 : 0);
+		else
+			return pattern.hashCode() ^ (isDistinct() ? 1 : 0);
 	}
 
 	@Override
@@ -97,30 +101,10 @@ public class SPARQLRequestImpl implements SPARQLRequest
 
 	@Override
 	public SPARQLQuery getQuery() {
-		final SPARQLQuery baseQuery = query != null ? query : SPARQLRequest.convertToQuery( getQueryPattern() );
-
-		if ( getProjectionVars() == null && ! isDistinct() )
-			return baseQuery;
-
-		// Clone the query to avoid mutating the original request
-		final Query q = baseQuery.asJenaQuery().cloneQuery();
-
-		// Apply request-level projection if specified and safe.
-		// This replaces the SELECT clause with the given variables.
-		// Note: This is only done when it does not interfere with query semantics
-		// (e.g., no aggregation or grouping present).
-		if ( getProjectionVars() != null && isSafeToOverrideProjection(q) ) {
-			q.setQueryResultStar(false);
-			q.getProject().clear();
-			getProjectionVars().forEach(q::addResultVar);
-		}
-
-		// Apply DISTINCT if requested.
-		// This enforces duplicate elimination at the endpoint level.
-		if ( isDistinct() )
-			q.setDistinct( true );
-
-		return new SPARQLQueryImpl(q);
+		if ( query != null )
+			return query;
+		else
+			return SPARQLRequest.convertToQuery( getQueryPattern(), getProjectionVars(), isDistinct() );
 	}
 
 	@Override
@@ -131,45 +115,12 @@ public class SPARQLRequestImpl implements SPARQLRequest
 	@Override
 	public String toString(){
 		if ( query != null )
-			return "SPARQLRequest with query: " + query.toString();
+			return "SPARQLRequest with query: " + query.toString()
+			     + ", projection variables: " + ( projectionVars == null ? "null" : projectionVars.toString() )
+			     + ", distinct: " + isDistinct;
 		else
-			return "SPARQLRequest with pattern: " + pattern.toString();
-	}
-
-	/**
-	 * Determines whether it is semantically safe to override the projection
-	 * of the given query.
-	 *
-	 * <p>Overriding the projection means replacing the SELECT clause with a
-	 * new set of variables (e.g., for projection pushdown). This is only safe
-	 * for "simple" SELECT queries without features that depend on the original
-	 * projection.</p>
-	 *
-	 * <p>In particular, projection must not be overridden if the query contains:
-	 * <ul>
-	 *   <li>GROUP BY (projection affects grouping semantics)</li>
-	 *   <li>HAVING clauses (depends on grouped results)</li>
-	 *   <li>Aggregators (e.g., COUNT, SUM), which rely on specific projection expressions</li>
-	 * </ul>
-	 * </p>
-	 *
-	 * @param q the query to inspect
-	 * @return {@code true} if projection can be safely overridden; {@code false} otherwise
-	 */
-	protected static boolean isSafeToOverrideProjection(final Query q)
-	{
-		// Query must be SELECT type
-		if ( ! q.isSelectType() ) return false;
-
-		// Must not contain GROUP BY
-		if ( q.hasGroupBy() ) return false;
-
-		// Must not contain HAVING (optional but safe)
-		if ( q.hasHaving() ) return false;
-
-		// Must not have expressions in SELECT
-		if ( q.hasAggregators() ) return false;
-
-		return true;
+			return "SPARQLRequest with pattern: " + pattern.toString()
+			     + ", projection variables: " + ( projectionVars == null ? "null" : projectionVars.toString() )
+			     + ", distinct: " + isDistinct;
 	}
 }

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImpl.java
@@ -15,21 +15,15 @@ import se.liu.ida.hefquin.federation.access.SPARQLRequest;
 public class SPARQLRequestImpl implements SPARQLRequest
 {
 	protected final SPARQLGraphPattern pattern;
-	protected final SPARQLQuery query;
-	protected final ExpectedVariables expectedVars;
 	protected final Set<Var> projectionVars;
 	protected final boolean isDistinct;
 
-	public SPARQLRequestImpl( final SPARQLGraphPattern pattern ) {
-		assert pattern != null;
-		this.pattern = pattern;
-		this.query = null;
-		this.projectionVars = null;
-		this.isDistinct = false;
+	protected final SPARQLQuery query;
 
-		// we materialize the ExpectedVariables in this case
-		// to avoid producing it again whenever it is used
-		expectedVars = pattern.getExpectedVariables();
+	protected final ExpectedVariables expectedVars;
+
+	public SPARQLRequestImpl( final SPARQLGraphPattern pattern ) {
+		this(pattern, null, false);
 	}
 
 	public SPARQLRequestImpl( final SPARQLGraphPattern pattern,
@@ -81,7 +75,7 @@ public class SPARQLRequestImpl implements SPARQLRequest
 	@Override
 	public int hashCode() {
 		if ( pattern == null )
-			return query.hashCode() ^ getProjectionVars().hashCode() ^ (isDistinct() ? 1 : 0);
+			return query.hashCode();
 		else
 			return pattern.hashCode() ^ getProjectionVars().hashCode() ^ (isDistinct() ? 1 : 0);
 	}

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/TriplePatternRequestImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/TriplePatternRequestImpl.java
@@ -47,7 +47,7 @@ public class TriplePatternRequestImpl implements TriplePatternRequest
 
 	@Override
 	public Set<Var> getProjectionVars() {
-		return Collections.emptySet();
+		return null;
 	}
 
 	@Override

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/TriplePatternRequestImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/TriplePatternRequestImpl.java
@@ -4,7 +4,11 @@ import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.base.query.TriplePattern;
 import se.liu.ida.hefquin.federation.access.TriplePatternRequest;
 
+import java.util.Collections;
 import java.util.Objects;
+import java.util.Set;
+
+import org.apache.jena.sparql.core.Var;
 
 public class TriplePatternRequestImpl implements TriplePatternRequest
 {
@@ -39,6 +43,16 @@ public class TriplePatternRequestImpl implements TriplePatternRequest
 	@Override
 	public String toString(){
 		return tp.toString();
+	}
+
+	@Override
+	public Set<Var> getProjectionVars() {
+		return Collections.emptySet();
+	}
+
+	@Override
+	public boolean isDistinct() {
+		return false;
 	}
 
 }

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/TriplePatternRequestImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/TriplePatternRequestImpl.java
@@ -50,7 +50,7 @@ public class TriplePatternRequestImpl implements TriplePatternRequest
 	}
 
 	@Override
-	public boolean isDistinct() {
+	public boolean getDistinctRequired() {
 		return false;
 	}
 

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/TriplePatternRequestImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/TriplePatternRequestImpl.java
@@ -4,7 +4,6 @@ import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.base.query.TriplePattern;
 import se.liu.ida.hefquin.federation.access.TriplePatternRequest;
 
-import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/reqproc/SPARQLRequestProcessorImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/reqproc/SPARQLRequestProcessorImpl.java
@@ -57,12 +57,32 @@ public class SPARQLRequestProcessorImpl implements SPARQLRequestProcessor
 	{
 		// see https://jena.apache.org/documentation/sparql-apis/#query-execution
 
+		// Clone the query to avoid mutating the original request
+		final Query q = req.getQuery().asJenaQuery().cloneQuery();
+
+		// Apply request-level projection if specified and safe.
+		// This replaces the SELECT clause with the given variables.
+		// Note: This is only done when it does not interfere with query semantics
+		// (e.g., no aggregation or grouping present).
+		if ( req.getProjectionVars() != null
+		&& ! req.getProjectionVars().isEmpty()
+		  && isSafeToOverrideProjection(q) ) {
+			q.setQueryResultStar(false);
+			q.getProject().clear();
+			req.getProjectionVars().forEach(q::addResultVar);
+		}
+
+		// Apply DISTINCT if requested.
+		// This enforces duplicate elimination at the endpoint level.
+		if ( req.isDistinct() )
+			q.setDistinct( true );
+
 		final QueryExecution qe;
 		try {
 			qe = QueryExecutionHTTPBuilder.create()
 					.endpoint(   fm.getURL() )
 					.httpClient( httpClient )
-					.query(      req.getQuery().asJenaQuery() )
+					.query(      q )
 					.timeout(    overallTimeout, TimeUnit.MILLISECONDS )
 					.httpHeader( "User-Agent", BuildInfo.getUserAgent() )
 					.build();
@@ -141,7 +161,43 @@ public class SPARQLRequestProcessorImpl implements SPARQLRequestProcessor
 		public void accept( final QuerySolution s ) {
 			solMaps.add( SolutionMappingUtils.createSolutionMapping(s) );
 		}
-		
+
 	} // end of MySolutionConsumer
 
+	/**
+	 * Determines whether it is semantically safe to override the projection
+	 * of the given query.
+	 *
+	 * <p>Overriding the projection means replacing the SELECT clause with a
+	 * new set of variables (e.g., for projection pushdown). This is only safe
+	 * for "simple" SELECT queries without features that depend on the original
+	 * projection.</p>
+	 *
+	 * <p>In particular, projection must not be overridden if the query contains:
+	 * <ul>
+	 *   <li>GROUP BY (projection affects grouping semantics)</li>
+	 *   <li>HAVING clauses (depends on grouped results)</li>
+	 *   <li>Aggregators (e.g., COUNT, SUM), which rely on specific projection expressions</li>
+	 * </ul>
+	 * </p>
+	 *
+	 * @param q the query to inspect
+	 * @return {@code true} if projection can be safely overridden; {@code false} otherwise
+	 */
+	protected static boolean isSafeToOverrideProjection(final Query q)
+	{
+		// Query must be SELECT type
+		if ( ! q.isSelectType() ) return false;
+
+		// Must not contain GROUP BY
+		if ( q.hasGroupBy() ) return false;
+
+		// Must not contain HAVING (optional but safe)
+		if ( q.hasHaving() ) return false;
+
+		// Must not have expressions in SELECT
+		if ( q.hasAggregators() ) return false;
+
+		return true;
+	}
 }

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/reqproc/SPARQLRequestProcessorImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/reqproc/SPARQLRequestProcessorImpl.java
@@ -57,32 +57,12 @@ public class SPARQLRequestProcessorImpl implements SPARQLRequestProcessor
 	{
 		// see https://jena.apache.org/documentation/sparql-apis/#query-execution
 
-		// Clone the query to avoid mutating the original request
-		final Query q = req.getQuery().asJenaQuery().cloneQuery();
-
-		// Apply request-level projection if specified and safe.
-		// This replaces the SELECT clause with the given variables.
-		// Note: This is only done when it does not interfere with query semantics
-		// (e.g., no aggregation or grouping present).
-		if ( req.getProjectionVars() != null
-		&& ! req.getProjectionVars().isEmpty()
-		  && isSafeToOverrideProjection(q) ) {
-			q.setQueryResultStar(false);
-			q.getProject().clear();
-			req.getProjectionVars().forEach(q::addResultVar);
-		}
-
-		// Apply DISTINCT if requested.
-		// This enforces duplicate elimination at the endpoint level.
-		if ( req.isDistinct() )
-			q.setDistinct( true );
-
 		final QueryExecution qe;
 		try {
 			qe = QueryExecutionHTTPBuilder.create()
 					.endpoint(   fm.getURL() )
 					.httpClient( httpClient )
-					.query(      q )
+					.query(      req.getQuery().asJenaQuery() )
 					.timeout(    overallTimeout, TimeUnit.MILLISECONDS )
 					.httpHeader( "User-Agent", BuildInfo.getUserAgent() )
 					.build();

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/reqproc/SPARQLRequestProcessorImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/reqproc/SPARQLRequestProcessorImpl.java
@@ -144,40 +144,4 @@ public class SPARQLRequestProcessorImpl implements SPARQLRequestProcessor
 
 	} // end of MySolutionConsumer
 
-	/**
-	 * Determines whether it is semantically safe to override the projection
-	 * of the given query.
-	 *
-	 * <p>Overriding the projection means replacing the SELECT clause with a
-	 * new set of variables (e.g., for projection pushdown). This is only safe
-	 * for "simple" SELECT queries without features that depend on the original
-	 * projection.</p>
-	 *
-	 * <p>In particular, projection must not be overridden if the query contains:
-	 * <ul>
-	 *   <li>GROUP BY (projection affects grouping semantics)</li>
-	 *   <li>HAVING clauses (depends on grouped results)</li>
-	 *   <li>Aggregators (e.g., COUNT, SUM), which rely on specific projection expressions</li>
-	 * </ul>
-	 * </p>
-	 *
-	 * @param q the query to inspect
-	 * @return {@code true} if projection can be safely overridden; {@code false} otherwise
-	 */
-	protected static boolean isSafeToOverrideProjection(final Query q)
-	{
-		// Query must be SELECT type
-		if ( ! q.isSelectType() ) return false;
-
-		// Must not contain GROUP BY
-		if ( q.hasGroupBy() ) return false;
-
-		// Must not contain HAVING (optional but safe)
-		if ( q.hasHaving() ) return false;
-
-		// Must not have expressions in SELECT
-		if ( q.hasAggregators() ) return false;
-
-		return true;
-	}
 }

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/FederationTestBase.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/FederationTestBase.java
@@ -9,8 +9,8 @@ import se.liu.ida.hefquin.federation.members.impl.TPFServerImpl;
 public abstract class FederationTestBase
 {
 	/**
-	 * Change this flag to true if you also want to run the
-	 * unit tests that access servers on the actual Web.
+	 * If this flag is true, tests that access servers on the actual
+	 * Web will be skipped.
 	 */
 	public static boolean skipLiveWebTests = true;
 

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/FederationTestBase.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/FederationTestBase.java
@@ -12,7 +12,7 @@ public abstract class FederationTestBase
 	 * If this flag is true, tests that access servers on the actual
 	 * Web will be skipped.
 	 */
-	public static boolean skipLiveWebTests = true;
+	public static boolean skipLiveWebTests = false;
 
 	/**
 	 * If this flag is true, tests that make requests to local neo4j

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/FederationTestBase.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/FederationTestBase.java
@@ -12,7 +12,7 @@ public abstract class FederationTestBase
 	 * If this flag is true, tests that access servers on the actual
 	 * Web will be skipped.
 	 */
-	public static boolean skipLiveWebTests = false;
+	public static boolean skipLiveWebTests = true;
 
 	/**
 	 * If this flag is true, tests that make requests to local neo4j

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImplTest.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImplTest.java
@@ -23,46 +23,42 @@ public class SPARQLRequestImplTest extends FederationTestBase
 {
 	@Test
 	public void testDistinctRequestInitialization() throws FederationAccessException {
-		if ( ! skipLiveWebTests ) {
-			// setting up
-			final String queryString = "SELECT ?s WHERE { ?s <http://xmlns.com/foaf/0.1/name> \"Berlin\"@en . ?s <http://xmlns.com/foaf/0.1/name> ?o2 .}";
-			final SPARQLQuery baseQuery = new SPARQLQueryImpl( QueryFactory.create(queryString) );
+		// setting up
+		final String queryString = "SELECT ?s WHERE { ?s <http://xmlns.com/foaf/0.1/name> \"Berlin\"@en . ?s <http://xmlns.com/foaf/0.1/name> ?o2 .}";
+		final SPARQLQuery baseQuery = new SPARQLQueryImpl( QueryFactory.create(queryString) );
 
-			final SPARQLRequest req1 = new SPARQLRequestImpl(baseQuery);
+		final SPARQLRequest req1 = new SPARQLRequestImpl(baseQuery);
 
-			final Element el = QueryFactory.create(queryString).getQueryPattern();
-			final SPARQLGraphPattern pattern = new GenericSPARQLGraphPatternImpl1(el);
-			final SPARQLRequest req2 = new SPARQLRequestImpl(pattern, Set.of(Var.alloc("s")), true);
+		final Element el = QueryFactory.create(queryString).getQueryPattern();
+		final SPARQLGraphPattern pattern = new GenericSPARQLGraphPatternImpl1(el);
+		final SPARQLRequest req2 = new SPARQLRequestImpl(pattern, Set.of(Var.alloc("s")), true);
 
-			// checking
-			// the base query does not contain DISTINCT
-			assertFalse( baseQuery.asJenaQuery().isDistinct() );
+		// checking
+		// the base query does not contain DISTINCT
+		assertFalse( baseQuery.asJenaQuery().isDistinct() );
 
-			// req1 inherits DISTINCT=false, req2 explicitly enforces DISTINCT
-			assertFalse( req1.getDistinctRequired() );
-			assertTrue( req2.getDistinctRequired() );
-		}
+		// req1 inherits DISTINCT=false, req2 explicitly enforces DISTINCT
+		assertFalse( req1.getDistinctRequired() );
+		assertTrue( req2.getDistinctRequired() );
 	}
 
 	@Test
 	public void testProjectionVariablesInitialization() throws FederationAccessException {
-		if ( ! skipLiveWebTests ) {
-			// setting up
-			final String queryString = "SELECT ?s ?o2 WHERE { ?s <http://xmlns.com/foaf/0.1/name> \"Berlin\"@en . " +
-			                           "?s <http://xmlns.com/foaf/0.1/name> ?o2 . }";
+		// setting up
+		final String queryString = "SELECT ?s ?o2 WHERE { ?s <http://xmlns.com/foaf/0.1/name> \"Berlin\"@en . " +
+									"?s <http://xmlns.com/foaf/0.1/name> ?o2 . }";
 
-			final SPARQLQuery baseQuery = new SPARQLQueryImpl( QueryFactory.create(queryString) );
+		final SPARQLQuery baseQuery = new SPARQLQueryImpl( QueryFactory.create(queryString) );
 
-			final SPARQLRequest req1 = new SPARQLRequestImpl(baseQuery);
+		final SPARQLRequest req1 = new SPARQLRequestImpl(baseQuery);
 
-			final Element el = QueryFactory.create(queryString).getQueryPattern();
-			final SPARQLGraphPattern pattern = new GenericSPARQLGraphPatternImpl1(el);
-			final SPARQLRequest req2 = new SPARQLRequestImpl(pattern, Set.of(Var.alloc("s")), false);
+		final Element el = QueryFactory.create(queryString).getQueryPattern();
+		final SPARQLGraphPattern pattern = new GenericSPARQLGraphPatternImpl1(el);
+		final SPARQLRequest req2 = new SPARQLRequestImpl(pattern, Set.of(Var.alloc("s")), false);
 
-			// checking
-			// ensure projection is applied
-			assertEquals( Set.of(Var.alloc("s"), Var.alloc("o2")), req1.getProjectionVars() );
-			assertEquals( Set.of(Var.alloc("s")), req2.getProjectionVars() );
-		}
+		// checking
+		// ensure projection is applied
+		assertEquals( Set.of(Var.alloc("s"), Var.alloc("o2")), req1.getProjectionVars() );
+		assertEquals( Set.of(Var.alloc("s")), req2.getProjectionVars() );
 	}
 }

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImplTest.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImplTest.java
@@ -1,0 +1,124 @@
+package se.liu.ida.hefquin.federation.access.impl.req;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.apache.jena.query.QueryFactory;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.syntax.Element;
+import org.junit.Test;
+
+import se.liu.ida.hefquin.base.data.SolutionMapping;
+import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
+import se.liu.ida.hefquin.base.query.SPARQLQuery;
+import se.liu.ida.hefquin.base.query.impl.GenericSPARQLGraphPatternImpl1;
+import se.liu.ida.hefquin.base.query.impl.SPARQLQueryImpl;
+import se.liu.ida.hefquin.federation.FederationTestBase;
+import se.liu.ida.hefquin.federation.access.FederationAccessException;
+import se.liu.ida.hefquin.federation.access.SPARQLRequest;
+import se.liu.ida.hefquin.federation.access.SolMapsResponse;
+import se.liu.ida.hefquin.federation.access.impl.reqproc.SPARQLRequestProcessor;
+import se.liu.ida.hefquin.federation.access.impl.reqproc.SPARQLRequestProcessorImpl;
+import se.liu.ida.hefquin.federation.members.SPARQLEndpoint;
+
+public class SPARQLRequestImplTest extends FederationTestBase
+{
+	@Test
+	public void performRequestWithQueryOnDBpediaDistinct() throws FederationAccessException {
+		if ( ! skipLiveWebTests ) {
+			// setting up
+			final String queryString = "SELECT ?s WHERE { ?s <http://xmlns.com/foaf/0.1/name> \"Berlin\"@en . ?s <http://xmlns.com/foaf/0.1/name> ?o2 .}";
+			final SPARQLQuery baseQuery = new SPARQLQueryImpl( QueryFactory.create(queryString) );
+
+			final SPARQLRequest req1 = new SPARQLRequestImpl(baseQuery);
+
+			final Element el = QueryFactory.create(queryString).getQueryPattern();
+			final SPARQLGraphPattern pattern = new GenericSPARQLGraphPatternImpl1(el);
+			final SPARQLRequest req2 = new SPARQLRequestImpl(pattern, Set.of(Var.alloc("s")), true);
+
+			// performing the tested operation
+			final SPARQLEndpoint fm = new SPARQLEndpointForTest("http://dbpedia.org/sparql");
+
+			final SPARQLRequestProcessor recProc = new SPARQLRequestProcessorImpl();
+
+			final SolMapsResponse resp1 = recProc.performRequest(req1, fm);
+			final SolMapsResponse resp2 = recProc.performRequest(req2, fm);
+
+			// checking
+			// the base query does not contain DISTINCT
+			assertFalse( baseQuery.asJenaQuery().isDistinct() );
+
+			// req1 inherits DISTINCT=false, req2 explicitly enforces DISTINCT
+			assertFalse( req1.isDistinct() );
+			assertTrue( req2.isDistinct() );
+
+			// ensure the endpoint actually returned data
+			assertTrue( resp2.getResponseData().iterator().hasNext() );
+
+			// DISTINCT should not increase result size
+			assertTrue( resp1.getSize() > resp2.getSize() );
+
+			// DISTINCT results must be a subset of the non-DISTINCT results
+			Set<SolutionMapping> resp1Set = new HashSet<>();
+			resp1.getResponseData().forEach( resp1Set::add );
+			resp2.getResponseData().forEach( sm -> assertTrue( resp1Set.contains(sm) ) );
+
+			// verify that the non-DISTINCT result actually contained duplicates
+			assertTrue( resp1.getSize() > resp1Set.size() );
+
+			// verify that DISTINCT removed all duplicates
+			Set<SolutionMapping> unique = new HashSet<>();
+			resp2.getResponseData().forEach( unique::add );
+			assertEquals( unique.size(), resp2.getSize() );
+		}
+	}
+
+	@Test
+	public void performRequestWithQueryOnDBpediaProject() throws FederationAccessException {
+		if ( ! skipLiveWebTests ) {
+			// setting up
+			final String queryString = "SELECT ?s ?o2 WHERE { ?s <http://xmlns.com/foaf/0.1/name> \"Berlin\"@en . " +
+			                           "?s <http://xmlns.com/foaf/0.1/name> ?o2 . }";
+
+			final SPARQLQuery baseQuery = new SPARQLQueryImpl( QueryFactory.create(queryString) );
+
+			final SPARQLRequest req1 = new SPARQLRequestImpl(baseQuery);
+
+			final Element el = QueryFactory.create(queryString).getQueryPattern();
+			final SPARQLGraphPattern pattern = new GenericSPARQLGraphPatternImpl1(el);
+			final SPARQLRequest req2 = new SPARQLRequestImpl(pattern, Set.of(Var.alloc("s")), false);
+
+			// performing the tested operation
+			final SPARQLEndpoint fm = new SPARQLEndpointForTest("http://dbpedia.org/sparql");
+
+			final SPARQLRequestProcessor recProc = new SPARQLRequestProcessorImpl();
+
+			final SolMapsResponse resp1 = recProc.performRequest(req1, fm);
+			final SolMapsResponse resp2 = recProc.performRequest(req2, fm);
+
+			// checking
+			// ensure projection is applied
+			for ( final SolutionMapping sm : resp2.getResponseData() ) {
+				assertEquals( 1, sm.asJenaBinding().size() );
+				assertTrue( sm.asJenaBinding().contains( Var.alloc("s") ) );
+			}
+
+			// ensure original had more variables
+			boolean foundO2 = false;
+			for ( final SolutionMapping sm : resp1.getResponseData() ) {
+				if ( sm.asJenaBinding().contains( Var.alloc("o2") ) ) {
+					foundO2 = true;
+					break;
+				}
+			}
+			assertTrue( foundO2 );
+
+			// ensure projection does NOT change number of rows
+			assertEquals( resp1.getSize(), resp2.getSize() );
+		}
+	}
+}

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImplTest.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImplTest.java
@@ -4,7 +4,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.jena.query.QueryFactory;
@@ -12,7 +11,6 @@ import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.syntax.Element;
 import org.junit.Test;
 
-import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
 import se.liu.ida.hefquin.base.query.SPARQLQuery;
 import se.liu.ida.hefquin.base.query.impl.GenericSPARQLGraphPatternImpl1;
@@ -20,15 +18,11 @@ import se.liu.ida.hefquin.base.query.impl.SPARQLQueryImpl;
 import se.liu.ida.hefquin.federation.FederationTestBase;
 import se.liu.ida.hefquin.federation.access.FederationAccessException;
 import se.liu.ida.hefquin.federation.access.SPARQLRequest;
-import se.liu.ida.hefquin.federation.access.SolMapsResponse;
-import se.liu.ida.hefquin.federation.access.impl.reqproc.SPARQLRequestProcessor;
-import se.liu.ida.hefquin.federation.access.impl.reqproc.SPARQLRequestProcessorImpl;
-import se.liu.ida.hefquin.federation.members.SPARQLEndpoint;
 
 public class SPARQLRequestImplTest extends FederationTestBase
 {
 	@Test
-	public void performRequestWithQueryOnDBpediaDistinct() throws FederationAccessException {
+	public void testDistinctRequestInitialization() throws FederationAccessException {
 		if ( ! skipLiveWebTests ) {
 			// setting up
 			final String queryString = "SELECT ?s WHERE { ?s <http://xmlns.com/foaf/0.1/name> \"Berlin\"@en . ?s <http://xmlns.com/foaf/0.1/name> ?o2 .}";
@@ -40,45 +34,18 @@ public class SPARQLRequestImplTest extends FederationTestBase
 			final SPARQLGraphPattern pattern = new GenericSPARQLGraphPatternImpl1(el);
 			final SPARQLRequest req2 = new SPARQLRequestImpl(pattern, Set.of(Var.alloc("s")), true);
 
-			// performing the tested operation
-			final SPARQLEndpoint fm = new SPARQLEndpointForTest("http://dbpedia.org/sparql");
-
-			final SPARQLRequestProcessor recProc = new SPARQLRequestProcessorImpl();
-
-			final SolMapsResponse resp1 = recProc.performRequest(req1, fm);
-			final SolMapsResponse resp2 = recProc.performRequest(req2, fm);
-
 			// checking
 			// the base query does not contain DISTINCT
 			assertFalse( baseQuery.asJenaQuery().isDistinct() );
 
 			// req1 inherits DISTINCT=false, req2 explicitly enforces DISTINCT
-			assertFalse( req1.isDistinct() );
-			assertTrue( req2.isDistinct() );
-
-			// ensure the endpoint actually returned data
-			assertTrue( resp2.getResponseData().iterator().hasNext() );
-
-			// DISTINCT should not increase result size
-			assertTrue( resp1.getSize() > resp2.getSize() );
-
-			// DISTINCT results must be a subset of the non-DISTINCT results
-			Set<SolutionMapping> resp1Set = new HashSet<>();
-			resp1.getResponseData().forEach( resp1Set::add );
-			resp2.getResponseData().forEach( sm -> assertTrue( resp1Set.contains(sm) ) );
-
-			// verify that the non-DISTINCT result actually contained duplicates
-			assertTrue( resp1.getSize() > resp1Set.size() );
-
-			// verify that DISTINCT removed all duplicates
-			Set<SolutionMapping> unique = new HashSet<>();
-			resp2.getResponseData().forEach( unique::add );
-			assertEquals( unique.size(), resp2.getSize() );
+			assertFalse( req1.getDistinctRequired() );
+			assertTrue( req2.getDistinctRequired() );
 		}
 	}
 
 	@Test
-	public void performRequestWithQueryOnDBpediaProject() throws FederationAccessException {
+	public void testProjectionVariablesInitialization() throws FederationAccessException {
 		if ( ! skipLiveWebTests ) {
 			// setting up
 			final String queryString = "SELECT ?s ?o2 WHERE { ?s <http://xmlns.com/foaf/0.1/name> \"Berlin\"@en . " +
@@ -92,33 +59,10 @@ public class SPARQLRequestImplTest extends FederationTestBase
 			final SPARQLGraphPattern pattern = new GenericSPARQLGraphPatternImpl1(el);
 			final SPARQLRequest req2 = new SPARQLRequestImpl(pattern, Set.of(Var.alloc("s")), false);
 
-			// performing the tested operation
-			final SPARQLEndpoint fm = new SPARQLEndpointForTest("http://dbpedia.org/sparql");
-
-			final SPARQLRequestProcessor recProc = new SPARQLRequestProcessorImpl();
-
-			final SolMapsResponse resp1 = recProc.performRequest(req1, fm);
-			final SolMapsResponse resp2 = recProc.performRequest(req2, fm);
-
 			// checking
 			// ensure projection is applied
-			for ( final SolutionMapping sm : resp2.getResponseData() ) {
-				assertEquals( 1, sm.asJenaBinding().size() );
-				assertTrue( sm.asJenaBinding().contains( Var.alloc("s") ) );
-			}
-
-			// ensure original had more variables
-			boolean foundO2 = false;
-			for ( final SolutionMapping sm : resp1.getResponseData() ) {
-				if ( sm.asJenaBinding().contains( Var.alloc("o2") ) ) {
-					foundO2 = true;
-					break;
-				}
-			}
-			assertTrue( foundO2 );
-
-			// ensure projection does NOT change number of rows
-			assertEquals( resp1.getSize(), resp2.getSize() );
+			assertEquals( Set.of(Var.alloc("s"), Var.alloc("o2")), req1.getProjectionVars() );
+			assertEquals( Set.of(Var.alloc("s")), req2.getProjectionVars() );
 		}
 	}
 }

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/reqproc/SPARQLRequestProcessorImplTest.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/reqproc/SPARQLRequestProcessorImplTest.java
@@ -13,6 +13,7 @@ import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.QueryFactory;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.syntax.Element;
 import org.junit.Test;
 
 import se.liu.ida.hefquin.base.data.SolutionMapping;
@@ -120,9 +121,9 @@ public class SPARQLRequestProcessorImplTest extends FederationTestBase
 
 			final SPARQLRequest req1 = new SPARQLRequestImpl(baseQuery);
 
-			final SPARQLRequest req2 = new SPARQLRequestImpl(baseQuery) {
-				@Override public boolean isDistinct() { return true; }
-			};
+			final Element el = QueryFactory.create(queryString).getQueryPattern();
+			final SPARQLGraphPattern pattern = new GenericSPARQLGraphPatternImpl1(el);
+			final SPARQLRequest req2 = new SPARQLRequestImpl(pattern, Set.of(Var.alloc("s")), true);
 
 			// performing the tested operation
 			final SPARQLEndpoint fm = new SPARQLEndpointForTest("http://dbpedia.org/sparql");
@@ -134,7 +135,7 @@ public class SPARQLRequestProcessorImplTest extends FederationTestBase
 
 			// checking
 			// the base query does not contain DISTINCT
-			assertFalse( baseQuery.isDistinct() );
+			assertFalse( baseQuery.asJenaQuery().isDistinct() );
 
 			// req1 inherits DISTINCT=false, req2 explicitly enforces DISTINCT
 			assertFalse( req1.isDistinct() );
@@ -172,9 +173,9 @@ public class SPARQLRequestProcessorImplTest extends FederationTestBase
 
 			final SPARQLRequest req1 = new SPARQLRequestImpl(baseQuery);
 
-			final SPARQLRequest req2 = new SPARQLRequestImpl(baseQuery) {
-				@Override public Set<Var> getProjectionVars() { return Set.of(Var.alloc("s")); }
-			};
+			final Element el = QueryFactory.create(queryString).getQueryPattern();
+			final SPARQLGraphPattern pattern = new GenericSPARQLGraphPatternImpl1(el);
+			final SPARQLRequest req2 = new SPARQLRequestImpl(pattern, Set.of(Var.alloc("s")), false);
 
 			// performing the tested operation
 			final SPARQLEndpoint fm = new SPARQLEndpointForTest("http://dbpedia.org/sparql");

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/reqproc/SPARQLRequestProcessorImplTest.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/reqproc/SPARQLRequestProcessorImplTest.java
@@ -219,8 +219,6 @@ public class SPARQLRequestProcessorImplTest extends FederationTestBase
 		// executing the tested method
 		final SolMapsResponse resp = recProc.performRequest(req, fm);
 
-		resp.getSize();
-
 		return resp.getResponseData().iterator();
 	}
 

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/reqproc/SPARQLRequestProcessorImplTest.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/reqproc/SPARQLRequestProcessorImplTest.java
@@ -1,9 +1,12 @@
 package se.liu.ida.hefquin.federation.access.impl.reqproc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Set;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
@@ -108,6 +111,100 @@ public class SPARQLRequestProcessorImplTest extends FederationTestBase
 		}
 	}
 
+	@Test
+	public void performRequestWithQueryOnDBpediaDistinct() throws FederationAccessException {
+		if ( ! skipLiveWebTests ) {
+			// setting up
+			final String queryString = "SELECT ?s WHERE { ?s <http://xmlns.com/foaf/0.1/name> \"Berlin\"@en . ?s <http://xmlns.com/foaf/0.1/name> ?o2 .}";
+			final SPARQLQuery baseQuery = new SPARQLQueryImpl( QueryFactory.create(queryString) );
+
+			final SPARQLRequest req1 = new SPARQLRequestImpl(baseQuery);
+
+			final SPARQLRequest req2 = new SPARQLRequestImpl(baseQuery) {
+				@Override public boolean isDistinct() { return true; }
+			};
+
+			// performing the tested operation
+			final SPARQLEndpoint fm = new SPARQLEndpointForTest("http://dbpedia.org/sparql");
+
+			final SPARQLRequestProcessor recProc = new SPARQLRequestProcessorImpl();
+
+			final SolMapsResponse resp1 = recProc.performRequest(req1, fm);
+			final SolMapsResponse resp2 = recProc.performRequest(req2, fm);
+
+			// checking
+			// the base query does not contain DISTINCT
+			assertFalse( baseQuery.isDistinct() );
+
+			// req1 inherits DISTINCT=false, req2 explicitly enforces DISTINCT
+			assertFalse( req1.isDistinct() );
+			assertTrue( req2.isDistinct() );
+
+			// ensure the endpoint actually returned data
+			assertTrue( resp2.getResponseData().iterator().hasNext() );
+
+			// DISTINCT should not increase result size
+			assertTrue( resp1.getSize() > resp2.getSize() );
+
+			// DISTINCT results must be a subset of the non-DISTINCT results
+			Set<SolutionMapping> resp1Set = new HashSet<>();
+			resp1.getResponseData().forEach( resp1Set::add );
+			resp2.getResponseData().forEach( sm -> assertTrue( resp1Set.contains(sm) ) );
+
+			// verify that the non-DISTINCT result actually contained duplicates
+			assertTrue( resp1.getSize() > resp1Set.size() );
+
+			// verify that DISTINCT removed all duplicates
+			Set<SolutionMapping> unique = new HashSet<>();
+			resp2.getResponseData().forEach( unique::add );
+			assertEquals( unique.size(), resp2.getSize() );
+		}
+	}
+
+	@Test
+	public void performRequestWithQueryOnDBpediaProject() throws FederationAccessException {
+		if ( ! skipLiveWebTests ) {
+			// setting up
+			final String queryString = "SELECT ?s ?o2 WHERE { ?s <http://xmlns.com/foaf/0.1/name> \"Berlin\"@en . " +
+			                           "?s <http://xmlns.com/foaf/0.1/name> ?o2 . }";
+
+			final SPARQLQuery baseQuery = new SPARQLQueryImpl( QueryFactory.create(queryString) );
+
+			final SPARQLRequest req1 = new SPARQLRequestImpl(baseQuery);
+
+			final SPARQLRequest req2 = new SPARQLRequestImpl(baseQuery) {
+				@Override public Set<Var> getProjectionVars() { return Set.of(Var.alloc("s")); }
+			};
+
+			// performing the tested operation
+			final SPARQLEndpoint fm = new SPARQLEndpointForTest("http://dbpedia.org/sparql");
+
+			final SPARQLRequestProcessor recProc = new SPARQLRequestProcessorImpl();
+
+			final SolMapsResponse resp1 = recProc.performRequest(req1, fm);
+			final SolMapsResponse resp2 = recProc.performRequest(req2, fm);
+
+			// checking
+			// ensure projection is applied
+			for ( SolutionMapping sm : resp2.getResponseData() ) {
+				assertEquals( 1, sm.asJenaBinding().size() );
+				assertTrue( sm.asJenaBinding().contains( Var.alloc("s") ) );
+			}
+
+			// ensure original had more variables
+			boolean foundO2 = false;
+			for (SolutionMapping sm : resp1.getResponseData()) {
+				if ( sm.asJenaBinding().contains( Var.alloc("o2") ) ) {
+					foundO2 = true;
+					break;
+				}
+			}
+			assertTrue( foundO2 );
+
+			// ensure projection does NOT change number of rows
+			assertEquals( resp1.getSize(), resp2.getSize() );
+		}
+	}
 
 	// ------------ helper code ------------
 
@@ -121,6 +218,8 @@ public class SPARQLRequestProcessorImplTest extends FederationTestBase
 
 		// executing the tested method
 		final SolMapsResponse resp = recProc.performRequest(req, fm);
+
+		resp.getSize();
 
 		return resp.getResponseData().iterator();
 	}

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/reqproc/SPARQLRequestProcessorImplTest.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/reqproc/SPARQLRequestProcessorImplTest.java
@@ -1,19 +1,15 @@
 package se.liu.ida.hefquin.federation.access.impl.reqproc;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.HashSet;
 import java.util.Iterator;
-import java.util.Set;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.QueryFactory;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.binding.Binding;
-import org.apache.jena.sparql.syntax.Element;
 import org.junit.Test;
 
 import se.liu.ida.hefquin.base.data.SolutionMapping;
@@ -109,101 +105,6 @@ public class SPARQLRequestProcessorImplTest extends FederationTestBase
 			final Node n = b.get(var);
 			assertTrue( n.isLiteral() );
 			assertEquals( 1, n.getLiteralValue() );
-		}
-	}
-
-	@Test
-	public void performRequestWithQueryOnDBpediaDistinct() throws FederationAccessException {
-		if ( ! skipLiveWebTests ) {
-			// setting up
-			final String queryString = "SELECT ?s WHERE { ?s <http://xmlns.com/foaf/0.1/name> \"Berlin\"@en . ?s <http://xmlns.com/foaf/0.1/name> ?o2 .}";
-			final SPARQLQuery baseQuery = new SPARQLQueryImpl( QueryFactory.create(queryString) );
-
-			final SPARQLRequest req1 = new SPARQLRequestImpl(baseQuery);
-
-			final Element el = QueryFactory.create(queryString).getQueryPattern();
-			final SPARQLGraphPattern pattern = new GenericSPARQLGraphPatternImpl1(el);
-			final SPARQLRequest req2 = new SPARQLRequestImpl(pattern, Set.of(Var.alloc("s")), true);
-
-			// performing the tested operation
-			final SPARQLEndpoint fm = new SPARQLEndpointForTest("http://dbpedia.org/sparql");
-
-			final SPARQLRequestProcessor recProc = new SPARQLRequestProcessorImpl();
-
-			final SolMapsResponse resp1 = recProc.performRequest(req1, fm);
-			final SolMapsResponse resp2 = recProc.performRequest(req2, fm);
-
-			// checking
-			// the base query does not contain DISTINCT
-			assertFalse( baseQuery.asJenaQuery().isDistinct() );
-
-			// req1 inherits DISTINCT=false, req2 explicitly enforces DISTINCT
-			assertFalse( req1.isDistinct() );
-			assertTrue( req2.isDistinct() );
-
-			// ensure the endpoint actually returned data
-			assertTrue( resp2.getResponseData().iterator().hasNext() );
-
-			// DISTINCT should not increase result size
-			assertTrue( resp1.getSize() > resp2.getSize() );
-
-			// DISTINCT results must be a subset of the non-DISTINCT results
-			Set<SolutionMapping> resp1Set = new HashSet<>();
-			resp1.getResponseData().forEach( resp1Set::add );
-			resp2.getResponseData().forEach( sm -> assertTrue( resp1Set.contains(sm) ) );
-
-			// verify that the non-DISTINCT result actually contained duplicates
-			assertTrue( resp1.getSize() > resp1Set.size() );
-
-			// verify that DISTINCT removed all duplicates
-			Set<SolutionMapping> unique = new HashSet<>();
-			resp2.getResponseData().forEach( unique::add );
-			assertEquals( unique.size(), resp2.getSize() );
-		}
-	}
-
-	@Test
-	public void performRequestWithQueryOnDBpediaProject() throws FederationAccessException {
-		if ( ! skipLiveWebTests ) {
-			// setting up
-			final String queryString = "SELECT ?s ?o2 WHERE { ?s <http://xmlns.com/foaf/0.1/name> \"Berlin\"@en . " +
-			                           "?s <http://xmlns.com/foaf/0.1/name> ?o2 . }";
-
-			final SPARQLQuery baseQuery = new SPARQLQueryImpl( QueryFactory.create(queryString) );
-
-			final SPARQLRequest req1 = new SPARQLRequestImpl(baseQuery);
-
-			final Element el = QueryFactory.create(queryString).getQueryPattern();
-			final SPARQLGraphPattern pattern = new GenericSPARQLGraphPatternImpl1(el);
-			final SPARQLRequest req2 = new SPARQLRequestImpl(pattern, Set.of(Var.alloc("s")), false);
-
-			// performing the tested operation
-			final SPARQLEndpoint fm = new SPARQLEndpointForTest("http://dbpedia.org/sparql");
-
-			final SPARQLRequestProcessor recProc = new SPARQLRequestProcessorImpl();
-
-			final SolMapsResponse resp1 = recProc.performRequest(req1, fm);
-			final SolMapsResponse resp2 = recProc.performRequest(req2, fm);
-
-			// checking
-			// ensure projection is applied
-			for ( SolutionMapping sm : resp2.getResponseData() ) {
-				assertEquals( 1, sm.asJenaBinding().size() );
-				assertTrue( sm.asJenaBinding().contains( Var.alloc("s") ) );
-			}
-
-			// ensure original had more variables
-			boolean foundO2 = false;
-			for (SolutionMapping sm : resp1.getResponseData()) {
-				if ( sm.asJenaBinding().contains( Var.alloc("o2") ) ) {
-					foundO2 = true;
-					break;
-				}
-			}
-			assertTrue( foundO2 );
-
-			// ensure projection does NOT change number of rows
-			assertEquals( resp1.getSize(), resp2.getSize() );
 		}
 	}
 

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/reqproc/SPARQLRequestProcessorImplTest.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/reqproc/SPARQLRequestProcessorImplTest.java
@@ -1,15 +1,19 @@
 package se.liu.ida.hefquin.federation.access.impl.reqproc;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.util.HashSet;
 import java.util.Iterator;
+import java.util.Set;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.QueryFactory;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.syntax.Element;
 import org.junit.Test;
 
 import se.liu.ida.hefquin.base.data.SolutionMapping;
@@ -105,6 +109,101 @@ public class SPARQLRequestProcessorImplTest extends FederationTestBase
 			final Node n = b.get(var);
 			assertTrue( n.isLiteral() );
 			assertEquals( 1, n.getLiteralValue() );
+		}
+	}
+
+	@Test
+	public void performRequestWithQueryOnDBpediaDistinct() throws FederationAccessException {
+		if ( ! skipLiveWebTests ) {
+			// setting up
+			final String queryString = "SELECT ?s WHERE { ?s <http://xmlns.com/foaf/0.1/name> \"Berlin\"@en . ?s <http://xmlns.com/foaf/0.1/name> ?o2 .}";
+			final SPARQLQuery baseQuery = new SPARQLQueryImpl( QueryFactory.create(queryString) );
+
+			final SPARQLRequest req1 = new SPARQLRequestImpl(baseQuery);
+
+			final Element el = QueryFactory.create(queryString).getQueryPattern();
+			final SPARQLGraphPattern pattern = new GenericSPARQLGraphPatternImpl1(el);
+			final SPARQLRequest req2 = new SPARQLRequestImpl(pattern, Set.of(Var.alloc("s")), true);
+
+			// performing the tested operation
+			final SPARQLEndpoint fm = new SPARQLEndpointForTest("http://dbpedia.org/sparql");
+
+			final SPARQLRequestProcessor recProc = new SPARQLRequestProcessorImpl();
+
+			final SolMapsResponse resp1 = recProc.performRequest(req1, fm);
+			final SolMapsResponse resp2 = recProc.performRequest(req2, fm);
+
+			// checking
+			// the base query does not contain DISTINCT
+			assertFalse( baseQuery.asJenaQuery().isDistinct() );
+
+			// req1 inherits DISTINCT=false, req2 explicitly enforces DISTINCT
+			assertFalse( req1.getDistinctRequired() );
+			assertTrue( req2.getDistinctRequired() );
+
+			// ensure the endpoint actually returned data
+			assertTrue( resp2.getResponseData().iterator().hasNext() );
+
+			// DISTINCT should not increase result size
+			assertTrue( resp1.getSize() > resp2.getSize() );
+
+			// DISTINCT results must be a subset of the non-DISTINCT results
+			Set<SolutionMapping> resp1Set = new HashSet<>();
+			resp1.getResponseData().forEach( resp1Set::add );
+			resp2.getResponseData().forEach( sm -> assertTrue( resp1Set.contains(sm) ) );
+
+			// verify that the non-DISTINCT result actually contained duplicates
+			assertTrue( resp1.getSize() > resp1Set.size() );
+
+			// verify that DISTINCT removed all duplicates
+			Set<SolutionMapping> unique = new HashSet<>();
+			resp2.getResponseData().forEach( unique::add );
+			assertEquals( unique.size(), resp2.getSize() );
+		}
+	}
+
+	@Test
+	public void performRequestWithQueryOnDBpediaProject() throws FederationAccessException {
+		if ( ! skipLiveWebTests ) {
+			// setting up
+			final String queryString = "SELECT ?s ?o2 WHERE { ?s <http://xmlns.com/foaf/0.1/name> \"Berlin\"@en . " +
+			                           "?s <http://xmlns.com/foaf/0.1/name> ?o2 . }";
+
+			final SPARQLQuery baseQuery = new SPARQLQueryImpl( QueryFactory.create(queryString) );
+
+			final SPARQLRequest req1 = new SPARQLRequestImpl(baseQuery);
+
+			final Element el = QueryFactory.create(queryString).getQueryPattern();
+			final SPARQLGraphPattern pattern = new GenericSPARQLGraphPatternImpl1(el);
+			final SPARQLRequest req2 = new SPARQLRequestImpl(pattern, Set.of(Var.alloc("s")), false);
+
+			// performing the tested operation
+			final SPARQLEndpoint fm = new SPARQLEndpointForTest("http://dbpedia.org/sparql");
+
+			final SPARQLRequestProcessor recProc = new SPARQLRequestProcessorImpl();
+
+			final SolMapsResponse resp1 = recProc.performRequest(req1, fm);
+			final SolMapsResponse resp2 = recProc.performRequest(req2, fm);
+
+			// checking
+			// ensure projection is applied
+			for ( final SolutionMapping sm : resp2.getResponseData() ) {
+				assertEquals( 1, sm.asJenaBinding().size() );
+				assertTrue( sm.asJenaBinding().contains( Var.alloc("s") ) );
+			}
+
+			// ensure original had more variables
+			boolean foundO2 = false;
+			for ( final SolutionMapping sm : resp1.getResponseData() ) {
+				if ( sm.asJenaBinding().contains( Var.alloc("o2") ) ) {
+					foundO2 = true;
+					break;
+				}
+			}
+			assertTrue( foundO2 );
+
+			// ensure projection does NOT change number of rows
+			assertEquals( resp1.getSize(), resp2.getSize() );
 		}
 	}
 

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/SPARQLQuery.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/SPARQLQuery.java
@@ -15,27 +15,6 @@ public interface SPARQLQuery extends Query
 	org.apache.jena.query.Query asJenaQuery();
 
 	/**
-	 * Returns the set of variables projected by this query.
-	 *
-	 * <p>This corresponds to the variables in the SELECT clause of the query.
-	 * For {@code SELECT *} queries, this typically reflects the variables
-	 * inferred by the underlying query representation.</p>
-	 *
-	 * @return the set of projected variables (never {@code null})
-	 */
-	Set<Var> getProjectionVars();
-
-	/**
-	 * Indicates whether this query enforces duplicate elimination.
-	 *
-	 * <p>This corresponds to the presence of the {@code DISTINCT} modifier
-	 * in the SELECT clause.</p>
-	 *
-	 * @return {@code true} if the query is DISTINCT; {@code false} otherwise
-	 */
-	boolean isDistinct();
-
-	/**
 	 * Returns the sets of variables that can be expected in the
 	 * solution mappings produced for this query.
 	 */

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/SPARQLQuery.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/SPARQLQuery.java
@@ -15,6 +15,27 @@ public interface SPARQLQuery extends Query
 	org.apache.jena.query.Query asJenaQuery();
 
 	/**
+	 * Returns the set of variables projected by this query.
+	 *
+	 * <p>This corresponds to the variables in the SELECT clause of the query.
+	 * For {@code SELECT *} queries, this typically reflects the variables
+	 * inferred by the underlying query representation.</p>
+	 *
+	 * @return the set of projected variables (never {@code null})
+	 */
+	Set<Var> getProjectionVars();
+
+	/**
+	 * Indicates whether this query enforces duplicate elimination.
+	 *
+	 * <p>This corresponds to the presence of the {@code DISTINCT} modifier
+	 * in the SELECT clause.</p>
+	 *
+	 * @return {@code true} if the query is DISTINCT; {@code false} otherwise
+	 */
+	boolean isDistinct();
+
+	/**
 	 * Returns the sets of variables that can be expected in the
 	 * solution mappings produced for this query.
 	 */

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/impl/SPARQLQueryImpl.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/impl/SPARQLQueryImpl.java
@@ -1,7 +1,11 @@
 package se.liu.ida.hefquin.base.query.impl;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryFactory;
+import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.syntax.Element;
 
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
@@ -23,11 +27,21 @@ public class SPARQLQueryImpl implements SPARQLQuery
 
 	protected SPARQLQueryImpl( final Element jenaElement ) {
 		assert jenaElement != null;
-		
+
 		jenaQuery = QueryFactory.create();
 		jenaQuery.setQuerySelectType();
-		jenaQuery.setQueryResultStar(true);
+		jenaQuery.setQueryResultStar( true );
 		jenaQuery.setQueryPattern( jenaElement );
+	}
+
+	@Override
+	public Set<Var> getProjectionVars() {
+		return new HashSet<>( jenaQuery.getProjectVars() );
+	}
+
+	@Override
+	public boolean isDistinct() {
+		return jenaQuery.isDistinct();
 	}
 
 	@Override

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/impl/SPARQLQueryImpl.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/impl/SPARQLQueryImpl.java
@@ -1,10 +1,7 @@
 package se.liu.ida.hefquin.base.query.impl;
 
-import java.util.Set;
-
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryFactory;
-import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.syntax.Element;
 
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
@@ -22,27 +19,6 @@ public class SPARQLQueryImpl implements SPARQLQuery
 
 	public SPARQLQueryImpl( final SPARQLGraphPattern p ) {
 		this( QueryPatternUtils.convertToJenaElement(p) );
-	}
-
-	public SPARQLQueryImpl( final SPARQLGraphPattern p,
-	                        final Set<Var> projectionVars,
-	                        final boolean isDistinct ) {
-		this( QueryPatternUtils.convertToJenaElement(p) );
-
-		// Apply request-level projection if specified and safe.
-		// This replaces the SELECT clause with the given variables.
-		// Note: This is only done when it does not interfere with query semantics
-		// (e.g., no aggregation or grouping present).
-		if ( projectionVars != null && ! projectionVars.isEmpty() ) {
-			jenaQuery.setQueryResultStar(false);
-			jenaQuery.getProject().clear();
-			projectionVars.forEach(jenaQuery::addResultVar);
-		}
-
-		// Apply DISTINCT if requested.
-		// This enforces duplicate elimination at the endpoint level.
-		if ( isDistinct )
-			jenaQuery.setDistinct( true );
 	}
 
 	protected SPARQLQueryImpl( final Element jenaElement ) {

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/impl/SPARQLQueryImpl.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/impl/SPARQLQueryImpl.java
@@ -1,6 +1,5 @@
 package se.liu.ida.hefquin.base.query.impl;
 
-import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.jena.query.Query;
@@ -25,6 +24,27 @@ public class SPARQLQueryImpl implements SPARQLQuery
 		this( QueryPatternUtils.convertToJenaElement(p) );
 	}
 
+	public SPARQLQueryImpl( final SPARQLGraphPattern p,
+	                        final Set<Var> projectionVars,
+	                        final boolean isDistinct ) {
+		this( QueryPatternUtils.convertToJenaElement(p) );
+
+		// Apply request-level projection if specified and safe.
+		// This replaces the SELECT clause with the given variables.
+		// Note: This is only done when it does not interfere with query semantics
+		// (e.g., no aggregation or grouping present).
+		if ( projectionVars != null && ! projectionVars.isEmpty() ) {
+			jenaQuery.setQueryResultStar(false);
+			jenaQuery.getProject().clear();
+			projectionVars.forEach(jenaQuery::addResultVar);
+		}
+
+		// Apply DISTINCT if requested.
+		// This enforces duplicate elimination at the endpoint level.
+		if ( isDistinct )
+			jenaQuery.setDistinct( true );
+	}
+
 	protected SPARQLQueryImpl( final Element jenaElement ) {
 		assert jenaElement != null;
 
@@ -32,16 +52,6 @@ public class SPARQLQueryImpl implements SPARQLQuery
 		jenaQuery.setQuerySelectType();
 		jenaQuery.setQueryResultStar( true );
 		jenaQuery.setQueryPattern( jenaElement );
-	}
-
-	@Override
-	public Set<Var> getProjectionVars() {
-		return new HashSet<>( jenaQuery.getProjectVars() );
-	}
-
-	@Override
-	public boolean isDistinct() {
-		return jenaQuery.isDistinct();
 	}
 
 	@Override

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/impl/SPARQLQueryImpl.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/impl/SPARQLQueryImpl.java
@@ -50,7 +50,7 @@ public class SPARQLQueryImpl implements SPARQLQuery
 	public boolean equals( final Object o ) {
 		if ( o == this ) return true;
 
-		return o instanceof SPARQLQuery && ((SPARQLQuery) o).asJenaQuery().equals(jenaQuery);
+		return o instanceof SPARQLQuery oo && oo.asJenaQuery().equals(jenaQuery);
 	}
 
 	@Override

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/impl/SPARQLQueryImpl.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/impl/SPARQLQueryImpl.java
@@ -22,13 +22,13 @@ public class SPARQLQueryImpl implements SPARQLQuery
 
 	public SPARQLQueryImpl( final SPARQLGraphPattern p,
 	                        final Set<Var> projectionVars,
-	                        final boolean isDistinct ) {
-		this( QueryPatternUtils.convertToJenaElement(p), projectionVars, isDistinct );
+	                        final boolean distinctRequired ) {
+		this( QueryPatternUtils.convertToJenaElement(p), projectionVars, distinctRequired );
 	}
 
 	protected SPARQLQueryImpl( final Element jenaElement,
 	                           final Set<Var> projectionVars,
-	                           final boolean isDistinct ) {
+	                           final boolean distinctRequired ) {
 		assert jenaElement != null;
 
 		jenaQuery = QueryFactory.create();
@@ -42,7 +42,7 @@ public class SPARQLQueryImpl implements SPARQLQuery
 			jenaQuery.setQueryResultStar( true );
 
 
-		jenaQuery.setDistinct( isDistinct );
+		jenaQuery.setDistinct( distinctRequired );
 		jenaQuery.setQueryPattern( jenaElement );
 	}
 

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/impl/SPARQLQueryImpl.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/impl/SPARQLQueryImpl.java
@@ -1,7 +1,10 @@
 package se.liu.ida.hefquin.base.query.impl;
 
+import java.util.Set;
+
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryFactory;
+import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.syntax.Element;
 
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
@@ -17,21 +20,36 @@ public class SPARQLQueryImpl implements SPARQLQuery
 		this.jenaQuery = jenaQuery;
 	}
 
-	public SPARQLQueryImpl( final SPARQLGraphPattern p ) {
-		this( QueryPatternUtils.convertToJenaElement(p) );
+	public SPARQLQueryImpl( final SPARQLGraphPattern p,
+	                        final Set<Var> projectionVars,
+	                        final boolean isDistinct ) {
+		this( QueryPatternUtils.convertToJenaElement(p), projectionVars, isDistinct );
 	}
 
-	protected SPARQLQueryImpl( final Element jenaElement ) {
+	protected SPARQLQueryImpl( final Element jenaElement,
+	                           final Set<Var> projectionVars,
+	                           final boolean isDistinct ) {
 		assert jenaElement != null;
 
 		jenaQuery = QueryFactory.create();
 		jenaQuery.setQuerySelectType();
-		jenaQuery.setQueryResultStar( true );
+		if ( projectionVars != null ) {
+			jenaQuery.setQueryResultStar( false );
+			jenaQuery.getProject().clear();
+			projectionVars.forEach(jenaQuery::addResultVar);
+		}
+		else
+			jenaQuery.setQueryResultStar( true );
+
+
+		jenaQuery.setDistinct( isDistinct );
 		jenaQuery.setQueryPattern( jenaElement );
 	}
 
 	@Override
 	public boolean equals( final Object o ) {
+		if ( o == this ) return true;
+
 		return o instanceof SPARQLQuery && ((SPARQLQuery) o).asJenaQuery().equals(jenaQuery);
 	}
 

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/CardinalityBasedJoinOrderingBaseTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/CardinalityBasedJoinOrderingBaseTest.java
@@ -202,6 +202,8 @@ public class CardinalityBasedJoinOrderingBaseTest extends EngineTestBase
 			final TriplePatternRequest req = new TriplePatternRequest() {
 				@Override public ExpectedVariables getExpectedVariables() { return ev; }
 				@Override public TriplePattern getQueryPattern() { throw new UnsupportedOperationException(); }
+				@Override public Set<Var> getProjectionVars() { throw new UnsupportedOperationException(); }
+				@Override public boolean isDistinct() { throw new UnsupportedOperationException(); }
 			};
 
 			subPlans[i] = new LogicalPlanWithNullaryRootImpl( new LogicalOpRequest<>(srv, false, req), null );

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/CardinalityBasedJoinOrderingBaseTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/CardinalityBasedJoinOrderingBaseTest.java
@@ -203,7 +203,7 @@ public class CardinalityBasedJoinOrderingBaseTest extends EngineTestBase
 				@Override public ExpectedVariables getExpectedVariables() { return ev; }
 				@Override public TriplePattern getQueryPattern() { throw new UnsupportedOperationException(); }
 				@Override public Set<Var> getProjectionVars() { throw new UnsupportedOperationException(); }
-				@Override public boolean isDistinct() { throw new UnsupportedOperationException(); }
+				@Override public boolean getDistinctRequired() { throw new UnsupportedOperationException(); }
 			};
 
 			subPlans[i] = new LogicalPlanWithNullaryRootImpl( new LogicalOpRequest<>(srv, false, req), null );


### PR DESCRIPTION
Addresses the extension of `SPARQLRequest` and `SPARQLRequestProcessor` part of #570.