### PR TITLE
Add info level logging for unary executable operators

### DIFF
--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBind.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBind.java
@@ -28,7 +28,7 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
  */
 public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 {
-	private static final Logger logger = LoggerFactory.getLogger( ExecOpBind.class );
+	private static final Logger log = LoggerFactory.getLogger( ExecOpBind.class );
 	private long numberOfOutputMappingsProduced = 0L;
 
 	protected final Worker worker;
@@ -39,7 +39,7 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 	                   final QueryPlanningInfo qpInfo ) {
 		super(mayReduce, collectExceptions, qpInfo);
 
-		logger.info( "Initialized ExecOpBind with {} bind expression(s).", bindExpressions.size() );
+		log.info( "Initialized ExecOpBind with {} bind expression(s).", bindExpressions.size() );
 
 		if ( bindExpressions.size() == 1 ) {
 			final Var var = bindExpressions.getVars().get(0);
@@ -61,7 +61,7 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 		assert var != null;
 		assert expr != null;
 
-		logger.info( "Initialized ExecOpBind for variable {} with expression {}.", var, expr );
+		log.info( "Initialized ExecOpBind for variable {} with expression {}.", var, expr );
 
 		worker = new OneVarWorker(var, expr);
 	}
@@ -71,9 +71,9 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 	                         final IntermediateResultElementSink sink,
 	                         final ExecutionContext execCxt )
 			 throws ExecOpExecutionException {
-		logger.info( "Processing solution mapping in ExecOpBind." );
+		log.info( "Processing solution mapping in ExecOpBind." );
 		sink.send( worker.extend(inputSolMap) );
-		logger.info( "Produced extended solution mapping." );
+		log.info( "Produced extended solution mapping." );
 		numberOfOutputMappingsProduced++;
 	}
 
@@ -84,7 +84,7 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 	                         final ExecutionContext execCxt )
 		 throws ExecOpExecutionException
 	{
-		logger.info( "Processing batch of solution mappings with max batch size {}.", maxBatchSize );
+		log.info( "Processing batch of solution mappings with max batch size {}.", maxBatchSize );
 		final List<SolutionMapping> output = new ArrayList<>();
 
 		// Produce the output solution mappings
@@ -98,7 +98,7 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 		}
 
 		numberOfOutputMappingsProduced += output.size();
-		logger.info( "Produced {} output solution mappings in batch.", output.size() );
+		log.info( "Produced {} output solution mappings in batch.", output.size() );
 		sink.send(output);
 	}
 
@@ -106,7 +106,7 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 	protected void _concludeExecution( final IntermediateResultElementSink sink,
 	                                   final ExecutionContext execCxt ) {
 		// nothing to be done here
-		logger.info( "ExecOpBind execution concluded. Produced {} output mappings.", numberOfOutputMappingsProduced );
+		log.info( "ExecOpBind execution concluded. Produced {} output mappings.", numberOfOutputMappingsProduced );
 	}
 
 	@Override
@@ -140,11 +140,11 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 		public SolutionMapping extend( final SolutionMapping solmap )
 				 throws ExecOpExecutionException
 		{
-			logger.info( "Evaluating bind expression {} for variable {}.", expr, var );
+			log.info( "Evaluating bind expression {} for variable {}.", expr, var );
 			final Binding sm = solmap.asJenaBinding();
 
 			if ( sm.contains(var) ) {
-				logger.info( "Cannot bind variable {} because it is already bound.", var );
+				log.info( "Cannot bind variable {} because it is already bound.", var );
 				throwExecOpExecutionException( "Variable '" + var.getVarName() + "' already bound in the given solution mapping." );
 			}
 
@@ -155,10 +155,10 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 			catch ( final Exception ex ) {
 				// If evaluating the expression based on the current input solution
 				// mapping failed, pass on the solution mapping without extending it.
-				logger.info( "Evaluation failed for variable {}. Returning original solution mapping.", var );
+				log.info( "Evaluation failed for variable {}. Returning original solution mapping.", var );
 				return solmap;
 			}
-			logger.info( "Successfully evaluated expression for variable {}.", var );
+			log.info( "Successfully evaluated expression for variable {}.", var );
 
 			final Binding smOut = BindingFactory.binding( sm, var, evaluationResult.asNode() );
 			return new SolutionMappingImpl(smOut);
@@ -176,7 +176,7 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 		public SolutionMapping extend( final SolutionMapping solmap )
 				 throws ExecOpExecutionException
 		{
-			logger.info( "Evaluating multiple bind expressions." );
+			log.info( "Evaluating multiple bind expressions." );
 
 			// This Binding will be replaced by extended versions of
 			// it within the following for-loop. Extending it stepwise
@@ -191,10 +191,10 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 				final Var var = e.getKey();
 				final Expr expr = e.getValue();
 
-				logger.info( "Evaluating bind expression {} for variable {}.", expr, var );
+				log.info( "Evaluating bind expression {} for variable {}.", expr, var );
 
 				if ( sm.contains(var) ) {
-					logger.info( "Cannot bind variable {} because it is already bound.", var );
+					log.info( "Cannot bind variable {} because it is already bound.", var );
 					throwExecOpExecutionException( "Variable '" + var.getVarName() + "' already bound in the given solution mapping." );
 				}
 
@@ -206,19 +206,19 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 					sm = BindingFactory.binding(sm, var, evaluationResult.asNode() );
 					extended = true;
 
-					logger.info( "Successfully extended solution mapping with variable {}.", var );
+					log.info( "Successfully extended solution mapping with variable {}.", var );
 				}
 				catch ( final Exception ex ) {
 					// If evaluating the expression based on the current
 					// input solution mapping failed, then do nothing.
-					logger.info( "Evaluation failed for variable {}. Skipping extension.", var );
+					log.info( "Evaluation failed for variable {}. Skipping extension.", var );
 				}
 			}
 
 			if ( extended )
 				return new SolutionMappingImpl(sm);
 			else {
-				logger.info( "No bind expressions could be evaluated successfully." );
+				log.info( "No bind expressions could be evaluated successfully." );
 				return solmap;
 			}
 		}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpDuplicateRemoval.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpDuplicateRemoval.java
