### PR TITLE
Add logging for UNION and remaining JOIN operators

### DIFF
--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForUnaryExecOpWithCollectedInput.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForUnaryExecOpWithCollectedInput.java
@@ -3,6 +3,9 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
@@ -36,6 +39,8 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
  */
 public abstract class BaseForUnaryExecOpWithCollectedInput extends UnaryExecutableOpBase
 {
+	private static final Logger log = LoggerFactory.getLogger( BaseForUnaryExecOpWithCollectedInput.class );
+
 	private int numberOfCollectionsProcessed = 0;
 
 	protected final int minimumCollectionSize;
@@ -51,6 +56,11 @@ public abstract class BaseForUnaryExecOpWithCollectedInput extends UnaryExecutab
 
 		this.minimumCollectionSize = minimumCollectionSize;
 		collectedInputSolMaps = new ArrayList<>(minimumCollectionSize);
+
+		log.info(
+			"Initialized unary batching operator: minimumCollectionSize={}, mayReduce={}.",
+			minimumCollectionSize,
+			mayReduce );
 	}
 
 	@Override
@@ -61,6 +71,8 @@ public abstract class BaseForUnaryExecOpWithCollectedInput extends UnaryExecutab
 	{
 		// Add the given solution mapping to the current collection.
 		collectedInputSolMaps.add(inputSolMap);
+
+		log.info( "Processing collected batch of {} solution mappings.", collectedInputSolMaps.size() );
 
 		// If enough solution mappings have been collected, process them now
 		// and, afterwards, remove them from the collection.
@@ -84,6 +96,7 @@ public abstract class BaseForUnaryExecOpWithCollectedInput extends UnaryExecutab
 		// next collection to be processed.
 		if (    inputSolMaps.size() >= minimumCollectionSize
 		     && collectedInputSolMaps.isEmpty()  ) {
+			log.info( "Passing through batch of {} mappings directly.", inputSolMaps.size() );
 			_processCollectedInput(inputSolMaps, sink, execCxt);
 			numberOfCollectionsProcessed++;
 			return;
@@ -106,6 +119,7 @@ public abstract class BaseForUnaryExecOpWithCollectedInput extends UnaryExecutab
 	                                         final ExecutionContext execCxt )
 			throws ExecOpExecutionException
 	{
+		log.info( "Concluding execution with remaining batch size {}.", collectedInputSolMaps.size() );
 		_concludeExecution(collectedInputSolMaps, sink, execCxt);
 
 		if ( ! collectedInputSolMaps.isEmpty() ) {

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BinaryExecutableOpBase.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BinaryExecutableOpBase.java
@@ -2,6 +2,9 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.BinaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
@@ -29,6 +32,8 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
  */
 public abstract class BinaryExecutableOpBase extends BaseForExecOps implements BinaryExecutableOp
 {
+	private static final Logger log = LoggerFactory.getLogger( BinaryExecutableOpBase.class );
+
 	private boolean leftInputConsumed           = false;
 	private boolean rightInputConsumed          = false;
 
@@ -48,6 +53,11 @@ public abstract class BinaryExecutableOpBase extends BaseForExecOps implements B
 	                               final boolean collectExceptions,
 	                               final QueryPlanningInfo qpInfo ) {
 		super(mayReduce, collectExceptions, qpInfo);
+
+		log.info(
+			"Initialized {} with collectExceptions={}.",
+			getClass().getSimpleName(),
+			collectExceptions );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBinaryUnion.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBinaryUnion.java
@@ -2,6 +2,9 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
@@ -10,12 +13,18 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 public class ExecOpBinaryUnion extends BinaryExecutableOpBase
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecOpBinaryUnion.class );
 	private long numberOfOutputMappingsProduced = 0L;
 
 	public ExecOpBinaryUnion( final boolean mayReduce,
 	                          final boolean collectExceptions,
 	                          final QueryPlanningInfo qpInfo ) {
 		super(mayReduce, collectExceptions, qpInfo);
+
+		log.info(
+			"Initialized ExecOpBinaryUnion (mayReduce={}, collectExceptions={}).",
+			mayReduce,
+			collectExceptions );
 	}
 
 	@Override
@@ -32,6 +41,7 @@ public class ExecOpBinaryUnion extends BinaryExecutableOpBase
 	protected void _processInputFromChild1( final SolutionMapping inputSolMap,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
+		log.info( "Processing input solution mapping from child1." );
 		numberOfOutputMappingsProduced++;
 		sink.send(inputSolMap);
 	}
@@ -40,6 +50,7 @@ public class ExecOpBinaryUnion extends BinaryExecutableOpBase
 	protected void _processInputFromChild1( final List<SolutionMapping> inputSolMaps,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
+		log.info( "Processing batch of {} solution mappings from child1.", inputSolMaps.size() );
 		numberOfOutputMappingsProduced += inputSolMaps.size();
 		sink.send(inputSolMaps);
 	}
@@ -48,12 +59,14 @@ public class ExecOpBinaryUnion extends BinaryExecutableOpBase
 	protected void _wrapUpForChild1( final IntermediateResultElementSink sink,
 	                                 final ExecutionContext execCxt ) {
 		// nothing to be done here
+		log.info( "Finished processing child1 input." );
 	}
 
 	@Override
 	protected void _processInputFromChild2( final SolutionMapping inputSolMap,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
+		log.info( "Processing input solution mapping from child2." );
 		numberOfOutputMappingsProduced++;
 		sink.send(inputSolMap);
 	}
@@ -62,6 +75,7 @@ public class ExecOpBinaryUnion extends BinaryExecutableOpBase
 	protected void _processInputFromChild2( final List<SolutionMapping> inputSolMaps,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
+		log.info( "Processing batch of {} solution mappings from child2.", inputSolMaps.size() );
 		numberOfOutputMappingsProduced += inputSolMaps.size();
 		sink.send(inputSolMaps);
 	}
@@ -70,6 +84,7 @@ public class ExecOpBinaryUnion extends BinaryExecutableOpBase
 	protected void _wrapUpForChild2( final IntermediateResultElementSink sink,
 	                                 final ExecutionContext execCxt ) {
 		// nothing to be done here
+		log.info( "Finished ExecOpBinaryUnion. Produced {} output mappings.", numberOfOutputMappingsProduced );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashBasedMinus.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashBasedMinus.java
@@ -3,6 +3,9 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 import java.util.Iterator;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
@@ -14,12 +17,20 @@ import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
  */
 public class ExecOpHashBasedMinus extends ExecOpHashJoin2
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecOpHashBasedMinus.class );
+
 	public ExecOpHashBasedMinus( final boolean mayReduce,
 	                             final ExpectedVariables inputVars1,
 	                             final ExpectedVariables inputVars2,
 	                             final boolean collectExceptions,
 	                             final QueryPlanningInfo qpInfo ) {
 		super(true, mayReduce, inputVars1, inputVars2, collectExceptions, qpInfo);
+
+		log.info(
+			"Initialized ExecOpHashBasedMinus with mayReduce={}, inputVarsLeft={}, inputVarsRight={}",
+			mayReduce,
+			inputVars1,
+			inputVars2 );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpMultiwayUnion.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpMultiwayUnion.java
@@ -2,6 +2,9 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
@@ -10,6 +13,7 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 public class ExecOpMultiwayUnion extends NaryExecutableOpBase
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecOpMultiwayUnion.class );
 	private long numberOfOutputMappingsProduced = 0L;
 
 	public ExecOpMultiwayUnion( final int numberOfChildren,
@@ -17,6 +21,12 @@ public class ExecOpMultiwayUnion extends NaryExecutableOpBase
 	                            final boolean collectExceptions,
 	                            final QueryPlanningInfo qpInfo ) {
 		super(numberOfChildren, mayReduce, collectExceptions, qpInfo);
+
+		log.info(
+			"Initialized ExecOpMultiwayUnion with {} children (mayReduce={}, collectExceptions={}).",
+			numberOfChildren,
+			mayReduce,
+			collectExceptions );
 	}
 
 	@Override
@@ -24,6 +34,7 @@ public class ExecOpMultiwayUnion extends NaryExecutableOpBase
 	                                          final SolutionMapping inputSolMap,
 	                                          final IntermediateResultElementSink sink,
 	                                          final ExecutionContext execCxt) {
+		log.info( "Processing input solution mapping from child{}.", x );
 		numberOfOutputMappingsProduced++;
 		sink.send(inputSolMap);
 	}
@@ -33,6 +44,7 @@ public class ExecOpMultiwayUnion extends NaryExecutableOpBase
 	                                          final List<SolutionMapping> inputSolMaps,
 	                                          final IntermediateResultElementSink sink,
 	                                          final ExecutionContext execCxt) {
+		log.info( "Processing batch of {} solution mappings from child{}.", inputSolMaps.size(), x );
 		numberOfOutputMappingsProduced += inputSolMaps.size();
 		sink.send(inputSolMaps);
 	}
@@ -42,6 +54,7 @@ public class ExecOpMultiwayUnion extends NaryExecutableOpBase
 	                                   final IntermediateResultElementSink sink,
 	                                   final ExecutionContext execCxt ) {
 		// nothing to be done here
+		log.info( "Finished processing child{} input.", x );
 	}
 
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoin.java
@@ -6,6 +6,8 @@ import java.util.concurrent.ExecutionException;
 
 import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.Var;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.data.utils.SolutionMappingUtils;
