### PR TITLE
Add logging for various JOIN executable operators

### DIFF
--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpHashJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpHashJoin.java
@@ -4,6 +4,8 @@ import java.util.Iterator;
 import java.util.Set;
 
 import org.apache.jena.sparql.core.Var;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import se.liu.ida.hefquin.base.datastructures.SolutionMappingsIndex;
 import se.liu.ida.hefquin.base.datastructures.impl.SolutionMappingsHashTable;
@@ -16,6 +18,7 @@ import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
 
 public abstract class BaseForExecOpHashJoin extends BinaryExecutableOpBase
 {
+	private static final Logger log = LoggerFactory.getLogger( BaseForExecOpHashJoin.class );
 	protected final SolutionMappingsIndex index;
 
 	protected BaseForExecOpHashJoin( final boolean mayReduce,
@@ -28,28 +31,35 @@ public abstract class BaseForExecOpHashJoin extends BinaryExecutableOpBase
 		// determine the certain join variables
 		final Set<Var> certainJoinVars = ExpectedVariablesUtils.intersectionOfCertainVariables(inputVars1, inputVars2);
 
+		log.info( "Initializing hash join operator with join variables {}.", certainJoinVars );
+
 		// set up the core part of the index first;
 		// it is built on the certain join variables
 		final SolutionMappingsIndex _index;
 		if ( certainJoinVars.size() == 1 ) {
 			final Var joinVar = certainJoinVars.iterator().next();
+			log.info( "Using one-variable hash table for join variable {}.", joinVar );
 			_index = new SolutionMappingsHashTableBasedOnOneVar(joinVar);
 		}
 		else if ( certainJoinVars.size() == 2 ) {
 			final Iterator<Var> liVar = certainJoinVars.iterator();
 			final Var joinVar1 = liVar.next();
 			final Var joinVar2 = liVar.next();
+			log.info( "Using two-variable hash table for join variables {}, {}.", joinVar1, joinVar2 );
 			_index = new SolutionMappingsHashTableBasedOnTwoVars(joinVar1, joinVar2);
 		}
 		else {
+			log.info( "Using generic hash table for join variables {}.", certainJoinVars );
 			_index = new SolutionMappingsHashTable(certainJoinVars);
 		}
 
 		// Check whether there are other variables that may be relevant for
 		// the join and, if so, set up the index to use post-matching.
 		final Set<Var> potentialJoinVars = ExpectedVariablesUtils.intersectionOfAllVariables(inputVars1, inputVars2);
-		if ( ! potentialJoinVars.equals(certainJoinVars) )
+		if ( ! potentialJoinVars.equals(certainJoinVars) ) {
+			log.info( "Post-matching enabled for potential join variables {}.", potentialJoinVars );
 			index = new SolutionMappingsIndexWithPostMatching(_index);
+		}
 		else
 			index = _index;
 	}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpIndexNestedLoopsJoinWithRequestOps.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpIndexNestedLoopsJoinWithRequestOps.java
@@ -6,6 +6,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.data.utils.SolutionMappingUtils;
 import se.liu.ida.hefquin.base.query.Query;
@@ -33,6 +36,7 @@ public abstract class BaseForExecOpIndexNestedLoopsJoinWithRequestOps<QueryType 
                                                                       MemberType extends FederationMember>
               extends BaseForUnaryExecOpWithCollectedInput
 {
+	private static final Logger log = LoggerFactory.getLogger( BaseForExecOpIndexNestedLoopsJoinWithRequestOps.class );
 	protected final QueryType query;
 	protected final MemberType fm;
 	protected final boolean useOuterJoinSemantics;
@@ -51,6 +55,8 @@ public abstract class BaseForExecOpIndexNestedLoopsJoinWithRequestOps<QueryType 
 	                                                           final QueryPlanningInfo qpInfo ) {
 		super(mayReduce, minimumInputBlockSize, collectExceptions, qpInfo);
 
+		log.info( "Initialized IndexNestedLoopsJoinWithRequestOps for query {} on federation member {}", query, fm );
+
 		assert query != null;
 		assert fm != null;
 
@@ -65,6 +71,7 @@ public abstract class BaseForExecOpIndexNestedLoopsJoinWithRequestOps<QueryType 
 	                              final ExecutionContext execCxt )
 			throws ExecOpExecutionException
 	{
+		log.info( "Starting request-based index nested loops join with {} input mappings", input.size() );
 		final CompletableFuture<?>[] futures = initiateProcessing( input, sink, execCxt );
 
 		// wait for all the futures to be completed
@@ -178,6 +185,9 @@ public abstract class BaseForExecOpIndexNestedLoopsJoinWithRequestOps<QueryType 
 	                                   final ExecutionContext execCxt )
 			throws ExecOpExecutionException
 	{
+		log.info( "Completed request-based index nested loops join. Requests issued: {}, outputs produced: {}",
+		numberOfRequestOpsUsed,
+		numberOfOutputMappingsProduced );
 		if ( input != null && ! input.isEmpty() ) {
 			_processCollectedInput(input, sink, execCxt);
 		}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpIndexNestedLoopsJoinWithSolMapsRequests.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpIndexNestedLoopsJoinWithSolMapsRequests.java
@@ -1,5 +1,8 @@
 package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.data.utils.SolutionMappingUtils;
 import se.liu.ida.hefquin.base.query.Query;
@@ -16,6 +19,8 @@ public abstract class BaseForExecOpIndexNestedLoopsJoinWithSolMapsRequests<Query
                                                                            ReqType extends DataRetrievalRequest>
      extends BaseForExecOpIndexNestedLoopsJoinWithRequests<QueryType,MemberType,ReqType,SolMapsResponse>
 {
+	private static final Logger log = LoggerFactory.getLogger( BaseForExecOpIndexNestedLoopsJoinWithSolMapsRequests.class );
+
 	public BaseForExecOpIndexNestedLoopsJoinWithSolMapsRequests( final QueryType query,
 	                                                             final MemberType fm,
 	                                                             final boolean mayReduce,
@@ -30,15 +35,18 @@ public abstract class BaseForExecOpIndexNestedLoopsJoinWithSolMapsRequests<Query
 	                                                       final IntermediateResultElementSink sink,
 	                                                       final ExecutableOperator op )
 	{
+		log.info( "Creating response processor for solution mapping." );
 		return new MyResponseProcessor( sm, sink, op ) {
 			@Override
 			protected Iterable<SolutionMapping> extractSolMaps( final SolMapsResponse response )
 					throws UnsupportedOperationDueToRetrievalError {
+				log.info( "Extracting solution mappings from federation response." );
 				return response.getResponseData();
 			}
 
 			@Override
 			protected void processExtractedSolMaps( final Iterable<SolutionMapping> solmaps ) {
+				log.info( "Merging solution mappings with input mapping." );
 				for ( final SolutionMapping fetchedSM : solmaps ) {
 					final SolutionMapping out = SolutionMappingUtils.merge( sm, fetchedSM );
 					sink.send( out );

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashJoin1.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashJoin1.java
@@ -11,11 +11,15 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Builds the hash table based on the input from the first subplan.
  */
 public class ExecOpHashJoin1 extends BaseForExecOpHashJoin
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecOpHashJoin1.class );
 	protected Stats statsOfIndex = null;
 
 	protected boolean child1InputComplete = false;
@@ -27,6 +31,8 @@ public class ExecOpHashJoin1 extends BaseForExecOpHashJoin
 	                        final boolean collectExceptions,
 	                        final QueryPlanningInfo qpInfo ) {
 		super(mayReduce, inputVars1, inputVars2, collectExceptions, qpInfo);
+
+		log.info( "Initialized ExecOpHashJoin1." );
 	}
 
 	@Override
@@ -43,12 +49,14 @@ public class ExecOpHashJoin1 extends BaseForExecOpHashJoin
 	protected void _processInputFromChild1( final SolutionMapping inputSolMap,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
+		log.info( "Adding solution mapping to hash join index." );
 		index.add(inputSolMap);
 	}
 
 	@Override
 	protected void _wrapUpForChild1( final IntermediateResultElementSink sink,
 	                                 final ExecutionContext execCxt ) {
+		log.info( "Completed build phase for hash join index." );
 		this.child1InputComplete = true;
 	}
 
@@ -59,6 +67,8 @@ public class ExecOpHashJoin1 extends BaseForExecOpHashJoin
 		if ( child1InputComplete == false ) {
 			throw new IllegalStateException();
 		}
+
+		log.info( "Processing probe-side solution mapping." );
 
 		final List<SolutionMapping> output = new ArrayList<>();
 		produceOutput(inputSolMap, output);
@@ -74,6 +84,8 @@ public class ExecOpHashJoin1 extends BaseForExecOpHashJoin
 			throw new IllegalStateException();
 		}
 
+		log.info( "Processing batch of {} probe-side solution mappings.", inputSolMaps.size() );
+
 		final List<SolutionMapping> output = new ArrayList<>();
 		for ( final SolutionMapping inputSolMap : inputSolMaps ) {
 			produceOutput(inputSolMap, output);
@@ -85,20 +97,25 @@ public class ExecOpHashJoin1 extends BaseForExecOpHashJoin
 	@Override
 	protected void _wrapUpForChild2( final IntermediateResultElementSink sink,
 	                                 final ExecutionContext execCxt ) {
+		log.info( "Hash join execution completed. Clearing index." );
 		child2InputComplete = true;
 
 		// clear the index to enable the GC to release memory early,
 		// but make sure we keep the final stats of the index
 		statsOfIndex = index.getStats();
+		log.info( "Final index statistics: {}.", statsOfIndex );
 		index.clear();
 	}
 
 	protected void produceOutput( final SolutionMapping inputSolMap,
 	                              final List<SolutionMapping> output ) {
+		final int sizeBefore = output.size();
+
 		final Iterable<SolutionMapping> matchSolMapL = index.getJoinPartners(inputSolMap);
 		for ( final SolutionMapping smL : matchSolMapL ){
 			output.add( SolutionMappingUtils.merge(smL,inputSolMap) );
 		}
+		log.info( "Produced {} joined solution mappings.", output.size() - sizeBefore );
 	}
 
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashJoin2.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashJoin2.java
@@ -11,11 +11,15 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Builds the hash table based on the input from the second subplan.
  */
 public class ExecOpHashJoin2 extends BaseForExecOpHashJoin
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecOpHashJoin2.class );
 	protected final boolean useOuterJoinSemantics;
 
 	protected boolean child1InputComplete = false;
@@ -32,6 +36,8 @@ public class ExecOpHashJoin2 extends BaseForExecOpHashJoin
 		super(mayReduce, inputVars1, inputVars2, collectExceptions, qpInfo);
 
 		this.useOuterJoinSemantics = useOuterJoinSemantics;
+
+		log.info( "Initialized ExecOpHashJoin2 with useOuterJoinSemantics: {}.", useOuterJoinSemantics );
 	}
 
 	@Override
@@ -48,12 +54,14 @@ public class ExecOpHashJoin2 extends BaseForExecOpHashJoin
 	protected void _processInputFromChild2( final SolutionMapping inputSolMap,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
+		log.info( "Adding solution mapping to hash join index." );
 		index.add(inputSolMap);
 	}
 
 	@Override
 	protected void _wrapUpForChild2( final IntermediateResultElementSink sink,
 	                                 final ExecutionContext execCxt ) {
+		log.info( "Completed build phase for hash join index." );
 		this.child2InputComplete = true;
 	}
 
@@ -64,6 +72,8 @@ public class ExecOpHashJoin2 extends BaseForExecOpHashJoin
 		if ( child2InputComplete == false ) {
 			throw new IllegalStateException();
 		}
+
+		log.info( "Processing probe-side solution mapping." );
 
 		final List<SolutionMapping> output = new ArrayList<>();
 		produceOutput(inputSolMap, output);
@@ -79,6 +89,8 @@ public class ExecOpHashJoin2 extends BaseForExecOpHashJoin
 			throw new IllegalStateException();
 		}
 
+		log.info( "Processing batch of {} probe-side solution mappings.", inputSolMaps.size() );
+
 		final List<SolutionMapping> output = new ArrayList<>();
 		for ( final SolutionMapping inputSolMap : inputSolMaps ) {
 			produceOutput(inputSolMap, output);
@@ -90,16 +102,20 @@ public class ExecOpHashJoin2 extends BaseForExecOpHashJoin
 	@Override
 	protected void _wrapUpForChild1( final IntermediateResultElementSink sink,
 	                                 final ExecutionContext execCxt ) {
+		log.info( "Hash join execution completed. Clearing index." );
 		child1InputComplete = true;
 
 		// clear the index to enable the GC to release memory early,
 		// but make sure we keep the final stats of the index
 		statsOfIndex = index.getStats();
+		log.info( "Final index statistics: {}.", statsOfIndex );
 		index.clear();
 	}
 
 	protected void produceOutput( final SolutionMapping inputSolMap,
 	                              final List<SolutionMapping> output ) {
+		final int sizeBefore = output.size();
+
 		final Iterable<SolutionMapping> joinPartners = index.getJoinPartners(inputSolMap);
 		boolean hasJoinPartner = false;
 		for ( final SolutionMapping joinPartner : joinPartners ) {
@@ -108,8 +124,10 @@ public class ExecOpHashJoin2 extends BaseForExecOpHashJoin
 		}
 
 		if ( useOuterJoinSemantics && ! hasJoinPartner ) {
+			log.info( "No join partner found. Applying outer join semantics." );
 			output.add(inputSolMap);
 		}
+		log.info( "Produced {} joined solution mappings.", output.size() - sizeBefore );
 	}
 
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinSPARQL.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinSPARQL.java
@@ -2,6 +2,9 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import java.util.concurrent.CompletableFuture;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
 import se.liu.ida.hefquin.base.query.VariableByBlankNodeSubstitutionException;
@@ -15,6 +18,7 @@ import se.liu.ida.hefquin.federation.members.SPARQLEndpoint;
 
 public class ExecOpIndexNestedLoopsJoinSPARQL extends BaseForExecOpIndexNestedLoopsJoinWithSolMapsRequests<SPARQLGraphPattern,SPARQLEndpoint,SPARQLRequest>
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecOpIndexNestedLoopsJoinSPARQL.class );
 	// For SPARQL endpoints, the number of input solution mappings processed
 	// as one block should be very small (perhaps even only 1) because this
 	// is the number of requests issued in parallel (to the same endpoint!)
@@ -28,6 +32,8 @@ public class ExecOpIndexNestedLoopsJoinSPARQL extends BaseForExecOpIndexNestedLo
 	                                         final boolean collectExceptions,
 	                                         final QueryPlanningInfo qpInfo ) {
 		super(query, fm, mayReduce, minimumInputBlockSize, collectExceptions, qpInfo);
+
+		log.info( "Initialized ExecOpIndexNestedLoopsJoinSPARQL for endpoint {}.", fm );
 
 		// TODO extend this implementation to support outer join semantics similar
 		// to how it is implemented in ExecOpGenericIndexNestedLoopsJoinWithRequestOps

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinTPF.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinTPF.java
@@ -1,5 +1,8 @@
 package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.query.TriplePattern;
 import se.liu.ida.hefquin.base.query.VariableByBlankNodeSubstitutionException;
@@ -17,6 +20,8 @@ import se.liu.ida.hefquin.federation.members.TPFServer;
 public class ExecOpIndexNestedLoopsJoinTPF
            extends BaseForExecOpIndexNestedLoopsJoinWithRequestOps<TriplePattern,TPFServer>
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecOpIndexNestedLoopsJoinTPF.class );
+
 	// Since this algorithm processes the input solution mappings
 	// in parallel, we should use an input block size with which
 	// we can leverage this parallelism. However, I am not sure
@@ -35,6 +40,8 @@ public class ExecOpIndexNestedLoopsJoinTPF
 	                                      final boolean collectExceptions,
 	                                      final QueryPlanningInfo qpInfo ) {
 		super(query, fm, useOuterJoinSemantics, mayReduce, minimumInputBlockSize, collectExceptions, qpInfo);
+
+		log.info("Initialized ExecOpIndexNestedLoopsJoinTPF for server {}", fm);
 	}
 
 	public ExecOpIndexNestedLoopsJoinTPF( final TriplePattern query,
@@ -44,6 +51,8 @@ public class ExecOpIndexNestedLoopsJoinTPF
 	                                      final boolean collectExceptions,
 	                                      final QueryPlanningInfo qpInfo ) {
 		super(query, fm, useOuterJoinSemantics, mayReduce, DEFAULT_INPUT_BLOCK_SIZE, collectExceptions, qpInfo);
+
+		log.info("Initialized ExecOpIndexNestedLoopsJoinTPF for server {}", fm);
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpNaiveNestedLoopsJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpNaiveNestedLoopsJoin.java
@@ -9,6 +9,9 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 /**
  * Attention, this is a purely local implementation of the nested loops
  * join algorithm---nothing fancy, no requests to federation members or
@@ -24,12 +27,15 @@ import java.util.List;
  */
 public class ExecOpNaiveNestedLoopsJoin extends BinaryExecutableOpBase
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecOpNaiveNestedLoopsJoin.class );
 	protected final List<SolutionMapping> inputLHS = new ArrayList<>();
 
 	public ExecOpNaiveNestedLoopsJoin( final boolean mayReduce,
 	                                   final boolean collectExceptions,
 	                                   final QueryPlanningInfo qpInfo ) {
 		super(mayReduce, collectExceptions, qpInfo);
+
+		log.info( "Initialized ExecOpNaiveNestedLoopsJoin." );
 	}
 
 	@Override
