### PR TITLE
Use QLever SPARQL endpoints for the example queries

### DIFF
--- a/examples/ExampleFederation.ttl
+++ b/examples/ExampleFederation.ttl
@@ -64,21 +64,11 @@ ex:openMeteo a fd:WrappedFederationMember ;
 _:openMeteoRestEndpoint a fd:TemplateBasedInterface ;
       fd:supportedProtocol fd:GenericWebAPIProtocol ;
       fd:uriTemplate [
-            hydra:template "https://api.open-meteo.com/v1/forecast{?latitude,longitude,current,hourly}" ;
+            hydra:template "https://api.open-meteo.com/v1/forecast?current=temperature_2m,wind_speed_10m&hourly=temperature_2m,wind_speed_10m{&latitude,longitude}" ;
             hydra:mapping [ hydra:variable "latitude" ;
-                            hydra:required true ;
-                            fd:paramType xsd:float
-                          ] ,
+                            hydra:required true ] ,
                           [ hydra:variable "longitude" ;
-                            hydra:required true ;
-                            fd:paramType xsd:float
-                          ] ,
-                          [ hydra:variable "current" ;
-                            fd:paramType xsd:string
-                          ] ,
-                          [ hydra:variable "hourly" ;
-                            fd:paramType xsd:string
-                          ]
+                            hydra:required true ]
           ] .
 
 ex:openMeteo2 a fd:WrappedFederationMember ;
@@ -128,7 +118,7 @@ _:openMeteoTM4
                           rml:referenceFormulation rml:JSONPath ;
                           rml:iterator "$" ] ;
       rml:subjectMap [ rml:termType rml:BlankNode ;
-                       rml:reference "hourly_units.time" ];
+                       rml:reference "current.time" ];
       rml:predicateObjectMap [ rml:predicateMap [ rml:constant ex:hourly_temperature ] ;
                                rml:objectMap [ rml:reference "hourly.temperature_2m" ; rml:datatype cdt:List ] ] .
 

--- a/examples/OpenMeteoBind.rq
+++ b/examples/OpenMeteoBind.rq
@@ -15,11 +15,9 @@ PREFIX ex:     <http://example.org/>
 SELECT * WHERE {
 	BIND ( "52.52"^^xsd:float AS ?lat )
 	BIND ( "13.41"^^xsd:float AS ?long )
-	BIND ( "temperature_2m,wind_speed_10m" AS ?req)
 
 	SERVICE <http://example.org/OpenMeteoWrapper> PARAMS(?lat AS "latitude",
-	                                                     ?long AS "longitude",
-	                                                     ?req AS "current") {
+	                                                     ?long AS "longitude") {
 		?x ex:temperature ?temp .
 		?x ex:windSpeed ?wind .
 	}

--- a/examples/OpenMeteoCDTList.rq
+++ b/examples/OpenMeteoCDTList.rq
@@ -18,16 +18,15 @@ PREFIX ex:     <http://example.org/>
 # forecasts from the Open-Meteo API does indeed contain arrays.
 
 SELECT * WHERE {
-	SERVICE <http://dbpedia.org/sparql> {
+	SERVICE <https://qlever.dev/api/dbpedia>
+	{
 		<http://dbpedia.org/resource/Berlin> geo:lat ?lat ;
 		                                     geo:long ?long .
 	}
 
-	BIND ( "temperature_2m" AS ?req)
-
 	SERVICE <http://example.org/OpenMeteoWrapper> PARAMS(?lat AS "latitude",
-	                                                     ?long AS "longitude",
-	                                                     ?req AS "hourly") {
+	                                                     ?long AS "longitude")
+	{
 		?x ex:hourly_temperature ?list .
 	}
 

--- a/examples/OpenMeteoCDTMap.rq
+++ b/examples/OpenMeteoCDTMap.rq
@@ -17,16 +17,15 @@ PREFIX ex:     <http://example.org/>
 # the cdt:List literal obtained from the cdt:keys function.
 
 SELECT * WHERE {
-	SERVICE <http://dbpedia.org/sparql> {
+	SERVICE <https://qlever.dev/api/dbpedia>
+	{
 		<http://dbpedia.org/resource/Berlin> geo:lat ?lat ;
 		                                     geo:long ?long .
 	}
 
-	BIND ( "temperature_2m,wind_speed_10m" AS ?req)
-
 	SERVICE <http://example.org/OpenMeteoWrapper> PARAMS(?lat AS "latitude",
-	                                                     ?long AS "longitude",
-	                                                     ?req AS "current") {
+	                                                     ?long AS "longitude")
+	{
 		?x ex:current ?c .
 	}
 

--- a/examples/OpenMeteoJoin2.rq
+++ b/examples/OpenMeteoJoin2.rq
@@ -9,19 +9,24 @@ PREFIX ex:     <http://example.org/>
 
 # This query accesses the Web API of the Open-Meteo weather service by using
 # requests that are formed based on data obtained from a SPARQL endpoint.
-# More specifically, the query obtains the geographic coordinates of Berlin
-# from the SPARQL endpoint of the DBpedia Knowledge Graph and, then, uses
-# these coordinates to request the current temperature and wind speed in
-# Berlin from the Web API.
+# More specifically, the query obtains the geographic coordinates of cities
+# in Croatia from the SPARQL endpoint of the DBpedia Knowledge Graph and,
+# then, uses these coordinates to request the current temperature and wind
+# speed in these cities from the Web API.
 
-SELECT * WHERE {
-	SERVICE <https://qlever.dev/api/dbpedia> {
-		<http://dbpedia.org/resource/Berlin> geo:lat ?lat ;
-		                                     geo:long ?long .
+SELECT * WHERE
+{
+	SERVICE <https://qlever.dev/api/dbpedia>
+	{
+		?city rdf:type dbo:City ;
+		      geo:lat ?lat ;
+		      geo:long ?long ;
+		      dbo:country <http://dbpedia.org/resource/Croatia>
 	}
 
 	SERVICE <http://example.org/OpenMeteoWrapper> PARAMS(?lat AS "latitude",
-	                                                     ?long AS "longitude") {
+	                                                     ?long AS "longitude")
+	{
 		?x ex:temperature ?temp .
 		?x ex:windSpeed ?wind .
 	}


### PR DESCRIPTION
This PR changes the example queries to use the QLever SPARQL endpoints for DBpedia and Wikidata. These endpoints are more reliable than the official endpoints.

Follow up to #620