### PR TITLE
Add logging for request executable operators

### DIFF
--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpRequestWithTPFPaging.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpRequestWithTPFPaging.java
@@ -2,6 +2,9 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import java.util.Iterator;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.data.Triple;
 import se.liu.ida.hefquin.engine.federation.access.utils.FederationAccessUtils;
@@ -26,6 +29,7 @@ public abstract class BaseForExecOpRequestWithTPFPaging<
                                   PageReqType extends DataRetrievalRequest>
        extends BaseForExecOpRequest<ReqType,MemberType>
 {
+	private static final Logger log = LoggerFactory.getLogger( BaseForExecOpRequestWithTPFPaging.class );
 	private int numberOfPageRequestsIssued = 0;
 	private long totalNumberOfMatchingTriplesRetrieved = 0L;
 	private int minNumberOfMatchingTriplesPerPage = Integer.MAX_VALUE;
@@ -44,6 +48,8 @@ public abstract class BaseForExecOpRequestWithTPFPaging<
 	protected final void _execute( final IntermediateResultElementSink sink,
 	                               final ExecutionContext execCxt ) throws ExecOpExecutionException
 	{
+		log.info( "Starting paging request execution for {}", fm );
+
 		TPFResponse currentPage = null;
 		while ( currentPage == null || ! isLastPage(currentPage) ) {
 			// create the request for the next page (which is the first page if currentPage is null)
@@ -84,6 +90,13 @@ public abstract class BaseForExecOpRequestWithTPFPaging<
 			}
 			consumeMatchingTriples( triples, sink );
 		}
+
+		log.info(
+			"Completed request execution for {}: pages={}, triples={}, outputMappings={}",
+			fm,
+			numberOfPageRequestsIssued,
+			totalNumberOfMatchingTriplesRetrieved,
+			numberOfOutputMappingsProduced );
 	}
 
 	protected PageReqType createPageRequest( final TPFResponse previousPage ) {

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLookupJoinViaWrapperWithParamVars.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLookupJoinViaWrapperWithParamVars.java
@@ -20,6 +20,8 @@ import org.apache.jena.datatypes.xsd.impl.RDFLangString;
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.binding.Binding;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.data.utils.SolutionMappingUtils;
@@ -42,6 +44,8 @@ import se.liu.ida.hefquin.federation.members.WrappedRESTEndpoint.DataConversionE
 public class ExecOpLookupJoinViaWrapperWithParamVars
        extends BaseForUnaryExecOpWithCollectedInput
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecOpLookupJoinViaWrapperWithParamVars.class );
+
 	// Since this algorithm processes the input solution mappings
 	// in parallel, we should use an input block size with which
 	// we can leverage this parallelism. However, I am not sure
@@ -109,6 +113,8 @@ public class ExecOpLookupJoinViaWrapperWithParamVars
 
 			this.paramVars.put(paramDecl, paramVar);
 		}
+
+		log.info( "Initialized ExecOpLookupJoinViaWrapperWithParamVars for endpoint {}", fm );
 	}
 
 	@Override
