### PR TITLE
Extends expandTemplate by supporting {&arg1,arg2,..} placeholders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Extending filter push down with the option to push also into the pattern of a gpAdd operator ([#589](https://github.com/LiUSemWeb/HeFQUIN/pull/589)).
 - Separation of logical and physical plans for mapping algebra ([#581](https://github.com/LiUSemWeb/HeFQUIN/pull/581), [#596](https://github.com/LiUSemWeb/HeFQUIN/pull/596)).
 - Fix in RML-to-algebra translation algorithm ([#610](https://github.com/LiUSemWeb/HeFQUIN/pull/610)).
+- Fix in code that expands URI templates ([#611](https://github.com/LiUSemWeb/HeFQUIN/pull/611)).
 - Removes unused provenance-related methods from DataRetrievalResponse ([#582](https://github.com/LiUSemWeb/HeFQUIN/pull/582)).
 
 

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/RESTRequestImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/RESTRequestImpl.java
@@ -49,7 +49,7 @@ public class RESTRequestImpl implements RESTRequest
 
 	private static String expandTemplate( final String urlTemplate, final Map<String,String> bindings ) {
         String result = urlTemplate;
-        
+
         // First, expand path variables {var} - these are mandatory
         for ( final Map.Entry<String,String> e : bindings.entrySet() ) {
             final String placeholder = "{" + e.getKey() + "}";
@@ -57,7 +57,7 @@ public class RESTRequestImpl implements RESTRequest
                 result = result.replace( placeholder, urlEncode(e.getValue()) );
             }
         }
-        
+
         // Handle query parameters {?arg1,arg2,...}
         final Pattern queryPattern = Pattern.compile("\\{\\?([^}]+)\\}");
         final Matcher queryMatcher = queryPattern.matcher(result);
@@ -87,10 +87,36 @@ public class RESTRequestImpl implements RESTRequest
             // Replace the {?...} pattern with the built query string
             result = queryMatcher.replaceAll(queryString.toString());
         }
-        
+
+        // Handle additional query parameters {&arg1,arg2,...}
+        final Pattern queryPattern2 = Pattern.compile("\\{\\&([^}]+)\\}");
+        final Matcher queryMatcher2 = queryPattern2.matcher(result);
+
+        if ( queryMatcher2.find() ) {
+            final String queryVars = queryMatcher2.group(1);
+            final String[] varNames = queryVars.split(",");
+
+            final StringBuilder queryString = new StringBuilder();
+
+            for ( String varName : varNames ) {
+                varName = varName.trim();
+                String value = bindings.get(varName);
+
+                if ( value != null && ! value.isEmpty() ) {
+                    queryString.append("&");
+                    queryString.append(varName);
+                    queryString.append("=");
+                    queryString.append( urlEncode(value) );
+                }
+            }
+
+            // Replace the {&...} pattern with the built query string
+            result = queryMatcher2.replaceAll( queryString.toString() );
+        }
+
         return result;
     }
-    
+
     private static String urlEncode( final String value) {
         try {
             return URLEncoder.encode(value, "UTF-8");


### PR DESCRIPTION
The function that expands URI templates into request URIs for REST requests (`expandTemplate` in `RESTRequestImpl`) did not consider the option of placeholders of the form `{&arg1,arg2,...}`. This PR fixes this issue. 

/cc @DrJonasWestman 