### PR TITLE
Bug fix in ExecOpBind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Refactoring the code of the logical plan rewriting rules to use the visitor pattern ([#560](https://github.com/LiUSemWeb/HeFQUIN/pull/560), [#569](https://github.com/LiUSemWeb/HeFQUIN/pull/569), [#571](https://github.com/LiUSemWeb/HeFQUIN/pull/571), [#575](https://github.com/LiUSemWeb/HeFQUIN/pull/575)).
 - More effective filter push down and cardinality estimation for the case of a filter over a fixed-solmap operator ([#588](https://github.com/LiUSemWeb/HeFQUIN/pull/588)).
 - Extending filter push down with the option to push also into the pattern of a gpAdd operator ([#589](https://github.com/LiUSemWeb/HeFQUIN/pull/589)).
+- Bug fix in the executable operator for BIND ([#612](https://github.com/LiUSemWeb/HeFQUIN/pull/612)).
 - Separation of logical and physical plans for mapping algebra ([#581](https://github.com/LiUSemWeb/HeFQUIN/pull/581), [#596](https://github.com/LiUSemWeb/HeFQUIN/pull/596)).
 - Fix in RML-to-algebra translation algorithm ([#610](https://github.com/LiUSemWeb/HeFQUIN/pull/610)).
 - Fix in code that expands URI templates ([#611](https://github.com/LiUSemWeb/HeFQUIN/pull/611)).

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBind.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBind.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.core.VarExprList;
 import org.apache.jena.sparql.engine.binding.Binding;
-import org.apache.jena.sparql.engine.binding.BindingBuilder;
 import org.apache.jena.sparql.engine.binding.BindingFactory;
 import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.NodeValue;
@@ -179,8 +178,13 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 		{
 			logger.info( "Evaluating multiple bind expressions." );
 
-			final Binding sm = solmap.asJenaBinding();
-			final BindingBuilder smBuilder = BindingFactory.builder(sm);
+			// This Binding will be replaced by extended versions of
+			// it within the following for-loop. Extending it stepwise
+			// is necessary because the variable bound by one of the
+			// expressions in 'exprs' may be used in a subsequent
+			// expressions in 'exprs'.
+			Binding sm = solmap.asJenaBinding();
+
 			boolean extended = false;
 
 			for ( final Map.Entry<Var, Expr> e : exprs.getExprs().entrySet() ) {
@@ -199,7 +203,7 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 				// to the output solution mapping.
 				try {
 					final NodeValue evaluationResult = ExprUtils.eval(expr, sm);
-					smBuilder.add( var, evaluationResult.asNode() );
+					sm = BindingFactory.binding(sm, var, evaluationResult.asNode() );
 					extended = true;
 
 					logger.info( "Successfully extended solution mapping with variable {}.", var );
@@ -212,7 +216,7 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 			}
 
 			if ( extended )
-				return new SolutionMappingImpl( smBuilder.build() );
+				return new SolutionMappingImpl(sm);
 			else {
 				logger.info( "No bind expressions could be evaluated successfully." );
 				return solmap;

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBindTest.java
@@ -245,4 +245,38 @@ public class ExecOpBindTest
 		assertFalse( it.hasNext() );
 	}
 
+	@Test
+	public void extendSolMapTwiceWithDependency() throws ExecOpExecutionException {
+		// Extends a solution mapping using an ExecOpBind that has
+		// two bind expressions, where the second bind expression
+		// uses the variable bound by the first bind expression.
+		final Node lit8 = NodeFactory.createLiteralDT( "8", XSDDatatype.XSDinteger );
+		final Var v1 = Var.alloc("v1");
+
+		final List<SolutionMapping> input = new ArrayList<>(1);
+		input.add( SolutionMappingUtils.createSolutionMapping(v1, lit8) );
+
+		final Var v2 = Var.alloc("v2");
+		final Var v3 = Var.alloc("v3");
+		final VarExprList veList = new VarExprList();
+		veList.add( v2, ExprUtils.parse("?v1 + 1") );
+		veList.add( v3, ExprUtils.parse("?v2 - 1") ); // <--- ?v2 !!
+
+		final ExecOpBind op = new ExecOpBind(veList, false, false, null);
+
+		final CollectingIntermediateResultElementSink sink = new CollectingIntermediateResultElementSink();
+
+		op.process(input, sink, null);
+
+		final Iterator<SolutionMapping> it = sink.getCollectedSolutionMappings().iterator();
+
+		assertTrue( it.hasNext() );
+		final Binding sm = it.next().asJenaBinding();
+		final Node lit9 = NodeFactory.createLiteralDT( "9", XSDDatatype.XSDinteger );
+		assertEquals( lit9, sm.get(v2) );
+		assertEquals( lit8, sm.get(v3) );
+
+		assertFalse( it.hasNext() );
+	}
+
 }


### PR DESCRIPTION
`ExecOpBind` can handle multiple bind expressions within one operator. However, for cases in which one of these expressions depends on one of the earlier expressions within the same `ExecOpBind` (in the sense of using the variable assigned by that earlier expression), the dependency has not been considered, which meant the dependent expressed failed. This PR fixes that issue.