@@ -46,6 +52,7 @@ public class ExecOpNaiveNestedLoopsJoin extends BinaryExecutableOpBase
 	protected void _processInputFromChild1( final SolutionMapping inputSolMap,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
+		log.info( "Adding solution mapping to left-hand-side input." );
 		inputLHS.add(inputSolMap);
 	}
 
@@ -53,12 +60,14 @@ public class ExecOpNaiveNestedLoopsJoin extends BinaryExecutableOpBase
 	protected void _wrapUpForChild1( final IntermediateResultElementSink sink,
 	                                 final ExecutionContext execCxt ) {
 		// nothing to be done here
+		log.info( "Completed build phase for child 1 with {} solution mappings.", inputLHS.size() );
 	}
 
 	@Override
 	protected void _processInputFromChild2( final SolutionMapping inputSolMap,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
+		log.info( "Processing probe-side solution mapping." );
 		final List<SolutionMapping> output = new ArrayList<>();
 		for ( final SolutionMapping smL : inputLHS ) {
 			if ( SolutionMappingUtils.compatible(smL,inputSolMap) ) {
@@ -66,6 +75,7 @@ public class ExecOpNaiveNestedLoopsJoin extends BinaryExecutableOpBase
 			}
 		}
 
+		log.info( "Produced {} joined solution mappings.", output.size() );
 		sink.send(output);
 	}
 
