### PR TITLE
Use QLever SPARQL endpoints for some of the example queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix in RML-to-algebra translation algorithm ([#610](https://github.com/LiUSemWeb/HeFQUIN/pull/610)).
 - Fix in code that expands URI templates ([#611](https://github.com/LiUSemWeb/HeFQUIN/pull/611)).
 - Removes unused provenance-related methods from DataRetrievalResponse ([#582](https://github.com/LiUSemWeb/HeFQUIN/pull/582)).
+- Changes some of the example queries to use the QLever SPARQL endpoints for DBpedia and Wikidata ([#620](https://github.com/LiUSemWeb/HeFQUIN/pull/620)).
 
 
 ## [0.0.10] - 2026-03-25

--- a/examples/Covid19Stats.rq
+++ b/examples/Covid19Stats.rq
@@ -18,7 +18,8 @@ PREFIX ex:     <http://example.org/>
 # ignores the solution mapping with this ISO code.
 
 SELECT * WHERE {
-	SERVICE <https://query.wikidata.org/sparql> {
+	SERVICE <https://qlever.dev/api/wikidata>
+	{
 		?country wdt:P31 wd:Q6256 ;       # instance of country
 		         wdt:P30 wd:Q46 ;         # located in Europe
 		         wdt:P297 ?isoCode ;      # ISO country code

--- a/examples/ExampleFederation.ttl
+++ b/examples/ExampleFederation.ttl
@@ -12,6 +12,12 @@ ex:dbpediaSPARQL a fd:RDFBasedFederationMember ;
                    fd:supportedProtocol  fd:SPARQLProtocol ;
                    fd:endpointAddress    "http://dbpedia.org/sparql"^^xsd:anyURI ] .
 
+ex:dbpediaSPARQL2 a fd:RDFBasedFederationMember ;
+    fd:serviceURI "https://qlever.dev/api/dbpedia"^^xsd:anyURI ;
+    fd:interface [ a                     fd:FixedEndpointInterface ;
+                   fd:supportedProtocol  fd:SPARQLProtocol ;
+                   fd:endpointAddress    "https://qlever.dev/api/dbpedia"^^xsd:anyURI ] .
+
 ex:dbpediaTPF a fd:RDFBasedFederationMember ;
     fd:serviceURI "http://fragments.dbpedia.org/2016-04/en"^^xsd:anyURI ;
     fd:interface [ a                         fd:FragmentInterface ;
@@ -23,6 +29,12 @@ ex:wikidataSPARQL a fd:RDFBasedFederationMember ;
     fd:interface [ a                     fd:FixedEndpointInterface ;
                    fd:supportedProtocol  fd:SPARQLProtocol ;
                    fd:endpointAddress    "https://query.wikidata.org/sparql"^^xsd:anyURI ] .
+
+ex:wikidataSPARQL2 a fd:RDFBasedFederationMember ;
+    fd:serviceURI "https://qlever.dev/api/wikidata"^^xsd:anyURI ;
+    fd:interface [ a                     fd:FixedEndpointInterface ;
+                   fd:supportedProtocol  fd:SPARQLProtocol ;
+                   fd:endpointAddress    "https://qlever.dev/api/wikidata"^^xsd:anyURI ] .
 
 ex:dbpediaSPARQLWithVocabMappings a fd:RDFBasedFederationMember ;
     fd:serviceURI "http://example.org/DBpediaWrapper"^^xsd:anyURI ;

--- a/examples/OpenLibraryAPI.rq
+++ b/examples/OpenLibraryAPI.rq
@@ -16,7 +16,7 @@ PREFIX ex:     <http://example.org/>
 SELECT ?authorName ?bookTitle ?publishYear WHERE {
   BIND(3 AS ?bookLimit)
 
-  SERVICE <http://dbpedia.org/sparql> {
+  SERVICE <https://qlever.dev/api/dbpedia> {
     ?author dbo:award dbr:Nobel_Prize_in_Literature ;
             rdfs:label ?authorName .
     FILTER( lang(?authorName) = "en" )


### PR DESCRIPTION
This PR changes some of the example queries to use the QLever SPARQL endpoints for DBpedia and Wikidata. These endpoints are more reliable than the official endpoints.