@@ -30,6 +32,7 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
  */
 public class ExecOpParallelMultiwayLeftJoin extends BaseForUnaryExecOpWithCollectedInput
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecOpParallelMultiwayLeftJoin.class );
 	public final static int DEFAULT_BATCH_SIZE = 30;
 
 	protected final ExpectedVariables inputVarsFromNonOptionalPart;
@@ -92,13 +95,28 @@ public class ExecOpParallelMultiwayLeftJoin extends BaseForUnaryExecOpWithCollec
 				indexes.add( new SolutionMappingsHashTable(joinVars) );
 			}
 		}
+
+		log.info(
+			"Initialized ExecOpParallelMultiwayLeftJoin with {} optional parts and {} join vars: {}.",
+			optionalParts.size(),
+			joinVars.size(),
+			joinVars );
+
+		log.info(
+			"Selected index implementation {} for {} join variables.",
+			indexes.get(0).getClass().getSimpleName(),
+			joinVars.size() );
 	}
 
 	@Override
 	protected void _processCollectedInput( final List<SolutionMapping> input,
 	                              final IntermediateResultElementSink sink,
 	                              final ExecutionContext execCxt ) throws ExecOpExecutionException {
+		log.info( "Processing batch of {} input solution mappings.", input.size() );
+
 		final List<SolutionMapping> inputForParallelProcess = determineInputForParallelProcess(input);
+
+		log.info( "Reduced batch to {} unique join-key bindings for parallel phase.", inputForParallelProcess.size() );
 
 		if ( inputForParallelProcess.size() > 0 ) {
 			parallelPhase(inputForParallelProcess, execCxt);
@@ -136,6 +154,7 @@ public class ExecOpParallelMultiwayLeftJoin extends BaseForUnaryExecOpWithCollec
 
 	protected void parallelPhase( final List<SolutionMapping> inputForParallelProcess,
 	                              final ExecutionContext execCxt ) throws ExecOpExecutionException {
+		log.info( "Starting parallel phase with {} workers.", optionalParts.size() );
 		// begin the parallel phase by starting the workers for the optional parts
 		final CompletableFuture<?>[] futures = new CompletableFuture<?>[ optionalParts.size() ];
 		for ( int i = 0; i < optionalParts.size(); i++ ) {
@@ -160,14 +179,17 @@ public class ExecOpParallelMultiwayLeftJoin extends BaseForUnaryExecOpWithCollec
 				throw new ExecOpExecutionException("The execution of the futures that run the executable operators caused an exception.", e, this);
 			}
 		}
+		log.info( "Parallel phase completed." );
 	}
 
 	protected void mergePhase( final Iterable<SolutionMapping> inputSolMaps,
 	                           final IntermediateResultElementSink sink ) {
+		log.info( "Starting merge phase." );
 		for( final SolutionMapping inputSolMap : inputSolMaps ) {
 			final Set<SolutionMapping> outputSolMaps = merge(inputSolMap);
 			sink.send(outputSolMaps);
 		}
+		log.info( "Merge phase completed." );
 	}
 
 	protected Set<SolutionMapping> merge( final SolutionMapping inputSol ) {
@@ -243,13 +265,18 @@ public class ExecOpParallelMultiwayLeftJoin extends BaseForUnaryExecOpWithCollec
 
 		@Override
 		public void run() {
+			log.info(
+				"Worker started processing {} input solution mappings.",
+				input.size() );
 			try {
 				execOp.process(input, mySink, execCxt);
 				execOp.concludeExecution(mySink, execCxt);
 			}
 			catch ( final ExecOpExecutionException e ) {
+				log.info( "Worker execution failed." );
 				throw new RuntimeException("Executing an add operator used by this parallel multi left join caused an exception.", e);
 			}
+			log.info( "Worker completed successfully." );
 		}
 	}
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/NaryExecutableOpBase.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/NaryExecutableOpBase.java
@@ -2,6 +2,9 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutableOperatorStats;
@@ -28,6 +31,8 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
  */
 public abstract class NaryExecutableOpBase extends BaseForExecOps implements NaryExecutableOp
 {
+	private static final Logger log = LoggerFactory.getLogger( NaryExecutableOpBase.class );
+
 	protected final int numberOfChildren;
 
 	private boolean[] xthInputConsumed;
@@ -53,6 +58,13 @@ public abstract class NaryExecutableOpBase extends BaseForExecOps implements Nar
 		timeAtCurrentProcStartXthInput         = new long[numberOfChildren];
 
 		resetStats();
+
+		log.info(
+			"Initialized {} with {} children, mayReduce={}, collectExceptions={}.",
+			getClass().getSimpleName(),
+			numberOfChildren,
+			mayReduce,
+			collectExceptions );
 	}
 
 	@Override


### PR DESCRIPTION
Addresses #607 by adding logging for:
- BaseForUnaryExecOpWithCollectedInput
- BinaryExecutableOpBase
- ExecOpBinaryUnion
- ExecOpHashBasedMinus
- ExecOpMultiwayUnion
- ExecOpParallelMultiwayLeftJoin
- NaryExecutableOpBase