### PR TITLE
Use QLever SPARQL endpoints for the rest of the example queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix in RML-to-algebra translation algorithm ([#610](https://github.com/LiUSemWeb/HeFQUIN/pull/610)).
 - Fix in code that expands URI templates ([#611](https://github.com/LiUSemWeb/HeFQUIN/pull/611)).
 - Removes unused provenance-related methods from DataRetrievalResponse ([#582](https://github.com/LiUSemWeb/HeFQUIN/pull/582)).
-- Changes some of the example queries to use the QLever SPARQL endpoints for DBpedia and Wikidata ([#620](https://github.com/LiUSemWeb/HeFQUIN/pull/620), [#621](https://github.com/LiUSemWeb/HeFQUIN/pull/621)).
+- Changes some of the example queries to use the QLever SPARQL endpoints for DBpedia and Wikidata ([#620](https://github.com/LiUSemWeb/HeFQUIN/pull/620), [#621](https://github.com/LiUSemWeb/HeFQUIN/pull/621), [#622](https://github.com/LiUSemWeb/HeFQUIN/pull/622)).
 - Logging for executable operators ([#608](https://github.com/LiUSemWeb/HeFQUIN/pull/608), [#609](https://github.com/LiUSemWeb/HeFQUIN/pull/609), [#614](https://github.com/LiUSemWeb/HeFQUIN/pull/614), [#617](https://github.com/LiUSemWeb/HeFQUIN/pull/617), [#618](https://github.com/LiUSemWeb/HeFQUIN/pull/618), [#619](https://github.com/LiUSemWeb/HeFQUIN/pull/619)).
 
 

--- a/examples/ExampleQuery1.rq
+++ b/examples/ExampleQuery1.rq
@@ -11,14 +11,14 @@ PREFIX dbo:    <http://dbpedia.org/ontology/>
 # algorithm, HeFQUIN pushes the FILTER into the request to the DBpedia endpoint.
 
 SELECT * WHERE {
-	SERVICE <http://dbpedia.org/sparql> {
+	SERVICE <https://qlever.dev/api/dbpedia> {
 		<http://dbpedia.org/resource/Berlin> dbo:country ?c .
 		?c owl:sameAs ?cc
 	}
 
 	FILTER ( CONTAINS(STR(?cc), "wikidata" ) )
 
-	SERVICE <https://query.wikidata.org/sparql> {
+	SERVICE <https://qlever.dev/api/wikidata> {
 		?cc rdfs:label ?o
 	}
 }

--- a/examples/ExampleQuery2.rq
+++ b/examples/ExampleQuery2.rq
@@ -18,7 +18,7 @@ SELECT * WHERE {
 		FILTER ( CONTAINS(STR(?cc), "wikidata" ) )
 	}
 
-	SERVICE <https://query.wikidata.org/sparql> {
+	SERVICE <https://qlever.dev/api/wikidata> {
 		?cc rdfs:label ?o
 	}
 }

--- a/examples/ExampleQuery3.rq
+++ b/examples/ExampleQuery3.rq
@@ -8,7 +8,7 @@ PREFIX dbo:    <http://dbpedia.org/ontology/>
 # now is that this one uses VALUES clauses to specify the federation members.
 # Notice that, while there are two separate VALUES clauses here, it is also
 # possible to merge them into one VALUE clause:
-#   VALUES (?s1 ?s2) { (<http://dbpedia.org/sparql> <https://query.wikidata.org/sparql>) }
+#   VALUES (?s1 ?s2) { (<https://qlever.dev/api/dbpedia> <https://qlever.dev/api/wikidata>) }
 #
 # In the query plan for this query, you can see that the service IRIs from the
 # VALUES clause(s) become an explicit argument of the corresponding operators
@@ -18,8 +18,8 @@ PREFIX dbo:    <http://dbpedia.org/ontology/>
 # optimize these subplans differently.
 
 SELECT * WHERE {
-	VALUES ?s1 { <http://dbpedia.org/sparql> }
-	#VALUES ?s1 { <http://fragments.dbpedia.org/2016-04/en> }
+	VALUES ?s1 { <https://qlever.dev/api/dbpedia> }             # SPARQL endpoint
+	#VALUES ?s1 { <http://fragments.dbpedia.org/2016-04/en> }   # TPF server
 
 	SERVICE ?s1 {
 		<http://dbpedia.org/resource/Berlin> dbo:country ?c .
@@ -27,7 +27,7 @@ SELECT * WHERE {
 		FILTER ( CONTAINS(STR(?cc), "wikidata" ) )
 	}
 
-	VALUES ?s2 { <https://query.wikidata.org/sparql> }
+	VALUES ?s2 { <https://qlever.dev/api/wikidata> }
 
 	SERVICE ?s2 {
 		?cc rdfs:label ?o


### PR DESCRIPTION
This PR changes the remaining example queries to use the QLever SPARQL endpoints for DBpedia and Wikidata. These endpoints are more reliable than the official endpoints.

Follow up to #621 and #620