@@ -73,6 +83,7 @@ public class ExecOpNaiveNestedLoopsJoin extends BinaryExecutableOpBase
 	protected void _processInputFromChild2( final List<SolutionMapping> inputSolMaps,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
+		log.info( "Processing batch of {} probe-side solution mappings.", inputSolMaps.size() );
 		final List<SolutionMapping> output = new ArrayList<>();
 		for ( final SolutionMapping inputSolMap : inputSolMaps ) {
 			for ( final SolutionMapping smL : inputLHS ) {
@@ -82,6 +93,7 @@ public class ExecOpNaiveNestedLoopsJoin extends BinaryExecutableOpBase
 			}
 		}
 
+		log.info( "Produced {} joined solution mappings.", output.size() );
 		sink.send(output);
 	}
 
@@ -90,6 +102,7 @@ public class ExecOpNaiveNestedLoopsJoin extends BinaryExecutableOpBase
 	                                 final ExecutionContext execCxt ) {
 		// clear the list of collected first-input solution
 		// mappings to enable the GC to release memory early
+		log.info( "Nested loops join execution completed. Clearing left-hand-side input." );
 		inputLHS.clear();
 	}
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSymmetricHashJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSymmetricHashJoin.java
@@ -1,6 +1,8 @@
 package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import org.apache.jena.sparql.core.Var;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.data.utils.SolutionMappingUtils;
