### PR TITLE
Makes fd:paramType optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Adding a logical plan rewriting that pushes project operators ([#580](https://github.com/LiUSemWeb/HeFQUIN/pull/580)).
 - Initial version of a CLI tool to use the RML component of HeFQUIN explicitly ([#601](https://github.com/LiUSemWeb/HeFQUIN/pull/601)).
 ### Changed
-- Reorganization of the vocabulary for federation descriptions ([#597](https://github.com/LiUSemWeb/HeFQUIN/pull/597)).
+- Reorganization of the vocabulary for federation descriptions ([#597](https://github.com/LiUSemWeb/HeFQUIN/pull/597), [#615](https://github.com/LiUSemWeb/HeFQUIN/pull/615)).
 - Refactoring the code of the logical plan rewriting rules to use the visitor pattern ([#560](https://github.com/LiUSemWeb/HeFQUIN/pull/560), [#569](https://github.com/LiUSemWeb/HeFQUIN/pull/569), [#571](https://github.com/LiUSemWeb/HeFQUIN/pull/571), [#575](https://github.com/LiUSemWeb/HeFQUIN/pull/575)).
 - More effective filter push down and cardinality estimation for the case of a filter over a fixed-solmap operator ([#588](https://github.com/LiUSemWeb/HeFQUIN/pull/588)).
 - Extending filter push down with the option to push also into the pattern of a gpAdd operator ([#589](https://github.com/LiUSemWeb/HeFQUIN/pull/589)).

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/catalog/FederationDescriptionReader.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/catalog/FederationDescriptionReader.java
@@ -14,6 +14,7 @@ import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Property;
@@ -299,16 +300,16 @@ public class FederationDescriptionReader
 
 				final Resource p = x.asResource();
 				final String name = ModelUtils.getSingleMandatoryProperty_XSDString(p, HydraVocab.variable);
-				final String type = getAsURIString(ModelUtils.getSingleMandatoryProperty(p, FDVocab.paramType));
-
-				if ( type == null )
-					throw new IllegalArgumentException();
+				final String type = getAsURIString(ModelUtils.getSingleOptionalProperty(p, FDVocab.paramType));
 
 				final Statement isRequiredStmt = p.getProperty(HydraVocab.required);
 				final boolean isRequired = isRequiredStmt == null ? false : isRequiredStmt.getBoolean();
 
 				final RDFDatatype dt;
-				if ( XSDDatatype.XSDstring.getURI().equals(type) ) {
+				if ( type == null ) {
+					dt = null;
+				}
+				else if ( XSDDatatype.XSDstring.getURI().equals(type) ) {
 					dt = XSDDatatype.XSDstring;
 				}
 				else if ( XSDDatatype.XSDinteger.getURI().equals(type) ) {
@@ -498,18 +499,24 @@ public class FederationDescriptionReader
 	 * In particular, if the node is a URI, then that URI is returned (as a
 	 * string); if the node is an xsd:anyURI literal with a valid URI as its
 	 * lexical form, then that URI is returned; otherwise, {@code null} is
-	 * returned.
+	 * returned (including for the case that the given node is already
+	 * {@code null}).
 	 */
 	protected String getAsURIString( final RDFNode n ) {
-		if ( n.isLiteral() && n.asLiteral().getDatatypeURI().equals(XSD.anyURI.getURI()) ) {
-			return n.asLiteral().getLexicalForm();
-		}
-		else if ( n.isURIResource() ) {
-			return n.asResource().getURI();
-		}
-		else {
+		if ( n == null )
 			return null;
+
+		if ( n.isURIResource() )
+			return n.asResource().getURI();
+
+		if ( n.isLiteral() ) {
+			final Literal lit = n.asLiteral();
+			final String anyURI = XSD.anyURI.getURI();
+			if ( lit.getDatatypeURI().equals(anyURI) )
+				return lit.getLexicalForm();
 		}
+
+		return null;
 	}
 
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLookupJoinViaWrapperWithParamVars.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLookupJoinViaWrapperWithParamVars.java
@@ -228,21 +228,23 @@ public class ExecOpLookupJoinViaWrapperWithParamVars
 			if ( paramValueAsNode == null ) return null;
 			if ( ! paramValueAsNode.isLiteral() ) return null;
 
-			// Check that the datatype of the literal equals
-			// the datatype expected for the parameter.
-			final RDFDatatype typeOfNode = paramValueAsNode.getLiteralDatatype();
-			if ( paramDecl.getType().equals(XSDDatatype.XSDstring) ) {
-				// Special case: If the expected datatype is xsd:string but
-				// the actual one is rdf:langString or rdf:dirLangString,
-				// then the value is still accepted.
-				if (    ! typeOfNode.equals(XSDDatatype.XSDstring)
-				     && ! RDFLangString.isRDFLangString(typeOfNode)
-				     && ! RDFDirLangString.isRDFDirLangString(typeOfNode) ) {
+			// If the parameter has an expected datatype, then check that
+			// the datatype of the literal equals that expected datatype.
+			if ( paramDecl.getType() != null ) {
+				final RDFDatatype typeOfNode = paramValueAsNode.getLiteralDatatype();
+				if ( paramDecl.getType().equals(XSDDatatype.XSDstring) ) {
+					// Special case: If the expected datatype is xsd:string but
+					// the actual one is rdf:langString or rdf:dirLangString,
+					// then the value is still accepted.
+					if (    ! typeOfNode.equals(XSDDatatype.XSDstring)
+							&& ! RDFLangString.isRDFLangString(typeOfNode)
+							&& ! RDFDirLangString.isRDFDirLangString(typeOfNode) ) {
+						return null;
+					}
+				}
+				else if ( ! paramDecl.getType().equals(typeOfNode) ) {
 					return null;
 				}
-			}
-			else if ( ! paramDecl.getType().equals(typeOfNode) ) {
-				return null;
 			}
 
 			result.put( paramDecl.getName(), paramValueAsNode );

--- a/hefquin-vocabs/feddesc.ttl
+++ b/hefquin-vocabs/feddesc.ttl
@@ -99,7 +99,7 @@ fd:paramType a owl:ObjectProperty ;
     rdfs:domain hydra:IriTemplateMapping ;
     rdfs:range  rdfs:Resource ;
     rdfs:label "type of template parameter"@en ;
-    rdfs:comment "The type of values to be used for a variable part of a URI template. This type is expected to be specified as a datatype URI (e.g., xsd:string, xsd:float)."@en .
+    rdfs:comment "The type of values to be used for a variable part of a URI template. This type is expected to be specified as a datatype URI (e.g., xsd:string, xsd:float). This property is optional; i.e., not every IriTemplateMapping needs to have it. If a IriTemplateMapping has this property, the datatype specified via this property is enforced when creating request URIs from the corresponding IriTemplate; i.e., the IriTemplate will be instantiated only for parameter values that have the specified datatype."@en .
 
 fd:exampleFragmentAddress a owl:DatatypeProperty ;
     rdfs:domain fd:FragmentInterface ;


### PR DESCRIPTION
This PR makes `fd:paramType` in federation descriptions optional. That is, not every `hydra:IriTemplateMapping` needs to have an `fd:paramType` property. If a `hydra:IriTemplateMapping` has this property, the datatype specified via this property is enforced when creating request URIs from the corresponding `hydra:IriTemplate`; i.e., the `hydra:IriTemplate` will be instantiated only for parameter values that have the specified datatype.

/cc @kentthang010 