### PR TITLE
Fix in RML2MappingAlgebra algorithm

### DIFF
--- a/hefquin-rml/src/main/java/se/liu/ida/hefquin/mappings/algebra/ops/extexprs/ExtendExprFunction.java
+++ b/hefquin-rml/src/main/java/se/liu/ida/hefquin/mappings/algebra/ops/extexprs/ExtendExprFunction.java
@@ -27,6 +27,9 @@ public class ExtendExprFunction implements ExtendExpression
 	                           final List<ExtendExpression> subExpressions ) {
 		assert fct != null;
 		assert fct.isCorrectNumberOfArgument( subExpressions.size() );
+		for ( final ExtendExpression sub : subExpressions ) {
+			assert sub != null;
+		}
 
 		this.fct = fct;
 		this.subExpressions = subExpressions;

--- a/hefquin-rml/src/main/java/se/liu/ida/hefquin/mappings/algebra/ops/extfcts/ExtnFct_NewBNode.java
+++ b/hefquin-rml/src/main/java/se/liu/ida/hefquin/mappings/algebra/ops/extfcts/ExtnFct_NewBNode.java
@@ -1,0 +1,31 @@
+package se.liu.ida.hefquin.mappings.algebra.ops.extfcts;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+
+/**
+ * A null-ary function that returns a new blank node every time it is called.
+ */
+public class ExtnFct_NewBNode implements ExtensionFunction
+{
+	public static final ExtensionFunction instance = new ExtnFct_NewBNode();
+
+	protected ExtnFct_NewBNode() {}
+
+	@Override
+	public boolean isCorrectNumberOfArgument( final int n ) {
+		return n == 0;
+	}
+
+	@Override
+	public Node apply( final Node ... args ) {
+		assert args.length == 0;
+
+		return NodeFactory.createBlankNode();
+	}
+
+	@Override
+	public String toString() {
+		return "newBNode";
+	}
+}

--- a/hefquin-rml/src/main/java/se/liu/ida/hefquin/mappings/rml/RML2MappingAlgebra.java
+++ b/hefquin-rml/src/main/java/se/liu/ida/hefquin/mappings/rml/RML2MappingAlgebra.java
@@ -29,6 +29,7 @@ import se.liu.ida.hefquin.mappings.algebra.ops.extexprs.ExtendExprConstant;
 import se.liu.ida.hefquin.mappings.algebra.ops.extexprs.ExtendExprFunction;
 import se.liu.ida.hefquin.mappings.algebra.ops.extexprs.ExtendExpression;
 import se.liu.ida.hefquin.mappings.algebra.ops.extfcts.ExtnFct_Concat;
+import se.liu.ida.hefquin.mappings.algebra.ops.extfcts.ExtnFct_NewBNode;
 import se.liu.ida.hefquin.mappings.algebra.ops.extfcts.ExtnFct_ToBNode;
 import se.liu.ida.hefquin.mappings.algebra.ops.extfcts.ExtnFct_ToIRI;
 import se.liu.ida.hefquin.mappings.algebra.ops.extfcts.ExtnFct_ToLiteral;
@@ -510,15 +511,32 @@ public class RML2MappingAlgebra
 					                                  subExpressions );
 				}
 			}
+			else if ( t == null && r == null ) {
+				// Not explicitly part of Algorithm 3, but needed to cover
+				// the case of a term maps with rml:termType rml:BlankNode
+				// (which is not covered by the algorithm!).
+				extExpr = null;
+			}
 			else {
-				throw new RMLParserException( "One of the term maps (" + u.toString() + ") does not have an rml:reference or rml:template statement, or has both of them.");
+				throw new RMLParserException( "One of the term maps (" + u.toString() + ") has both an rml:reference and an rml:template statement.");
 			}
 
 			// line 13 of Algorithm 3
 			final RDFNode type = ModelUtils.getSingleOptionalProperty( u, RMLVocab.termType );
 			if ( type != null && RMLVocab.BlankNode.equals(type) ) {
-				return new ExtendExprFunction( ExtnFct_ToBNode.instance,
-				                               extExpr );
+				if ( extExpr == null ) {
+					// This case is not covered by Algorithm 3,
+					// which is a bug in the algorithm.
+					return new ExtendExprFunction( ExtnFct_NewBNode.instance );
+				}
+				else {
+					return new ExtendExprFunction( ExtnFct_ToBNode.instance,
+					                               extExpr );
+				}
+			}
+
+			if ( extExpr == null ) {
+				throw new RMLParserException( "One of the term maps (" + u.toString() + ") does not have an rml:reference or rml:template statement.");
 			}
 
 			// line 14 of Algorithm 3


### PR DESCRIPTION
The algorithm for translating a (normalized) RML mapping document into the mapping algebra does not consider the case of term maps with `rml:termType rml:BlankNode` but no `rml:reference` property. This PR fixes this aspect of our implementation of the algorithm. The fix is to add a new extension function, newBNode, and use this function in such cases.

/cc @s-minoo