@@ -117,6 +123,7 @@ public class ExecOpLookupJoinViaWrapperWithParamVars
 	                              final ExecutionContext execCxt )
 			throws ExecOpExecutionException
 	{
+		log.info( "Executing lookup join batch (with param vars) against {}", fm );
 		final Map<Map<String,Node>, List<SolutionMapping>> paramsForRequests = new HashMap<>();
 		for ( final SolutionMapping sm : input ) {
 			final Map<String,Node> paramValues = extractParamValues(sm);
@@ -133,6 +140,7 @@ public class ExecOpLookupJoinViaWrapperWithParamVars
 			if ( cachedResult != null ) {
 				// ... we can join the current solution mapping with the
 				// result that has been cached earlier.
+				log.info( "Cache hit for param values {} (endpoint={})", paramValues, fm );
 				join(cachedResult, sm, sink);
 			}
 			else {
@@ -140,6 +148,7 @@ public class ExecOpLookupJoinViaWrapperWithParamVars
 				// for an earlier batch, then remember them, together with
 				// the current solution mapping, for further processing
 				// after this for loop.
+				log.info( "Cache miss for param values {}, issuing request to {}", paramValues, fm );
 				List<SolutionMapping> solmaps = paramsForRequests.get(paramValues);
 				if ( solmaps == null ) {
 					solmaps = new ArrayList<>();
@@ -167,10 +176,12 @@ public class ExecOpLookupJoinViaWrapperWithParamVars
 				f = execCxt.getFederationAccessMgr().issueRequest(req, fm);
 			}
 			catch ( final FederationAccessException e ) {
+				log.info( "Request issuance failed for endpoint {} (paramValues={})", fm, entry.getKey() );
 				throw new ExecOpExecutionException("Issuing a request caused an exception.", e, this);
 			}
 
 			numberOfRequestsIssued++;
+			log.info( "Issued request #{} to {}", numberOfRequestsIssued, fm );
 
 			// attach the processing of the response obtained for the request
 			final MyResponseProcessor respProc = new MyResponseProcessor(
@@ -178,7 +189,9 @@ public class ExecOpLookupJoinViaWrapperWithParamVars
 			futures[i++] = f.thenAccept(respProc);
 		}
 
+
 		// Wait for all the futures to be completed.
+		log.info( "Waiting for {} async requests to complete for {}", futures.length, fm );
 		try {
 			CompletableFuture.allOf(futures).get();
 		}
@@ -188,6 +201,7 @@ public class ExecOpLookupJoinViaWrapperWithParamVars
 		catch ( final ExecutionException e ) {
 			throw new ExecOpExecutionException("The execution of the futures that perform the requests and process the responses caused an exception.", e, this);
 		}
+		log.info( "Completed lookup join batch for {} (requests={})", fm, numberOfRequestsIssued );
 	}
 
 	@Override
@@ -315,6 +329,7 @@ public class ExecOpLookupJoinViaWrapperWithParamVars
 			}
 			catch ( final DataConversionException e ) {
 				numberOfDataConversionExceptions.incrementAndGet();
+				log.info( "Data conversion failed for endpoint {} (paramValues={})", fm, paramValues );
 				final ExecOpExecutionException ex = new ExecOpExecutionException( "Converting the reponse of a REST request into RDF failed (message: " + e.getMessage() + ").", e, op );
 				recordExceptionCaughtDuringExecution( ex );
 				return;

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLookupJoinViaWrapperWithoutParamVars.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLookupJoinViaWrapperWithoutParamVars.java
@@ -4,6 +4,9 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.data.utils.SolutionMappingUtils;
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
@@ -23,6 +26,8 @@ import se.liu.ida.hefquin.federation.members.WrappedRESTEndpoint.DataConversionE
 public class ExecOpLookupJoinViaWrapperWithoutParamVars
        extends UnaryExecutableOpBase
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecOpLookupJoinViaWrapperWithoutParamVars.class );
+
 	protected final SPARQLGraphPattern pattern;
 	protected final WrappedRESTEndpoint fm;
 
@@ -54,6 +59,8 @@ public class ExecOpLookupJoinViaWrapperWithoutParamVars
 
 		this.pattern = pattern;
 		this.fm = fm;
+
+		log.info( "Initialized ExecOpLookupJoinViaWrapperWithoutParamVars for endpoint {}", fm );
 	}
 
 	@Override
@@ -61,6 +68,7 @@ public class ExecOpLookupJoinViaWrapperWithoutParamVars
 	                         final IntermediateResultElementSink sink,
 	                         final ExecutionContext execCxt )
 			throws ExecOpExecutionException {
+		log.info( "Executing lookup join (without param vars) against {}", fm );
 		if ( solmapsFromRequest == null ) {
 			solmapsFromRequest = performRequest(execCxt);
 		}
@@ -84,6 +92,8 @@ public class ExecOpLookupJoinViaWrapperWithoutParamVars
 	protected List<SolutionMapping> performRequest( final ExecutionContext execCxt )
 			throws ExecOpExecutionException
 	{
+		log.info( "Sending REST request to {}", fm.getURLTemplate() );
+
 		final RESTRequest req = new RESTRequestImpl( fm.getURLTemplate() );
 
 		final long time1 = System.currentTimeMillis();
@@ -132,6 +142,7 @@ public class ExecOpLookupJoinViaWrapperWithoutParamVars
 		requestExecTime = time2 - time1;
 		responseProcTime = time3 - time2;
 		numOfSolMapsFromRequest = result.size();
+		log.info( "Lookup join received {} solution mappings from {}", result.size(), fm );
 		return result;
 	}
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestBRTPF.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestBRTPF.java
@@ -2,6 +2,9 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import java.util.Iterator;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.data.Triple;
 import se.liu.ida.hefquin.base.data.utils.TriplesToSolMapsConverter;
@@ -13,12 +16,16 @@ import se.liu.ida.hefquin.federation.members.BRTPFServer;
 
 public class ExecOpRequestBRTPF extends BaseForExecOpRequestWithTPFPaging<BindingsRestrictedTriplePatternRequest,BRTPFServer,BRTPFRequest>
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecOpRequestBRTPF.class );
+
 	public ExecOpRequestBRTPF( final BindingsRestrictedTriplePatternRequest req,
 	                           final BRTPFServer fm,
 	                           final boolean mayReduce,
 	                           final boolean collectExceptions,
 	                           final QueryPlanningInfo qpInfo ) {
 		super(req, fm, mayReduce, collectExceptions, qpInfo);
+
+		log.info( "Initialized ExecOpRequestBRTPF for server {}", fm );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestOther.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestOther.java
@@ -2,6 +2,9 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.federation.access.utils.FederationAccessUtils;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
@@ -21,6 +24,7 @@ import se.liu.ida.hefquin.federation.members.WrappedRESTEndpoint.DataConversionE
 public class ExecOpRequestOther extends BaseForExecOpRequest<SPARQLRequest,
                                                              WrappedRESTEndpoint>
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecOpRequestOther.class );
 	private long timeAfterResponse = 0L;
 	private long numberOfOutputMappingsProduced = 0L;
 