@@ -30,6 +32,7 @@ import java.util.*;
  */
 public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecOpSymmetricHashJoin.class );
 	protected final SolutionMappingsIndex indexForChild1;
 	protected final SolutionMappingsIndex indexForChild2;
 
@@ -62,11 +65,14 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 		// determine the certain join variables
 		final Set<Var> certainJoinVars = ExpectedVariablesUtils.intersectionOfCertainVariables(inputVars1, inputVars2);
 
+		log.info( "Initializing symmetric hash join operator with join variables {}.", certainJoinVars );
+
 		// set up the core part of the two indexes first; it is built on the certain join variables
 		SolutionMappingsIndex solMHashTableL;
 		SolutionMappingsIndex solMHashTableR;
 		if ( certainJoinVars.size() == 1 ) {
 			final Var joinVar = certainJoinVars.iterator().next();
+			log.info( "Using one-variable hash table for join variable {}.", joinVar );
 			solMHashTableL = new SolutionMappingsHashTableBasedOnOneVar(joinVar);
 			solMHashTableR = new SolutionMappingsHashTableBasedOnOneVar(joinVar);
 		}
@@ -75,10 +81,13 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 			final Var joinVar1 = liVar.next();
 			final Var joinVar2 = liVar.next();
 
+			log.info( "Using two-variable hash table for join variables {}, {}.", joinVar1, joinVar2 );
+
 			solMHashTableL = new SolutionMappingsHashTableBasedOnTwoVars(joinVar1, joinVar2);
 			solMHashTableR = new SolutionMappingsHashTableBasedOnTwoVars(joinVar1, joinVar2);
 		}