@@ -3,6 +3,9 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
@@ -16,6 +19,7 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
  */
 public class ExecOpDuplicateRemoval extends UnaryExecutableOpBase
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecOpDuplicateRemoval.class );
 	private long numberOfOutputMappingsProduced = 0L;
 	private long numberOfDuplicates = 0L;
 
@@ -25,6 +29,8 @@ public class ExecOpDuplicateRemoval extends UnaryExecutableOpBase
 	                     final boolean collectExceptions,
 	                     final QueryPlanningInfo qpInfo ) {
 		super(true, collectExceptions, qpInfo);
+
+		log.info( "Initialized ExecOpDuplicateRemoval (collectExceptions={}).", collectExceptions );
 	}
 
 	@Override
@@ -41,6 +47,12 @@ public class ExecOpDuplicateRemoval extends UnaryExecutableOpBase
 	@Override
 	protected void _concludeExecution( final IntermediateResultElementSink sink,
 	                                   final ExecutionContext execCxt ) {
+		log.info(
+			"Distinct operator finishing. Produced={}, duplicates={}, uniqueSize={}.",
+			numberOfOutputMappingsProduced,
+			numberOfDuplicates,
+			distinctSolMaps.size() );
+
 		distinctSolMaps.clear();
 	}
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpFilter.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpFilter.java
@@ -6,6 +6,8 @@ import java.util.List;
 
 import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.ExprList;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.data.utils.SolutionMappingUtils;
@@ -16,6 +18,8 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 public class ExecOpFilter extends UnaryExecutableOpBaseWithoutBlocking
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecOpFilter.class );
+
 	private long numberOfOutputMappingsProduced = 0L;
 
 	protected final ExprList filterExpressions;
@@ -30,6 +34,12 @@ public class ExecOpFilter extends UnaryExecutableOpBaseWithoutBlocking
 		assert ! filterExpressions.isEmpty();
 
 		this.filterExpressions = filterExpressions;
+
+		log.info(
+			"Initialized ExecOpFilter with {} expressions, mayReduce={}, collectExceptions={}.",
+			filterExpressions.size(),
+			mayReduce,
+			collectExceptions );
 	}
 
 	public ExecOpFilter( final Expr filterExpression,
@@ -41,6 +51,11 @@ public class ExecOpFilter extends UnaryExecutableOpBaseWithoutBlocking
 		assert filterExpression != null;
 
 		this.filterExpressions = new ExprList(filterExpression);
+
+		log.info(
+			"Initialized ExecOpFilter with one expression, mayReduce={}, collectExceptions={}.",
+			mayReduce,
+			collectExceptions );
 	}
 
 	@Override
@@ -74,6 +89,8 @@ public class ExecOpFilter extends UnaryExecutableOpBaseWithoutBlocking
 			}
 		}
 
+		log.info( "Processing batch of {} solution mappings.", cnt );
+
 		// Continue consuming the rest of the batch (if any). If we find
 		// further solution mappings that can be passed on as output, we
 		// collect them in an output list, with the earlier-found first
@@ -106,12 +123,18 @@ public class ExecOpFilter extends UnaryExecutableOpBaseWithoutBlocking
 			sink.send(firstOutput);
 			numberOfOutputMappingsProduced++;
 		}