@@ -32,6 +36,8 @@ public class ExecOpRequestOther extends BaseForExecOpRequest<SPARQLRequest,
 		super(req, fm, mayReduce, collectExceptions, qpInfo);
 
 		assert fm.getNumberOfParameters() != 0;
+
+		log.info( "Initialized ExecOpRequestOther for {}", fm );
 	}
 
 	@Override
@@ -39,6 +45,8 @@ public class ExecOpRequestOther extends BaseForExecOpRequest<SPARQLRequest,
 	                               final ExecutionContext execCxt )
 		throws ExecOpExecutionException
 	{
+		log.info( "Issuing REST request to endpoint {}", fm.getURLTemplate() );
+
 		final StringResponse response;
 		try {
 			response = FederationAccessUtils.performRequest( execCxt.getFederationAccessMgr(),
@@ -57,6 +65,8 @@ public class ExecOpRequestOther extends BaseForExecOpRequest<SPARQLRequest,
 		} catch ( final UnsupportedOperationDueToRetrievalError e ) {
 			throw new ExecOpExecutionException( "Accessing the response data caused an exception, which indicates a data retrieval error (message: " + e.getMessage() + ").", e, this );
 		}
+
+		log.info( "Received REST response from {}", fm.getURLTemplate() );
 
 		process(data, sink);
 	}
@@ -78,6 +88,7 @@ public class ExecOpRequestOther extends BaseForExecOpRequest<SPARQLRequest,
 
 		final int cnt = sink.send(solmaps);
 		numberOfOutputMappingsProduced += cnt;
+		log.info( "Processed REST response: produced {} solution mappings", numberOfOutputMappingsProduced );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestSPARQL.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestSPARQL.java
@@ -1,5 +1,8 @@
 package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.federation.access.utils.FederationAccessUtils;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
@@ -17,6 +20,7 @@ public class ExecOpRequestSPARQL<ReqType extends DataRetrievalRequest,
                                  MemberType extends FederationMember>
                 extends BaseForExecOpRequest<ReqType,MemberType>
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecOpRequestSPARQL.class );
 	private long timeAfterResponse = 0L;
 	private long solMapsRetrieved = 0L;
 	private long numberOfOutputMappingsProduced = 0L;
@@ -27,12 +31,16 @@ public class ExecOpRequestSPARQL<ReqType extends DataRetrievalRequest,
 	                            final boolean collectExceptions,
 	                            final QueryPlanningInfo qpInfo ) {
 		super(req, fm, mayReduce, collectExceptions, qpInfo);
+
+		log.info( "Initialized ExecOpRequestSPARQL for {}", fm );
 	}
 
 	@Override
 	protected final void _execute( final IntermediateResultElementSink sink, final ExecutionContext execCxt )
 		throws ExecOpExecutionException
 	{
+		log.info( "Starting SPARQL request execution for {}", fm );
+
 		final SolMapsResponse response;
 		try {
 			response = FederationAccessUtils.performRequest( execCxt.getFederationAccessMgr(), req, fm );
@@ -49,6 +57,12 @@ public class ExecOpRequestSPARQL<ReqType extends DataRetrievalRequest,
 		}
 
 		process(response, sink);
+
+		log.info(
+			"Completed SPARQL request execution for {}: solMaps={}, outputMappings={}",
+			fm,
+			solMapsRetrieved,
+			numberOfOutputMappingsProduced );
 	}
 
 	protected void process( final SolMapsResponse response, final IntermediateResultElementSink sink )

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestTPF.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestTPF.java
@@ -2,6 +2,9 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import java.util.Iterator;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.data.Triple;
 import se.liu.ida.hefquin.base.data.utils.TriplesToSolMapsConverter;
@@ -18,12 +21,16 @@ import se.liu.ida.hefquin.federation.access.impl.req.TPFRequestImpl;
 public class ExecOpRequestTPF<MemberType extends FederationMember>
        extends BaseForExecOpRequestWithTPFPaging<TriplePatternRequest,MemberType,TPFRequest>
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecOpRequestTPF.class );
+
 	public ExecOpRequestTPF( final TriplePatternRequest req,
 	                         final MemberType fm,
 	                         final boolean mayReduce,
 	                         final boolean collectExceptions,
 	                         final QueryPlanningInfo qpInfo ) {
 		super(req, fm, mayReduce, collectExceptions, qpInfo);
+
+		log.info( "Initialized ExecOpRequestBRTPF for server {}", fm );
 	}
 
 	@Override


### PR DESCRIPTION
Addresses #607 by adding logging for the following request executable operators and base class:
- BaseForExecOpRequestWithTPFPaging
- ExecOpLookupJoinViaWrapperWithParamVars
- ExecOpLookupJoinViaWrapperWithoutParamVars
- ExecOpRequestBRTPF
- ExecOpRequestOther
- ExecOpRequestSPARQL
- ExecOpRequestTPF