-		else{
+		else {
+			log.info( "Using generic hash table for join variables {}.", certainJoinVars );
 			solMHashTableL = new SolutionMappingsHashTable(certainJoinVars);
 			solMHashTableR = new SolutionMappingsHashTable(certainJoinVars);
 		}
@@ -87,6 +96,7 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 		// the join and, if so, set up the indexes to use post-matching.
 		final Set<Var> potentialJoinVars = ExpectedVariablesUtils.intersectionOfAllVariables(inputVars1, inputVars2);
 		if ( ! potentialJoinVars.equals(certainJoinVars) ) {
+			log.info( "Post-matching enabled for potential join variables {}.", potentialJoinVars );
 			solMHashTableL = new SolutionMappingsIndexWithPostMatching(solMHashTableL);
 			solMHashTableR = new SolutionMappingsIndexWithPostMatching(solMHashTableR);
 		}
@@ -109,11 +119,14 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 	protected void _processInputFromChild1( final SolutionMapping inputSolMap,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
+		log.info( "Processing solution mapping from child 1." );
+
 		buffer.clear();
 
 		_processInputSolMap(inputSolMap, indexForChild1, indexForChild2, buffer);
 
 		numberOfOutputMappingsProduced += buffer.size();
+		log.info( "Produced {} joined solution mappings.", buffer.size() );
 		sink.send(buffer);
 
 		buffer.clear();
@@ -123,6 +136,8 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 	protected void _processInputFromChild1( final List<SolutionMapping> inputSolMaps,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
+		log.info( "Processing batch of {} solution mappings from child 1.", inputSolMaps.size() );
+
 		buffer.clear();
 
 		for ( final SolutionMapping inputSolMap : inputSolMaps ) {
@@ -130,6 +145,7 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 		}
 
 		numberOfOutputMappingsProduced += buffer.size();
+		log.info( "Produced {} joined solution mappings.", buffer.size() );
 		sink.send(buffer);
 
 		buffer.clear();
@@ -138,6 +154,7 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 	@Override
 	protected void _wrapUpForChild1( final IntermediateResultElementSink sink,
 									 final ExecutionContext execCxt ) {
+		log.info( "Completed input processing for child 1." );
 		child1InputComplete = true;
 
 		if ( child2InputComplete ) {
@@ -149,11 +166,14 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 	protected void _processInputFromChild2( final SolutionMapping inputSolMap,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
+		log.info( "Processing solution mapping from child 2." );
+
 		buffer.clear();
 
 		_processInputSolMap(inputSolMap, indexForChild2, indexForChild1, buffer);
 
 		numberOfOutputMappingsProduced += buffer.size();
+		log.info( "Produced {} joined solution mappings.", buffer.size() );
 		sink.send(buffer);
 
 		buffer.clear();
@@ -163,6 +183,8 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 	protected void _processInputFromChild2( final List<SolutionMapping> inputSolMaps,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
+		log.info( "Processing batch of {} solution mappings from child 2.", inputSolMaps.size() );
+
 		buffer.clear();
 
 		for ( final SolutionMapping inputSolMap : inputSolMaps ) {
@@ -170,6 +192,7 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 		}
 
 		numberOfOutputMappingsProduced += buffer.size();
+		log.info( "Produced {} joined solution mappings.", buffer.size() );
 		sink.send(buffer);
 
 		buffer.clear();
@@ -178,6 +201,7 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 	@Override
 	protected void _wrapUpForChild2( final IntermediateResultElementSink sink,
 	                                 final ExecutionContext execCxt ) {
+		log.info( "Completed input processing for child 2." );
 		child2InputComplete = true;
 
 		if ( child1InputComplete ) {
@@ -188,8 +212,12 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 	protected void wrapUp() {
 		// clear both indexes to enable the GC to release memory early,
 		// but make sure we keep the final stats of the indexes
+		log.info( "Symmetric hash join execution completed. Clearing indexes." );
+
 		statsOfIndexForChild1 = indexForChild1.getStats();
 		statsOfIndexForChild2 = indexForChild2.getStats();
+		log.info( "Final index statistics for child 1: {}.", statsOfIndexForChild1 );
+		log.info( "Final index statistics for child 2: {}.", statsOfIndexForChild2 );
 
 		indexForChild1.clear();
 		indexForChild2.clear();


### PR DESCRIPTION
Addresses #607 by adding logging for the following join executable operators and base classes:
- BaseForExecOpHashJoin
- BaseForExecOpIndexNestedLoopsJoinWithRequestOps
- BaseForExecOpIndexNestedLoopsJoinWithSolMapsRequests
- ExecOpHashJoin1
- ExecOpHashJoin2
- ExecOpIndexNestedLoopsJoinSPARQL
- ExecOpIndexNestedLoopsJoinTPF
- ExecOpNaiveNestedLoopsJoin
- ExecOpSymmetricHashJoin