+
+		log.info(
+			"Batch processed: {} input, {} output mappings.",
+			cnt,
+			(allOutput != null ? allOutput.size() : (firstOutput != null ? 1 : 0)) );
 	}
 
 	@Override
 	protected void _concludeExecution( final IntermediateResultElementSink sink,
 	                                   final ExecutionContext execCxt ) {
 		// nothing to be done here
+		log.info( "ExecOpFilter concluded execution." );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpGlobalToLocal.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpGlobalToLocal.java
@@ -5,6 +5,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.data.VocabularyMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
@@ -14,6 +17,7 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 public class ExecOpGlobalToLocal extends UnaryExecutableOpBaseWithoutBlocking
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecOpGlobalToLocal.class );
 	private long numberOfOutputMappingsProduced = 0L;
 
 	protected final VocabularyMapping vm;
@@ -26,6 +30,11 @@ public class ExecOpGlobalToLocal extends UnaryExecutableOpBaseWithoutBlocking
 
 		assert vm != null;
 		this.vm = vm;
+
+		log.info(
+			"Initialized ExecOpGlobalToLocal with VocabularyMapping {} (class={}).",
+			vm,
+			vm.getClass().getSimpleName() );
 	}
 
 	@Override
@@ -42,6 +51,7 @@ public class ExecOpGlobalToLocal extends UnaryExecutableOpBaseWithoutBlocking
 	                         final int maxBatchSize,
 	                         final IntermediateResultElementSink sink,
 	                         final ExecutionContext execCxt ) {
+		log.info( "Processing batch of up to {} solution mappings (GlobalToLocal).", maxBatchSize );
 		final List<SolutionMapping> output = new ArrayList<>();
 
 		// Produce the output solution mappings
@@ -55,12 +65,18 @@ public class ExecOpGlobalToLocal extends UnaryExecutableOpBaseWithoutBlocking
 
 		numberOfOutputMappingsProduced += output.size();
 		sink.send(output);
+
+		log.info(
+			"Batch translated: {} output mappings produced from {} input mappings.",
+			output.size(),
+			cnt );
 	}
 
 	@Override
 	protected void _concludeExecution( final IntermediateResultElementSink sink,
 	                                   final ExecutionContext execCxt ) {
 		// nothing to be done here
+		log.info( "ExecOpGlobalToLocal concluded execution." );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLocalToGlobal.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLocalToGlobal.java
@@ -5,6 +5,9 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.data.VocabularyMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
@@ -14,6 +17,7 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
 
 public class ExecOpLocalToGlobal extends UnaryExecutableOpBaseWithoutBlocking
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecOpLocalToGlobal.class );
 	private long numberOfOutputMappingsProduced = 0L;
 
 	protected final VocabularyMapping vm;
@@ -26,6 +30,11 @@ public class ExecOpLocalToGlobal extends UnaryExecutableOpBaseWithoutBlocking
 
 		assert vm != null;
 		this.vm = vm;
+
+		log.info(
+			"Initialized ExecOpLocalToGlobal with VocabularyMapping {} (class={}).",
+			vm,
+			vm.getClass().getSimpleName() );
 	}
 
 	@Override
@@ -42,6 +51,7 @@ public class ExecOpLocalToGlobal extends UnaryExecutableOpBaseWithoutBlocking
 	                         final int maxBatchSize,
 	                         final IntermediateResultElementSink sink,
 	                         final ExecutionContext execCxt ) {
+		log.info( "Processing batch of up to {} solution mappings (LocalToGlobal).", maxBatchSize );
 		final List<SolutionMapping> output = new ArrayList<>();
 
 		// Produce the output solution mappings
@@ -55,12 +65,18 @@ public class ExecOpLocalToGlobal extends UnaryExecutableOpBaseWithoutBlocking
 
 		numberOfOutputMappingsProduced += output.size();
 		sink.send(output);
+
+		log.info(
+			"Batch translated: {} output mappings produced from {} input mappings.",
+			output.size(),
+			cnt );
 	}
 
 	@Override
 	protected void _concludeExecution( final IntermediateResultElementSink sink,
 	                                   final ExecutionContext execCxt ) {
 		// nothing to be done here
+		log.info( "ExecOpLocalToGlobal concluded execution." );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpProject.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpProject.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Set;
 
 import org.apache.jena.sparql.core.Var;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.data.utils.SolutionMappingUtils;
@@ -22,6 +24,7 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
  */
 public class ExecOpProject extends UnaryExecutableOpBaseWithoutBlocking
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecOpProject.class );
 	private long numberOfOutputMappingsProduced = 0L;
 
 	protected final Set<Var> variables;
@@ -35,6 +38,11 @@ public class ExecOpProject extends UnaryExecutableOpBaseWithoutBlocking
 		assert variables != null;
 
 		this.variables = variables;
+
+		log.info(
+			"Initialized ExecOpProject with {} projection variables: {}.",
+			variables.size(),
+			variables );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpUnfold.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpUnfold.java
@@ -19,6 +19,8 @@ import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.ExprEvalException;
 import org.apache.jena.sparql.expr.NodeValue;
 import org.apache.jena.sparql.util.ExprUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.data.impl.SolutionMappingImpl;
@@ -35,6 +37,8 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
  */
 public class ExecOpUnfold extends UnaryExecutableOpBaseWithoutBlocking
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecOpUnfold.class );
+
 	protected final Expr expr;
 	protected final Var var1;
 	protected final Var var2;
@@ -58,6 +62,10 @@ public class ExecOpUnfold extends UnaryExecutableOpBaseWithoutBlocking
 		this.expr = expr;
 		this.var1 = var1;
 		this.var2 = var2;
+
+		log.info(
+			"Initialized ExecOpUnfold (var1={}, var2={}, collectExceptions={})",
+			var1, var2, collectExceptions );
 	}
 
 	@Override
@@ -73,6 +81,7 @@ public class ExecOpUnfold extends UnaryExecutableOpBaseWithoutBlocking
 			// If the expression failed to evaluate for a given
 			// solution mapping, then the expected result is that
 			// this solution mapping is returned as is.
+			log.info( "Expression evaluation failed for inputSolMap={}: {}", inputSolMap, ex.getMessage() );
 			sink.send(inputSolMap);
 			numberOfOutputMappingsProduced++;
 			numberOfExprEvalErrors++;
@@ -86,6 +95,7 @@ public class ExecOpUnfold extends UnaryExecutableOpBaseWithoutBlocking
 
 			if ( CompositeDatatypeList.uri.equals(dtURI)
 			     && lit.isWellFormed() ) {
+				log.info( "Unfolding CDT list" );
 				numberOfUnfoldedCDTs++;
 				unfoldList(lit, inputSolMap, sink);
 				return;
@@ -93,6 +103,7 @@ public class ExecOpUnfold extends UnaryExecutableOpBaseWithoutBlocking
 
 			if ( CompositeDatatypeMap.uri.equals(dtURI)
 			     && lit.isWellFormed() ) {
+				log.info( "Unfolding CDT map" );
 				numberOfUnfoldedCDTs++;
 				unfoldMap(lit, inputSolMap, sink);
 				return;

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/UnaryExecutableOpBase.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/UnaryExecutableOpBase.java
@@ -2,6 +2,9 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutableOperatorStats;
@@ -31,6 +34,8 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
  */
 public abstract class UnaryExecutableOpBase extends BaseForExecOps implements UnaryExecutableOp
 {
+	private static final Logger log = LoggerFactory.getLogger( UnaryExecutableOpBase.class );
+
 	private boolean executionConcluded = false;
 	private long numberOfInputMappingsProcessed = 0L;
 
@@ -38,6 +43,12 @@ public abstract class UnaryExecutableOpBase extends BaseForExecOps implements Un
 	                              final boolean collectExceptions,
 	                              final QueryPlanningInfo qpInfo ) {
 		super(mayReduce, collectExceptions, qpInfo);
+
+		log.info(
+			"Initialized {} (mayReduce={}, collectExceptions={}).",
+			getClass().getSimpleName(),
+			mayReduce,
+			collectExceptions );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/UnaryExecutableOpBaseWithoutBlocking.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/UnaryExecutableOpBaseWithoutBlocking.java
@@ -3,6 +3,9 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 import java.util.Iterator;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
@@ -31,12 +34,20 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
  */
 public abstract class UnaryExecutableOpBaseWithoutBlocking extends UnaryExecutableOpBase
 {
+	private static final Logger log = LoggerFactory.getLogger( UnaryExecutableOpBaseWithoutBlocking.class );
+
 	public static final int MAX_BATCH_SIZE = 100;
 
 	public UnaryExecutableOpBaseWithoutBlocking( final boolean mayReduce,
 	                                             final boolean collectExceptions,
 	                                             final QueryPlanningInfo qpInfo ) {
 		super(mayReduce, collectExceptions, qpInfo);
+
+		log.info(
+			"Initialized {} (mayReduce={}, collectExceptions={}).",
+			getClass().getSimpleName(),
+			mayReduce,
+			collectExceptions );
 	}
 
 	@Override


### PR DESCRIPTION
Addresses #607 by adding logging for unary executable operators.

Also renames `logger` to `log` in `ExecOpBind`.