### PR TITLE
Change certain logs to DEBUG level

### DIFF
--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpHashJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpHashJoin.java
@@ -31,25 +31,23 @@ public abstract class BaseForExecOpHashJoin extends BinaryExecutableOpBase
 		// determine the certain join variables
 		final Set<Var> certainJoinVars = ExpectedVariablesUtils.intersectionOfCertainVariables(inputVars1, inputVars2);
 
-		log.info( "Initializing hash join operator with join variables {}.", certainJoinVars );
-
 		// set up the core part of the index first;
 		// it is built on the certain join variables
 		final SolutionMappingsIndex _index;
 		if ( certainJoinVars.size() == 1 ) {
 			final Var joinVar = certainJoinVars.iterator().next();
-			log.info( "Using one-variable hash table for join variable {}.", joinVar );
+			log.debug( "Using one-variable hash table for join variable {}.", joinVar );
 			_index = new SolutionMappingsHashTableBasedOnOneVar(joinVar);
 		}
 		else if ( certainJoinVars.size() == 2 ) {
 			final Iterator<Var> liVar = certainJoinVars.iterator();
 			final Var joinVar1 = liVar.next();
 			final Var joinVar2 = liVar.next();
-			log.info( "Using two-variable hash table for join variables {}, {}.", joinVar1, joinVar2 );
+			log.debug( "Using two-variable hash table for join variables {}, {}.", joinVar1, joinVar2 );
 			_index = new SolutionMappingsHashTableBasedOnTwoVars(joinVar1, joinVar2);
 		}
 		else {
-			log.info( "Using generic hash table for join variables {}.", certainJoinVars );
+			log.debug( "Using generic hash table for join variables {}.", certainJoinVars );
 			_index = new SolutionMappingsHashTable(certainJoinVars);
 		}
 
@@ -57,7 +55,7 @@ public abstract class BaseForExecOpHashJoin extends BinaryExecutableOpBase
 		// the join and, if so, set up the index to use post-matching.
 		final Set<Var> potentialJoinVars = ExpectedVariablesUtils.intersectionOfAllVariables(inputVars1, inputVars2);
 		if ( ! potentialJoinVars.equals(certainJoinVars) ) {
-			log.info( "Post-matching enabled for potential join variables {}.", potentialJoinVars );
+			log.debug( "Post-matching enabled for potential join variables {}.", potentialJoinVars );
 			index = new SolutionMappingsIndexWithPostMatching(_index);
 		}
 		else

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpIndexNestedLoopsJoinWithSolMapsRequests.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpIndexNestedLoopsJoinWithSolMapsRequests.java
@@ -35,7 +35,7 @@ public abstract class BaseForExecOpIndexNestedLoopsJoinWithSolMapsRequests<Query
 	                                                       final IntermediateResultElementSink sink,
 	                                                       final ExecutableOperator op )
 	{
-		log.info( "Creating response processor for solution mapping." );
+		log.debug( "Creating response processor for solution mapping." );
 		return new MyResponseProcessor( sm, sink, op ) {
 			@Override
 			protected Iterable<SolutionMapping> extractSolMaps( final SolMapsResponse response )
@@ -46,7 +46,7 @@ public abstract class BaseForExecOpIndexNestedLoopsJoinWithSolMapsRequests<Query
 
 			@Override
 			protected void processExtractedSolMaps( final Iterable<SolutionMapping> solmaps ) {
-				log.info( "Merging solution mappings with input mapping." );
+				log.debug( "Merging solution mappings with input mapping." );
 				for ( final SolutionMapping fetchedSM : solmaps ) {
 					final SolutionMapping out = SolutionMappingUtils.merge( sm, fetchedSM );
 					sink.send( out );

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpParallelBindJoinSPARQL.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpParallelBindJoinSPARQL.java
@@ -35,13 +35,6 @@ public abstract class BaseForExecOpParallelBindJoinSPARQL
 	                                            final boolean collectExceptions,
 	                                            final QueryPlanningInfo qpInfo ) {
 		super(p, p.getAllMentionedVariables(), fm, inputVars, useOuterJoinSemantics, mayReduce, batchSize, collectExceptions, qpInfo);
-
-		log.info(
-			"Initialized parallel SPARQL bind-join base for endpoint {} (outerJoin={}, mayReduce={}, batchSize={})",
-			fm,
-			useOuterJoinSemantics,
-			mayReduce,
-			batchSize );
 	}
 
 	@Override
@@ -52,7 +45,7 @@ public abstract class BaseForExecOpParallelBindJoinSPARQL
 
 	@Override
 	protected NullaryExecutableOp createExecutableReqOpForAll() {
-		log.info( "Creating FULL RETRIEVAL SPARQL request for endpoint {}", fm );
+		log.debug( "Creating FULL RETRIEVAL SPARQL request for endpoint {}", fm );
 
 		final SPARQLRequest req = new SPARQLRequestImpl(query);
 		return new ExecOpRequestSPARQL<>(req, fm, this.mayReduce, false, null);

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpRequestWithTPFPaging.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpRequestWithTPFPaging.java
@@ -48,7 +48,7 @@ public abstract class BaseForExecOpRequestWithTPFPaging<
 	protected final void _execute( final IntermediateResultElementSink sink,
 	                               final ExecutionContext execCxt ) throws ExecOpExecutionException
 	{
-		log.info( "Starting paging request execution for {}", fm );
+		log.debug( "Starting paging request execution for {}", fm );
 
 		TPFResponse currentPage = null;
 		while ( currentPage == null || ! isLastPage(currentPage) ) {
@@ -91,7 +91,7 @@ public abstract class BaseForExecOpRequestWithTPFPaging<
 			consumeMatchingTriples( triples, sink );
 		}
 
-		log.info(
+		log.debug(
 			"Completed request execution for {}: pages={}, triples={}, outputMappings={}",
 			fm,
 			numberOfPageRequestsIssued,

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpSequentialBindJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpSequentialBindJoin.java
@@ -237,7 +237,7 @@ public abstract class BaseForExecOpSequentialBindJoin<
 		// in which case we can find the join partners for the given input
 		// solution mapping within the full result that we had to retrieve.
 		if ( fullResult != null ) {
-			log.info( "Using FULL RETRIEVAL join mode for endpoint {}", fm );
+			log.debug( "Using FULL RETRIEVAL join mode for endpoint {}", fm );
 			joinInFullRetrievalMode(inputSolMap, sink);
 			return;
 		}
@@ -338,7 +338,7 @@ public abstract class BaseForExecOpSequentialBindJoin<
 		// If we have accumulated enough solution mappings for the next
 		// bind-join request, then let's perform this request.
 		if ( currentSolMapsForRequest.size() == requestBlockSize ) {
-			log.info(
+			log.debug(
 				"Triggering bind-join request for endpoint {} with batch size {}",
 				fm,
 				currentSolMapsForRequest.size() );
@@ -395,7 +395,7 @@ public abstract class BaseForExecOpSequentialBindJoin<
 
 		numOfSolMapsRetrievedPerReqOp.add( (Long) statsOfLastReqOp.getEntry("numberOfOutputMappingsProduced") );
 
-		log.info( "Completed bind-join request for endpoint {} (results from request-op={})", fm, reqOp.getStats() );
+		log.debug( "Completed bind-join request for endpoint {} (results from request-op={})", fm, reqOp.getStats() );
 	}
 
 	protected boolean alreadyCovered( final Binding inputSolMapRestricted ) {
@@ -452,7 +452,7 @@ public abstract class BaseForExecOpSequentialBindJoin<
 	protected boolean reduceRequestBlockSize() {
 		final int newRequestBlockSize = requestBlockSize / 2;
 
-		log.info(
+		log.debug(
 			"Reducing request block size for endpoint {}: new size={}, minimum={}",
 			fm,
 			newRequestBlockSize,
@@ -601,7 +601,7 @@ public abstract class BaseForExecOpSequentialBindJoin<
 	protected void switchToFullRetrievalMode( final ExecutionContext execCxt )
 			throws ExecOpExecutionException
 	{
-		log.info(
+		log.debug(
 			"Switching to FULL RETRIEVAL mode for endpoint {} (joinVars={}, batchSize={})",
 			fm,
 			varsInQuery,

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpSequentialBindJoinSPARQL.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForExecOpSequentialBindJoinSPARQL.java
@@ -29,18 +29,11 @@ public abstract class BaseForExecOpSequentialBindJoinSPARQL extends BaseForExecO
 			final boolean collectExceptions,
 			final QueryPlanningInfo qpInfo ) {
 		super(p, p.getAllMentionedVariables(), fm, inputVars, useOuterJoinSemantics, mayReduce, batchSize, collectExceptions, qpInfo);
-
-		log.info(
-			"Initialized sequential SPARQL bind-join base operator for endpoint {} (batchSize={}, outerJoin={}, mayReduce={})",
-			fm,
-			batchSize,
-			useOuterJoinSemantics,
-			mayReduce );
 	}
 
 	@Override
 	protected NullaryExecutableOp createExecutableReqOpForAll() {
-		log.info( "Creating non-batched SPARQL request operator for endpoint {}", fm );
+		log.debug( "Creating non-batched SPARQL request operator for endpoint {}", fm );
 		final SPARQLRequest req = new SPARQLRequestImpl(query);
 		return new ExecOpRequestSPARQL<>(req, fm, this.mayReduce, false, null);
 	}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForUnaryExecOpWithCollectedInput.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForUnaryExecOpWithCollectedInput.java
@@ -56,11 +56,6 @@ public abstract class BaseForUnaryExecOpWithCollectedInput extends UnaryExecutab
 
 		this.minimumCollectionSize = minimumCollectionSize;
 		collectedInputSolMaps = new ArrayList<>(minimumCollectionSize);
-
-		log.info(
-			"Initialized unary batching operator: minimumCollectionSize={}, mayReduce={}.",
-			minimumCollectionSize,
-			mayReduce );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BinaryExecutableOpBase.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BinaryExecutableOpBase.java
@@ -2,9 +2,6 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.BinaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
@@ -32,8 +29,6 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
  */
 public abstract class BinaryExecutableOpBase extends BaseForExecOps implements BinaryExecutableOp
 {
-	private static final Logger log = LoggerFactory.getLogger( BinaryExecutableOpBase.class );
-
 	private boolean leftInputConsumed           = false;
 	private boolean rightInputConsumed          = false;
 
@@ -53,11 +48,6 @@ public abstract class BinaryExecutableOpBase extends BaseForExecOps implements B
 	                               final boolean collectExceptions,
 	                               final QueryPlanningInfo qpInfo ) {
 		super(mayReduce, collectExceptions, qpInfo);
-
-		log.info(
-			"Initialized {} with collectExceptions={}.",
-			getClass().getSimpleName(),
-			collectExceptions );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBinaryUnion.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBinaryUnion.java
@@ -21,7 +21,7 @@ public class ExecOpBinaryUnion extends BinaryExecutableOpBase
 	                          final QueryPlanningInfo qpInfo ) {
 		super(mayReduce, collectExceptions, qpInfo);
 
-		log.info(
+		log.debug(
 			"Initialized ExecOpBinaryUnion (mayReduce={}, collectExceptions={}).",
 			mayReduce,
 			collectExceptions );

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBind.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBind.java
@@ -39,7 +39,7 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 	                   final QueryPlanningInfo qpInfo ) {
 		super(mayReduce, collectExceptions, qpInfo);
 
-		log.info( "Initialized ExecOpBind with {} bind expression(s).", bindExpressions.size() );
+		log.debug( "Initialized ExecOpBind with {} bind expression(s).", bindExpressions.size() );
 
 		if ( bindExpressions.size() == 1 ) {
 			final Var var = bindExpressions.getVars().get(0);
@@ -61,7 +61,7 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 		assert var != null;
 		assert expr != null;
 
-		log.info( "Initialized ExecOpBind for variable {} with expression {}.", var, expr );
+		log.debug( "Initialized ExecOpBind for variable {} with expression {}.", var, expr );
 
 		worker = new OneVarWorker(var, expr);
 	}
@@ -140,7 +140,7 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 		public SolutionMapping extend( final SolutionMapping solmap )
 				 throws ExecOpExecutionException
 		{
-			log.info( "Evaluating bind expression {} for variable {}.", expr, var );
+			log.debug( "Evaluating bind expression {} for variable {}.", expr, var );
 			final Binding sm = solmap.asJenaBinding();
 
 			if ( sm.contains(var) ) {
@@ -155,10 +155,10 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 			catch ( final Exception ex ) {
 				// If evaluating the expression based on the current input solution
 				// mapping failed, pass on the solution mapping without extending it.
-				log.info( "Evaluation failed for variable {}. Returning original solution mapping.", var );
+				log.debug( "Evaluation failed for variable {}. Returning original solution mapping.", var );
 				return solmap;
 			}
-			log.info( "Successfully evaluated expression for variable {}.", var );
+			log.debug( "Successfully evaluated expression for variable {}.", var );
 
 			final Binding smOut = BindingFactory.binding( sm, var, evaluationResult.asNode() );
 			return new SolutionMappingImpl(smOut);
@@ -176,7 +176,7 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 		public SolutionMapping extend( final SolutionMapping solmap )
 				 throws ExecOpExecutionException
 		{
-			log.info( "Evaluating multiple bind expressions." );
+			log.debug( "Evaluating multiple bind expressions." );
 
 			// This Binding will be replaced by extended versions of
 			// it within the following for-loop. Extending it stepwise
@@ -191,10 +191,10 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 				final Var var = e.getKey();
 				final Expr expr = e.getValue();
 
-				log.info( "Evaluating bind expression {} for variable {}.", expr, var );
+				log.debug( "Evaluating bind expression {} for variable {}.", expr, var );
 
 				if ( sm.contains(var) ) {
-					log.info( "Cannot bind variable {} because it is already bound.", var );
+					log.debug( "Cannot bind variable {} because it is already bound.", var );
 					throwExecOpExecutionException( "Variable '" + var.getVarName() + "' already bound in the given solution mapping." );
 				}
 
@@ -206,19 +206,19 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 					sm = BindingFactory.binding(sm, var, evaluationResult.asNode() );
 					extended = true;
 
-					log.info( "Successfully extended solution mapping with variable {}.", var );
+					log.debug( "Successfully extended solution mapping with variable {}.", var );
 				}
 				catch ( final Exception ex ) {
 					// If evaluating the expression based on the current
 					// input solution mapping failed, then do nothing.
-					log.info( "Evaluation failed for variable {}. Skipping extension.", var );
+					log.debug( "Evaluation failed for variable {}. Skipping extension.", var );
 				}
 			}
 
 			if ( extended )
 				return new SolutionMappingImpl(sm);
 			else {
-				log.info( "No bind expressions could be evaluated successfully." );
+				log.debug( "No bind expressions could be evaluated successfully." );
 				return solmap;
 			}
 		}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpDuplicateRemoval.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpDuplicateRemoval.java
@@ -30,13 +30,14 @@ public class ExecOpDuplicateRemoval extends UnaryExecutableOpBase
 	                     final QueryPlanningInfo qpInfo ) {
 		super(true, collectExceptions, qpInfo);
 
-		log.info( "Initialized ExecOpDuplicateRemoval (collectExceptions={}).", collectExceptions );
+		log.debug( "Initialized ExecOpDuplicateRemoval (collectExceptions={}).", collectExceptions );
 	}
 
 	@Override
 	protected void _process( final SolutionMapping inputSolMap,
 	                         final IntermediateResultElementSink sink,
 	                         final ExecutionContext execCxt ) {
+		log.info( "Processing solution mapping in ExecOpDuplicateRemoval." );
 		if ( distinctSolMaps.add(inputSolMap) ) {
 			sink.send(inputSolMap);
 			numberOfOutputMappingsProduced++;

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpFilter.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpFilter.java
@@ -35,7 +35,7 @@ public class ExecOpFilter extends UnaryExecutableOpBaseWithoutBlocking
 
 		this.filterExpressions = filterExpressions;
 
-		log.info(
+		log.debug(
 			"Initialized ExecOpFilter with {} expressions, mayReduce={}, collectExceptions={}.",
 			filterExpressions.size(),
 			mayReduce,
@@ -52,7 +52,7 @@ public class ExecOpFilter extends UnaryExecutableOpBaseWithoutBlocking
 
 		this.filterExpressions = new ExprList(filterExpression);
 
-		log.info(
+		log.debug(
 			"Initialized ExecOpFilter with one expression, mayReduce={}, collectExceptions={}.",
 			mayReduce,
 			collectExceptions );
@@ -89,7 +89,7 @@ public class ExecOpFilter extends UnaryExecutableOpBaseWithoutBlocking
 			}
 		}
 
-		log.info( "Processing batch of {} solution mappings.", cnt );
+		log.info( "Processing batch of {} solution mappings in ExecOpFilter.", cnt );
 
 		// Continue consuming the rest of the batch (if any). If we find
 		// further solution mappings that can be passed on as output, we

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpGlobalToLocal.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpGlobalToLocal.java
@@ -31,7 +31,7 @@ public class ExecOpGlobalToLocal extends UnaryExecutableOpBaseWithoutBlocking
 		assert vm != null;
 		this.vm = vm;
 
-		log.info(
+		log.debug(
 			"Initialized ExecOpGlobalToLocal with VocabularyMapping {} (class={}).",
 			vm,
 			vm.getClass().getSimpleName() );
@@ -41,6 +41,7 @@ public class ExecOpGlobalToLocal extends UnaryExecutableOpBaseWithoutBlocking
 	protected void _process( final SolutionMapping inputSolMap,
 	                         final IntermediateResultElementSink sink,
 	                         final ExecutionContext execCxt ) {
+		log.info( "Processing solution mapping in ExecOpGlobalToLocal." );
 		final Set<SolutionMapping> output = vm.translateSolutionMappingFromGlobal(inputSolMap);
 		numberOfOutputMappingsProduced += output.size();
 		sink.send(output);

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashBasedMinus.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashBasedMinus.java
@@ -26,7 +26,7 @@ public class ExecOpHashBasedMinus extends ExecOpHashJoin2
 	                             final QueryPlanningInfo qpInfo ) {
 		super(true, mayReduce, inputVars1, inputVars2, collectExceptions, qpInfo);
 
-		log.info(
+		log.debug(
 			"Initialized ExecOpHashBasedMinus with mayReduce={}, inputVarsLeft={}, inputVarsRight={}",
 			mayReduce,
 			inputVars1,

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashJoin1.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashJoin1.java
@@ -32,7 +32,7 @@ public class ExecOpHashJoin1 extends BaseForExecOpHashJoin
 	                        final QueryPlanningInfo qpInfo ) {
 		super(mayReduce, inputVars1, inputVars2, collectExceptions, qpInfo);
 
-		log.info( "Initialized ExecOpHashJoin1." );
+		log.debug( "Initialized ExecOpHashJoin1." );
 	}
 
 	@Override
@@ -115,7 +115,7 @@ public class ExecOpHashJoin1 extends BaseForExecOpHashJoin
 		for ( final SolutionMapping smL : matchSolMapL ){
 			output.add( SolutionMappingUtils.merge(smL,inputSolMap) );
 		}
-		log.info( "Produced {} joined solution mappings.", output.size() - sizeBefore );
+		log.debug( "Produced {} joined solution mappings.", output.size() - sizeBefore );
 	}
 
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashJoin2.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashJoin2.java
@@ -37,7 +37,7 @@ public class ExecOpHashJoin2 extends BaseForExecOpHashJoin
 
 		this.useOuterJoinSemantics = useOuterJoinSemantics;
 
-		log.info( "Initialized ExecOpHashJoin2 with useOuterJoinSemantics: {}.", useOuterJoinSemantics );
+		log.debug( "Initialized ExecOpHashJoin2 with useOuterJoinSemantics: {}.", useOuterJoinSemantics );
 	}
 
 	@Override
@@ -124,10 +124,10 @@ public class ExecOpHashJoin2 extends BaseForExecOpHashJoin
 		}
 
 		if ( useOuterJoinSemantics && ! hasJoinPartner ) {
-			log.info( "No join partner found. Applying outer join semantics." );
+			log.debug( "No join partner found. Applying outer join semantics." );
 			output.add(inputSolMap);
 		}
-		log.info( "Produced {} joined solution mappings.", output.size() - sizeBefore );
+		log.debug( "Produced {} joined solution mappings.", output.size() - sizeBefore );
 	}
 
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinSPARQL.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinSPARQL.java
@@ -33,7 +33,7 @@ public class ExecOpIndexNestedLoopsJoinSPARQL extends BaseForExecOpIndexNestedLo
 	                                         final QueryPlanningInfo qpInfo ) {
 		super(query, fm, mayReduce, minimumInputBlockSize, collectExceptions, qpInfo);
 
-		log.info( "Initialized ExecOpIndexNestedLoopsJoinSPARQL for endpoint {}.", fm );
+		log.debug( "Initialized ExecOpIndexNestedLoopsJoinSPARQL for endpoint {}.", fm );
 
 		// TODO extend this implementation to support outer join semantics similar
 		// to how it is implemented in ExecOpGenericIndexNestedLoopsJoinWithRequestOps

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinTPF.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpIndexNestedLoopsJoinTPF.java
@@ -41,7 +41,7 @@ public class ExecOpIndexNestedLoopsJoinTPF
 	                                      final QueryPlanningInfo qpInfo ) {
 		super(query, fm, useOuterJoinSemantics, mayReduce, minimumInputBlockSize, collectExceptions, qpInfo);
 
-		log.info("Initialized ExecOpIndexNestedLoopsJoinTPF for server {}", fm);
+		log.debug("Initialized ExecOpIndexNestedLoopsJoinTPF for server {}", fm);
 	}
 
 	public ExecOpIndexNestedLoopsJoinTPF( final TriplePattern query,
@@ -52,7 +52,7 @@ public class ExecOpIndexNestedLoopsJoinTPF
 	                                      final QueryPlanningInfo qpInfo ) {
 		super(query, fm, useOuterJoinSemantics, mayReduce, DEFAULT_INPUT_BLOCK_SIZE, collectExceptions, qpInfo);
 
-		log.info("Initialized ExecOpIndexNestedLoopsJoinTPF for server {}", fm);
+		log.debug("Initialized ExecOpIndexNestedLoopsJoinTPF for server {}", fm);
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLocalToGlobal.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLocalToGlobal.java
@@ -31,7 +31,7 @@ public class ExecOpLocalToGlobal extends UnaryExecutableOpBaseWithoutBlocking
 		assert vm != null;
 		this.vm = vm;
 
-		log.info(
+		log.debug(
 			"Initialized ExecOpLocalToGlobal with VocabularyMapping {} (class={}).",
 			vm,
 			vm.getClass().getSimpleName() );
@@ -41,6 +41,7 @@ public class ExecOpLocalToGlobal extends UnaryExecutableOpBaseWithoutBlocking
 	protected void _process( final SolutionMapping inputSolMap,
 	                         final IntermediateResultElementSink sink,
 	                         final ExecutionContext execCxt ) {
+		log.info( "Processing solution mapping in ExecOpLocalToGlobal." );
 		final Set<SolutionMapping> output = vm.translateSolutionMapping(inputSolMap);
 		numberOfOutputMappingsProduced += output.size();
 		sink.send(output);

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLookupJoinViaWrapperWithParamVars.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLookupJoinViaWrapperWithParamVars.java
@@ -114,7 +114,7 @@ public class ExecOpLookupJoinViaWrapperWithParamVars
 			this.paramVars.put(paramDecl, paramVar);
 		}
 
-		log.info( "Initialized ExecOpLookupJoinViaWrapperWithParamVars for endpoint {}", fm );
+		log.debug( "Initialized ExecOpLookupJoinViaWrapperWithParamVars for endpoint {}", fm );
 	}
 
 	@Override
@@ -140,7 +140,7 @@ public class ExecOpLookupJoinViaWrapperWithParamVars
 			if ( cachedResult != null ) {
 				// ... we can join the current solution mapping with the
 				// result that has been cached earlier.
-				log.info( "Cache hit for param values {} (endpoint={})", paramValues, fm );
+				log.debug( "Cache hit for param values {} (endpoint={})", paramValues, fm );
 				join(cachedResult, sm, sink);
 			}
 			else {
@@ -148,7 +148,7 @@ public class ExecOpLookupJoinViaWrapperWithParamVars
 				// for an earlier batch, then remember them, together with
 				// the current solution mapping, for further processing
 				// after this for loop.
-				log.info( "Cache miss for param values {}, issuing request to {}", paramValues, fm );
+				log.debug( "Cache miss for param values {}, issuing request to {}", paramValues, fm );
 				List<SolutionMapping> solmaps = paramsForRequests.get(paramValues);
 				if ( solmaps == null ) {
 					solmaps = new ArrayList<>();
@@ -176,12 +176,12 @@ public class ExecOpLookupJoinViaWrapperWithParamVars
 				f = execCxt.getFederationAccessMgr().issueRequest(req, fm);
 			}
 			catch ( final FederationAccessException e ) {
-				log.info( "Request issuance failed for endpoint {} (paramValues={})", fm, entry.getKey() );
+				log.debug( "Request issuance failed for endpoint {} (paramValues={})", fm, entry.getKey() );
 				throw new ExecOpExecutionException("Issuing a request caused an exception.", e, this);
 			}
 
 			numberOfRequestsIssued++;
-			log.info( "Issued request #{} to {}", numberOfRequestsIssued, fm );
+			log.debug( "Issued request #{} to {}", numberOfRequestsIssued, fm );
 
 			// attach the processing of the response obtained for the request
 			final MyResponseProcessor respProc = new MyResponseProcessor(
@@ -191,7 +191,7 @@ public class ExecOpLookupJoinViaWrapperWithParamVars
 
 
 		// Wait for all the futures to be completed.
-		log.info( "Waiting for {} async requests to complete for {}", futures.length, fm );
+		log.debug( "Waiting for {} async requests to complete for {}", futures.length, fm );
 		try {
 			CompletableFuture.allOf(futures).get();
 		}
@@ -331,7 +331,7 @@ public class ExecOpLookupJoinViaWrapperWithParamVars
 			}
 			catch ( final DataConversionException e ) {
 				numberOfDataConversionExceptions.incrementAndGet();
-				log.info( "Data conversion failed for endpoint {} (paramValues={})", fm, paramValues );
+				log.debug( "Data conversion failed for endpoint {} (paramValues={})", fm, paramValues );
 				final ExecOpExecutionException ex = new ExecOpExecutionException( "Converting the reponse of a REST request into RDF failed (message: " + e.getMessage() + ").", e, op );
 				recordExceptionCaughtDuringExecution( ex );
 				return;

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLookupJoinViaWrapperWithoutParamVars.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLookupJoinViaWrapperWithoutParamVars.java
@@ -60,7 +60,7 @@ public class ExecOpLookupJoinViaWrapperWithoutParamVars
 		this.pattern = pattern;
 		this.fm = fm;
 
-		log.info( "Initialized ExecOpLookupJoinViaWrapperWithoutParamVars for endpoint {}", fm );
+		log.debug( "Initialized ExecOpLookupJoinViaWrapperWithoutParamVars for endpoint {}", fm );
 	}
 
 	@Override
@@ -92,7 +92,7 @@ public class ExecOpLookupJoinViaWrapperWithoutParamVars
 	protected List<SolutionMapping> performRequest( final ExecutionContext execCxt )
 			throws ExecOpExecutionException
 	{
-		log.info( "Sending REST request to {}", fm.getURLTemplate() );
+		log.debug( "Sending REST request to {}", fm.getURLTemplate() );
 
 		final RESTRequest req = new RESTRequestImpl( fm.getURLTemplate() );
 
@@ -142,7 +142,7 @@ public class ExecOpLookupJoinViaWrapperWithoutParamVars
 		requestExecTime = time2 - time1;
 		responseProcTime = time3 - time2;
 		numOfSolMapsFromRequest = result.size();
-		log.info( "Lookup join received {} solution mappings from {}", result.size(), fm );
+		log.debug( "Lookup join received {} solution mappings from {}", result.size(), fm );
 		return result;
 	}
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpNaiveNestedLoopsJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpNaiveNestedLoopsJoin.java
@@ -35,7 +35,7 @@ public class ExecOpNaiveNestedLoopsJoin extends BinaryExecutableOpBase
 	                                   final QueryPlanningInfo qpInfo ) {
 		super(mayReduce, collectExceptions, qpInfo);
 
-		log.info( "Initialized ExecOpNaiveNestedLoopsJoin." );
+		log.debug( "Initialized ExecOpNaiveNestedLoopsJoin." );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelBindJoinSPARQLwithFILTER.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelBindJoinSPARQLwithFILTER.java
@@ -68,7 +68,7 @@ public class ExecOpParallelBindJoinSPARQLwithFILTER
 
 		pattern = QueryPatternUtils.convertToJenaElement(query);
 
-		log.info(
+		log.debug(
 			"Initialized ExecOpParallelBindJoinSPARQLwithFILTER for endpoint {} (patternType={}, batchSize={}, outerJoin={})",
 			fm,
 			pattern.getClass().getSimpleName(),
@@ -78,7 +78,7 @@ public class ExecOpParallelBindJoinSPARQLwithFILTER
 
 	@Override
 	protected SPARQLRequest createRequest( final Set<Binding> batch ) {
-		log.info(
+		log.debug(
 			"Creating parallel FILTER-based SPARQL bind-join request with {} bindings for endpoint {}",
 			batch.size(),
 			fm );

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelBindJoinSPARQLwithUNION.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelBindJoinSPARQLwithUNION.java
@@ -67,7 +67,7 @@ public class ExecOpParallelBindJoinSPARQLwithUNION
 
 		pattern = QueryPatternUtils.convertToJenaElement(query);
 
-		log.info(
+		log.debug(
 			"Initialized ExecOpParallelBindJoinSPARQLwithUNION for endpoint {} (patternType={}, batchSize={}, outerJoin={})",
 			fm,
 			pattern.getClass().getSimpleName(),
@@ -77,7 +77,7 @@ public class ExecOpParallelBindJoinSPARQLwithUNION
 
 	@Override
 	protected SPARQLRequest createRequest( final Set<Binding> batch ) {
-		log.info(
+		log.debug(
 			"Creating parallel UNION-based SPARQL bind-join request with {} bindings for endpoint {}",
 			batch.size(),
 			fm );

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelBindJoinSPARQLwithVALUES.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelBindJoinSPARQLwithVALUES.java
@@ -68,7 +68,7 @@ public class ExecOpParallelBindJoinSPARQLwithVALUES
 
 		pattern = QueryPatternUtils.convertToJenaElement(query);
 
-		log.info(
+		log.debug(
 			"Initialized ExecOpParallelBindJoinSPARQLwithVALUES for endpoint {} (patternType={}, batchSize={}, outerJoin={})",
 			fm,
 			pattern.getClass().getSimpleName(),
@@ -78,7 +78,7 @@ public class ExecOpParallelBindJoinSPARQLwithVALUES
 
 	@Override
 	protected SPARQLRequest createRequest( final Set<Binding> batch ) {
-		log.info(
+		log.debug(
 			"Creating parallel VALUES-based SPARQL bind-join request with {} bindings for endpoint {}",
 			batch.size(),
 			fm );

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoin.java
@@ -96,13 +96,13 @@ public class ExecOpParallelMultiwayLeftJoin extends BaseForUnaryExecOpWithCollec
 			}
 		}
 
-		log.info(
+		log.debug(
 			"Initialized ExecOpParallelMultiwayLeftJoin with {} optional parts and {} join vars: {}.",
 			optionalParts.size(),
 			joinVars.size(),
 			joinVars );
 
-		log.info(
+		log.debug(
 			"Selected index implementation {} for {} join variables.",
 			indexes.get(0).getClass().getSimpleName(),
 			joinVars.size() );
@@ -154,7 +154,7 @@ public class ExecOpParallelMultiwayLeftJoin extends BaseForUnaryExecOpWithCollec
 
 	protected void parallelPhase( final List<SolutionMapping> inputForParallelProcess,
 	                              final ExecutionContext execCxt ) throws ExecOpExecutionException {
-		log.info( "Starting parallel phase with {} workers.", optionalParts.size() );
+		log.debug( "Starting parallel phase with {} workers.", optionalParts.size() );
 		// begin the parallel phase by starting the workers for the optional parts
 		final CompletableFuture<?>[] futures = new CompletableFuture<?>[ optionalParts.size() ];
 		for ( int i = 0; i < optionalParts.size(); i++ ) {
@@ -179,17 +179,17 @@ public class ExecOpParallelMultiwayLeftJoin extends BaseForUnaryExecOpWithCollec
 				throw new ExecOpExecutionException("The execution of the futures that run the executable operators caused an exception.", e, this);
 			}
 		}
-		log.info( "Parallel phase completed." );
+		log.debug( "Parallel phase completed." );
 	}
 
 	protected void mergePhase( final Iterable<SolutionMapping> inputSolMaps,
 	                           final IntermediateResultElementSink sink ) {
-		log.info( "Starting merge phase." );
+		log.debug( "Starting merge phase." );
 		for( final SolutionMapping inputSolMap : inputSolMaps ) {
 			final Set<SolutionMapping> outputSolMaps = merge(inputSolMap);
 			sink.send(outputSolMaps);
 		}
-		log.info( "Merge phase completed." );
+		log.debug( "Merge phase completed." );
 	}
 
 	protected Set<SolutionMapping> merge( final SolutionMapping inputSol ) {
@@ -265,7 +265,7 @@ public class ExecOpParallelMultiwayLeftJoin extends BaseForUnaryExecOpWithCollec
 
 		@Override
 		public void run() {
-			log.info(
+			log.debug(
 				"Worker started processing {} input solution mappings.",
 				input.size() );
 			try {
@@ -273,10 +273,10 @@ public class ExecOpParallelMultiwayLeftJoin extends BaseForUnaryExecOpWithCollec
 				execOp.concludeExecution(mySink, execCxt);
 			}
 			catch ( final ExecOpExecutionException e ) {
-				log.info( "Worker execution failed." );
+				log.debug( "Worker execution failed." );
 				throw new RuntimeException("Executing an add operator used by this parallel multi left join caused an exception.", e);
 			}
-			log.info( "Worker completed successfully." );
+			log.debug( "Worker completed successfully." );
 		}
 	}
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpProject.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpProject.java
@@ -39,7 +39,7 @@ public class ExecOpProject extends UnaryExecutableOpBaseWithoutBlocking
 
 		this.variables = variables;
 
-		log.info(
+		log.debug(
 			"Initialized ExecOpProject with {} projection variables: {}.",
 			variables.size(),
 			variables );

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestBRTPF.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestBRTPF.java
@@ -25,7 +25,7 @@ public class ExecOpRequestBRTPF extends BaseForExecOpRequestWithTPFPaging<Bindin
 	                           final QueryPlanningInfo qpInfo ) {
 		super(req, fm, mayReduce, collectExceptions, qpInfo);
 
-		log.info( "Initialized ExecOpRequestBRTPF for server {}", fm );
+		log.debug( "Initialized ExecOpRequestBRTPF for server {}", fm );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestOther.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestOther.java
@@ -37,7 +37,7 @@ public class ExecOpRequestOther extends BaseForExecOpRequest<SPARQLRequest,
 
 		assert fm.getNumberOfParameters() != 0;
 
-		log.info( "Initialized ExecOpRequestOther for {}", fm );
+		log.debug( "Initialized ExecOpRequestOther for {}", fm );
 	}
 
 	@Override
@@ -45,7 +45,7 @@ public class ExecOpRequestOther extends BaseForExecOpRequest<SPARQLRequest,
 	                               final ExecutionContext execCxt )
 		throws ExecOpExecutionException
 	{
-		log.info( "Issuing REST request to endpoint {}", fm.getURLTemplate() );
+		log.debug( "Issuing REST request to endpoint {}", fm.getURLTemplate() );
 
 		final StringResponse response;
 		try {
@@ -66,7 +66,7 @@ public class ExecOpRequestOther extends BaseForExecOpRequest<SPARQLRequest,
 			throw new ExecOpExecutionException( "Accessing the response data caused an exception, which indicates a data retrieval error (message: " + e.getMessage() + ").", e, this );
 		}
 
-		log.info( "Received REST response from {}", fm.getURLTemplate() );
+		log.debug( "Received REST response from {}", fm.getURLTemplate() );
 
 		process(data, sink);
 	}
@@ -88,7 +88,7 @@ public class ExecOpRequestOther extends BaseForExecOpRequest<SPARQLRequest,
 
 		final int cnt = sink.send(solmaps);
 		numberOfOutputMappingsProduced += cnt;
-		log.info( "Processed REST response: produced {} solution mappings", numberOfOutputMappingsProduced );
+		log.debug( "Processed REST response: produced {} solution mappings", numberOfOutputMappingsProduced );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestSPARQL.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestSPARQL.java
@@ -32,14 +32,14 @@ public class ExecOpRequestSPARQL<ReqType extends DataRetrievalRequest,
 	                            final QueryPlanningInfo qpInfo ) {
 		super(req, fm, mayReduce, collectExceptions, qpInfo);
 
-		log.info( "Initialized ExecOpRequestSPARQL for {}", fm );
+		log.debug( "Initialized ExecOpRequestSPARQL for {}", fm );
 	}
 
 	@Override
 	protected final void _execute( final IntermediateResultElementSink sink, final ExecutionContext execCxt )
 		throws ExecOpExecutionException
 	{
-		log.info( "Starting SPARQL request execution for {}", fm );
+		log.debug( "Starting SPARQL request execution for {}", fm );
 
 		final SolMapsResponse response;
 		try {
@@ -58,7 +58,7 @@ public class ExecOpRequestSPARQL<ReqType extends DataRetrievalRequest,
 
 		process(response, sink);
 
-		log.info(
+		log.debug(
 			"Completed SPARQL request execution for {}: solMaps={}, outputMappings={}",
 			fm,
 			solMapsRetrieved,

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestTPF.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestTPF.java
@@ -30,7 +30,7 @@ public class ExecOpRequestTPF<MemberType extends FederationMember>
 	                         final QueryPlanningInfo qpInfo ) {
 		super(req, fm, mayReduce, collectExceptions, qpInfo);
 
-		log.info( "Initialized ExecOpRequestBRTPF for server {}", fm );
+		log.debug( "Initialized ExecOpRequestBRTPF for server {}", fm );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSequentialBindJoinBRTPF.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSequentialBindJoinBRTPF.java
@@ -85,7 +85,7 @@ public class ExecOpSequentialBindJoinBRTPF
 			final QueryPlanningInfo qpInfo ) {
 		super( tp, tp.getAllMentionedVariables(), fm, inputVars, useOuterJoinSemantics, mayReduce, batchSize, collectExceptions, qpInfo );
 
-		log.info(
+		log.debug(
 			"Initialized ExecOpSequentialBindJoinBRTPF for pattern {} on server {} (batchSize={}, outerJoin={})",
 			tp,
 			fm,
@@ -98,7 +98,7 @@ public class ExecOpSequentialBindJoinBRTPF
 		// If there is only a single solution mapping, we
 		// do a TPF request instead of a brTPF request.
 		if ( solMaps.size() == 1 ) {
-			log.info( "Using TPF request (single binding) for server {} (pattern={})", fm, query );
+			log.debug( "Using TPF request (single binding) for server {} (pattern={})", fm, query );
 			final Binding sm = solMaps.iterator().next();
 			final TriplePattern restrictedTP;
 			try {
@@ -115,14 +115,14 @@ public class ExecOpSequentialBindJoinBRTPF
 			return new ExecOpRequestTPF<>(req, fm, this.mayReduce, false, null );
 		}
 
-		log.info( "Using BRTPF request with {} bindings for server {}", solMaps.size(), fm );
+		log.debug( "Using BRTPF request with {} bindings for server {}", solMaps.size(), fm );
 		final BindingsRestrictedTriplePatternRequest req = new BindingsRestrictedTriplePatternRequestImpl(query, solMaps);
 		return new ExecOpRequestBRTPF(req, fm, this.mayReduce, false, null );
 	}
 
 	@Override
 	protected NullaryExecutableOp createExecutableReqOpForAll() {
-		log.info( "Using full TPF request (no bindings) for pattern {} on server {}", query, fm );
+		log.debug( "Using full TPF request (no bindings) for pattern {} on server {}", query, fm );
 		final TriplePatternRequest req = new TriplePatternRequestImpl(query);
 		return new ExecOpRequestTPF<>(req, fm, this.mayReduce, false, null );
 	}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSequentialBindJoinSPARQLwithFILTER.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSequentialBindJoinSPARQLwithFILTER.java
@@ -83,7 +83,7 @@ public class ExecOpSequentialBindJoinSPARQLwithFILTER
 
 		pattern = QueryPatternUtils.convertToJenaElement(query);
 
-		log.info(
+		log.debug(
 			"Initialized ExecOpSequentialBindJoinSPARQLwithFILTER for endpoint {} (patternType={}, batchSize={}, outerJoin={})",
 			fm,
 			pattern.getClass().getSimpleName(),
@@ -103,14 +103,14 @@ public class ExecOpSequentialBindJoinSPARQLwithFILTER
 	                                                         final Element pattern,
 	                                                         final SPARQLEndpoint fm,
 	                                                         final boolean mayReduce ) {
-		log.info( "Creating SPARQL request with {} bindings for endpoint {}", solMaps.size(), fm );
+		log.debug( "Creating SPARQL request with {} bindings for endpoint {}", solMaps.size(), fm );
 		final SPARQLRequest request = createRequest(solMaps, pattern);
 		return new ExecOpRequestSPARQL<>(request, fm, mayReduce, false, null);
 	}
 
 	public static SPARQLRequest createRequest( final Set<Binding> solMaps,
 	                                           final Element pattern ) {
-		log.info( "Building FILTER expression for {} solution mappings", solMaps.size() );
+		log.debug( "Building FILTER expression for {} solution mappings", solMaps.size() );
 		final Expr expr = createFilterExpression(solMaps);
 
 		final ElementGroup group = new ElementGroup();
@@ -118,7 +118,7 @@ public class ExecOpSequentialBindJoinSPARQLwithFILTER
 		group.addElement( new ElementFilter(expr) );
 
 		final SPARQLGraphPattern patternForReq = new GenericSPARQLGraphPatternImpl1(group);
-		log.info( "Constructed SPARQL FILTER request for {} bindings", solMaps.size() );
+		log.debug( "Constructed SPARQL FILTER request for {} bindings", solMaps.size() );
 		return new SPARQLRequestImpl(patternForReq);
 	}
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSequentialBindJoinSPARQLwithUNION.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSequentialBindJoinSPARQLwithUNION.java
@@ -81,7 +81,7 @@ public class ExecOpSequentialBindJoinSPARQLwithUNION
 
 		pattern = QueryPatternUtils.convertToJenaElement(query);
 
-		log.info(
+		log.debug(
 			"Initialized ExecOpSequentialBindJoinSPARQLwithUNION for endpoint {} (patternType={}, batchSize={}, outerJoin={})",
 			fm,
 			pattern.getClass().getSimpleName(),
@@ -91,7 +91,7 @@ public class ExecOpSequentialBindJoinSPARQLwithUNION
 
 	@Override
 	protected NullaryExecutableOp createExecutableReqOp( final Set<Binding> solMaps ) {
-		log.info( "Creating SPARQL request with {} bindings for endpoint {}", solMaps.size(), fm );
+		log.debug( "Creating SPARQL request with {} bindings for endpoint {}", solMaps.size(), fm );
 		final SPARQLRequest request = createRequest(solMaps, pattern, varsInQuery);
 		return new ExecOpRequestSPARQL<>(request, fm, this.mayReduce, false, null);
 	}
@@ -99,9 +99,9 @@ public class ExecOpSequentialBindJoinSPARQLwithUNION
 	public static SPARQLRequest createRequest( final Set<Binding> solMaps,
 	                                           final Element pattern,
 	                                           final Set<Var> varsInQuery ) {
-		log.info( "Building SPARQL UNION request for {} solution mappings", solMaps.size() );
+		log.debug( "Building SPARQL UNION request for {} solution mappings", solMaps.size() );
 		final Element elmt = createUnion(solMaps, pattern, varsInQuery);
-		log.info( "Constructed SPARQL UNION request for {} bindings", solMaps.size() );
+		log.debug( "Constructed SPARQL UNION request for {} bindings", solMaps.size() );
 		return new SPARQLRequestImpl( new GenericSPARQLGraphPatternImpl1(elmt) );
 	}
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSequentialBindJoinSPARQLwithVALUES.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSequentialBindJoinSPARQLwithVALUES.java
@@ -78,7 +78,7 @@ public class ExecOpSequentialBindJoinSPARQLwithVALUES
 
 		pattern = QueryPatternUtils.convertToJenaElement(query);
 
-		log.info(
+		log.debug(
 			"Initialized ExecOpSequentialBindJoinSPARQLwithVALUES for endpoint {} (patternType={}, batchSize={}, outerJoin={})",
 			fm,
 			pattern.getClass().getSimpleName(),
@@ -88,7 +88,7 @@ public class ExecOpSequentialBindJoinSPARQLwithVALUES
 
 	@Override
 	protected NullaryExecutableOp createExecutableReqOp( final Set<Binding> solMaps ) {
-		log.info( "Creating SPARQL request with {} bindings for endpoint {}", solMaps.size(), fm );
+		log.debug( "Creating SPARQL request with {} bindings for endpoint {}", solMaps.size(), fm );
 		return createExecutableReqOp(solMaps, pattern, fm, this.mayReduce);
 	}
 
@@ -103,7 +103,7 @@ public class ExecOpSequentialBindJoinSPARQLwithVALUES
 	public static SPARQLRequest createRequest( final Set<Binding> solMaps,
 	                                           final Element pattern ) {
 		// Create the VALUES clause.
-		log.info( "Creating VALUES clause for {} bindings", solMaps.size() );
+		log.debug( "Creating VALUES clause for {} bindings", solMaps.size() );
 		final Element valuesClause = createValuesClause(solMaps);
 
 		// Combine the VALUES clause with the graph pattern of this operator.
@@ -126,7 +126,7 @@ public class ExecOpSequentialBindJoinSPARQLwithVALUES
 			}
 		}
 
-		log.info("Constructed VALUES clause with {} join variables and {} bindings", joinVars.size(), solMaps.size());
+		log.debug("Constructed VALUES clause with {} join variables and {} bindings", joinVars.size(), solMaps.size());
 
 		// Create the VALUES clause.
 		return new ElementData( new ArrayList<>(joinVars), new ArrayList<>(solMaps) );

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSequentialBindJoinSPARQLwithVALUESorFILTER.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSequentialBindJoinSPARQLwithVALUESorFILTER.java
@@ -90,7 +90,7 @@ public class ExecOpSequentialBindJoinSPARQLwithVALUESorFILTER
 
 		pattern = QueryPatternUtils.convertToJenaElement(query);
 
-		log.info(
+		log.debug(
 			"Initialized ExecOpSequentialBindJoinSPARQLwithVALUESorFILTER for endpoint {} (patternType={}, batchSize={}, outerJoin={})",
 			fm,
 			pattern.getClass().getSimpleName(),
@@ -100,7 +100,7 @@ public class ExecOpSequentialBindJoinSPARQLwithVALUESorFILTER
 
 	@Override
 	protected NullaryExecutableOp createExecutableReqOp( final Set<Binding> solMaps ) {
-		log.info(
+		log.debug(
 			"Creating {}-based SPARQL bind-join request for {} bindings on endpoint {}",
 			useFilterBasedApproach ? "FILTER" : "VALUES",
 			solMaps.size(),
@@ -118,7 +118,7 @@ public class ExecOpSequentialBindJoinSPARQLwithVALUESorFILTER
 	                                                final ExecutionContext execCxt )
 			throws ExecOpExecutionException
 	{
-		log.info(
+		log.debug(
 			"Executing {}-based bind-join request (trialPhase={}, bindings={})",
 			useFilterBasedApproach ? "FILTER" : "VALUES",
 			trialPhase,
@@ -136,7 +136,7 @@ public class ExecOpSequentialBindJoinSPARQLwithVALUESorFILTER
 				throw new ExecOpExecutionException("Executing a request operator used by this bind join caused an exception.", e, this);
 			}
 
-			log.info(
+			log.debug(
 				"VALUES-based bind-join request failed for endpoint {}. Falling back to FILTER-based approach.",
 				fm,
 				e );
@@ -144,7 +144,7 @@ public class ExecOpSequentialBindJoinSPARQLwithVALUESorFILTER
 			trialPhase = false;
 			useFilterBasedApproach = true;
 
-			log.info( "Switched bind-join strategy to FILTER-based requests for endpoint {}", fm );
+			log.debug( "Switched bind-join strategy to FILTER-based requests for endpoint {}", fm );
 
 			statsOfLastReqOp = reqOp.getStats();
 			if ( statsOfFirstReqOp == null ) statsOfFirstReqOp = statsOfLastReqOp;
@@ -160,7 +160,7 @@ public class ExecOpSequentialBindJoinSPARQLwithVALUESorFILTER
 
 		statsOfLastReqOp = reqOp.getStats();
 		if ( statsOfFirstReqOp == null ) statsOfFirstReqOp = statsOfLastReqOp;
-		log.info(
+		log.debug(
 			"Successfully executed {}-based bind-join request for endpoint {}",
 			useFilterBasedApproach ? "FILTER" : "VALUES",
 			fm );

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSequentialBindJoinSPARQLwithVarRenaming.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSequentialBindJoinSPARQLwithVarRenaming.java
@@ -100,7 +100,7 @@ public class ExecOpSequentialBindJoinSPARQLwithVarRenaming
 		pattern = QueryPatternUtils.convertToJenaElement(query);
 
 		renamedVar = getVarForRenaming(query, inputVars);
-		log.info(
+		log.debug(
 			"Initialized ExecOpSequentialBindJoinSPARQLwithVarRenaming for endpoint {} (renamedVar={}, batchSize={}, outerJoin={})",
 			fm,
 			renamedVar,
@@ -110,7 +110,7 @@ public class ExecOpSequentialBindJoinSPARQLwithVarRenaming
 		if( renamedVar == null ){
 			// If there are no non-joining vars, we need to fall back to a non-renaming
 			// version of the bind join strategy.
-			log.info( "No suitable non-join variable found for renaming in query {}", query );
+			log.debug( "No suitable non-join variable found for renaming in query {}", query );
 			throw new IllegalArgumentException("No suitable variable found for renaming");
 		}
 		renamedVarPrefix = renamedVar.getVarName() + "_";
@@ -142,12 +142,12 @@ public class ExecOpSequentialBindJoinSPARQLwithVarRenaming
 
 	@Override
 	protected NullaryExecutableOp createExecutableReqOp( final Set<Binding> solMaps ) {
-		log.info(
+		log.debug(
 			"Creating UNION-based SPARQL bind-join request with {} bindings for endpoint {}",
 			solMaps.size(),
 			fm );
 		final Element elmt = createUnion(solMaps);
-		log.info(
+		log.debug(
 			"Created UNION pattern with {} branches using renamed variable prefix '{}'",
 			solMaps.size(),
 			renamedVarPrefix );
@@ -162,7 +162,7 @@ public class ExecOpSequentialBindJoinSPARQLwithVarRenaming
 		solMapsList.clear();
 		solMaps.forEach(solMapsList::add);
 
-		log.info( "Building UNION pattern for {} input solution mappings", solMapsList.size() );
+		log.debug( "Building UNION pattern for {} input solution mappings", solMapsList.size() );
 
 		// Union element
 		final ElementUnion union = new ElementUnion();
@@ -190,19 +190,19 @@ public class ExecOpSequentialBindJoinSPARQLwithVarRenaming
 
 			i++;
 
-			log.info(
+			log.debug(
 				"Renaming variable {} to {} for UNION branch {}",
 				renamedVar,
 				v,
 				i );
 		}
-		log.info( "Finished UNION construction with {} UNION branches", i );
+		log.debug( "Finished UNION construction with {} UNION branches", i );
 		return union;
 	}
 
 	@Override
 	protected MyIntermediateResultElementSink createMySink() {
-		log.info(
+		log.debug(
 			"Creating {} sink for var-renaming bind join",
 			useOuterJoinSemantics ? "outer-join" : "inner-join" );
 		if (useOuterJoinSemantics) {
@@ -230,7 +230,7 @@ public class ExecOpSequentialBindJoinSPARQLwithVarRenaming
 			// Resolve renamed var and merge with smFromRequest
 			final Binding renamedAndMerged = resolveRenamedVarAndMerge( smFromRequest.asJenaBinding() );
 
-			log.info( "Produced merged solution mapping from renamed binding" );
+			log.debug( "Produced merged solution mapping from renamed binding" );
 
 			// Merge with inputSolutionMappings
 			for ( final SolutionMapping smFromInput : inputSolutionMappings ) {
@@ -259,7 +259,7 @@ public class ExecOpSequentialBindJoinSPARQLwithVarRenaming
 			// Resolve renamed var and merge with smFromRequest
 			final Binding renamedAndMerged = resolveRenamedVarAndMerge( smFromRequest.asJenaBinding() );
 
-			log.info( "Produced outer-join-compatible merged solution mapping" );
+			log.debug( "Produced outer-join-compatible merged solution mapping" );
 
 			// Merge with inputSolutionMappings
 			for ( final SolutionMapping smFromInput : inputSolutionMappings ) {
@@ -286,7 +286,7 @@ public class ExecOpSequentialBindJoinSPARQLwithVarRenaming
 	public static Element renameVar( final SPARQLGraphPattern pattern,
                                      final Var oldVar,
                                      final Var newVar ) {
-		log.info( "Renaming variable {} to {} in SPARQL graph pattern", oldVar, newVar );
+		log.debug( "Renaming variable {} to {} in SPARQL graph pattern", oldVar, newVar );
 		// Element transform
 		final Element elt = QueryPatternUtils.convertToJenaElement(pattern);
 		final Map<Var, Node> eltMap = Collections.singletonMap(oldVar, newVar);
@@ -311,7 +311,7 @@ public class ExecOpSequentialBindJoinSPARQLwithVarRenaming
 	public static Binding renameVar( final Binding binding,
 	                                 final Var oldVar,
 	                                 final Var newVar ) {
-		log.info( "Renaming variable {} to {} in binding", oldVar, newVar );
+		log.debug( "Renaming variable {} to {} in binding", oldVar, newVar );
 		final BindingBuilder builder = BindingFactory.builder();
 		binding.forEach( (v, n) -> builder.add( v.equals(oldVar) ? newVar : v, n ) );
 		return builder.build();
@@ -339,7 +339,7 @@ public class ExecOpSequentialBindJoinSPARQLwithVarRenaming
 
 		// Fail if no variable was found
 		if ( matchedVar == null ) {
-			log.info(
+			log.debug(
 				"No renamed variable with prefix '{}' found in binding {}",
 				renamedVarPrefix,
 				sm );
@@ -348,13 +348,13 @@ public class ExecOpSequentialBindJoinSPARQLwithVarRenaming
 			                                                  sm) );
 		}
 
-		log.info( "Resolved renamed variable {} in binding", matchedVar );
+		log.debug( "Resolved renamed variable {} in binding", matchedVar );
 
 		// Parse index, rename, and merge
 		final String idxPart = matchedVar.getVarName().substring( renamedVarPrefix.length() );
 		final int i = Integer.parseInt(idxPart);
 		final Binding smRenamed = renameVar(sm, matchedVar, renamedVar);
-		log.info(
+		log.debug(
 			"Mapped renamed variable {} to original solution mapping index {}",
 			matchedVar,
 			i );

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSymmetricHashJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSymmetricHashJoin.java
@@ -65,14 +65,14 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 		// determine the certain join variables
 		final Set<Var> certainJoinVars = ExpectedVariablesUtils.intersectionOfCertainVariables(inputVars1, inputVars2);
 
-		log.info( "Initializing symmetric hash join operator with join variables {}.", certainJoinVars );
+		log.debug( "Initializing symmetric hash join operator with join variables {}.", certainJoinVars );
 
 		// set up the core part of the two indexes first; it is built on the certain join variables
 		SolutionMappingsIndex solMHashTableL;
 		SolutionMappingsIndex solMHashTableR;
 		if ( certainJoinVars.size() == 1 ) {
 			final Var joinVar = certainJoinVars.iterator().next();
-			log.info( "Using one-variable hash table for join variable {}.", joinVar );
+			log.debug( "Using one-variable hash table for join variable {}.", joinVar );
 			solMHashTableL = new SolutionMappingsHashTableBasedOnOneVar(joinVar);
 			solMHashTableR = new SolutionMappingsHashTableBasedOnOneVar(joinVar);
 		}
@@ -81,13 +81,13 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 			final Var joinVar1 = liVar.next();
 			final Var joinVar2 = liVar.next();
 
-			log.info( "Using two-variable hash table for join variables {}, {}.", joinVar1, joinVar2 );
+			log.debug( "Using two-variable hash table for join variables {}, {}.", joinVar1, joinVar2 );
 
 			solMHashTableL = new SolutionMappingsHashTableBasedOnTwoVars(joinVar1, joinVar2);
 			solMHashTableR = new SolutionMappingsHashTableBasedOnTwoVars(joinVar1, joinVar2);
 		}
 		else {
-			log.info( "Using generic hash table for join variables {}.", certainJoinVars );
+			log.debug( "Using generic hash table for join variables {}.", certainJoinVars );
 			solMHashTableL = new SolutionMappingsHashTable(certainJoinVars);
 			solMHashTableR = new SolutionMappingsHashTable(certainJoinVars);
 		}
@@ -96,7 +96,7 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 		// the join and, if so, set up the indexes to use post-matching.
 		final Set<Var> potentialJoinVars = ExpectedVariablesUtils.intersectionOfAllVariables(inputVars1, inputVars2);
 		if ( ! potentialJoinVars.equals(certainJoinVars) ) {
-			log.info( "Post-matching enabled for potential join variables {}.", potentialJoinVars );
+			log.debug( "Post-matching enabled for potential join variables {}.", potentialJoinVars );
 			solMHashTableL = new SolutionMappingsIndexWithPostMatching(solMHashTableL);
 			solMHashTableR = new SolutionMappingsIndexWithPostMatching(solMHashTableR);
 		}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpUnfold.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpUnfold.java
@@ -63,7 +63,7 @@ public class ExecOpUnfold extends UnaryExecutableOpBaseWithoutBlocking
 		this.var1 = var1;
 		this.var2 = var2;
 
-		log.info(
+		log.debug(
 			"Initialized ExecOpUnfold (var1={}, var2={}, collectExceptions={})",
 			var1, var2, collectExceptions );
 	}
@@ -81,7 +81,7 @@ public class ExecOpUnfold extends UnaryExecutableOpBaseWithoutBlocking
 			// If the expression failed to evaluate for a given
 			// solution mapping, then the expected result is that
 			// this solution mapping is returned as is.
-			log.info( "Expression evaluation failed for inputSolMap={}: {}", inputSolMap, ex.getMessage() );
+			log.debug( "Expression evaluation failed for inputSolMap={}: {}", inputSolMap, ex.getMessage() );
 			sink.send(inputSolMap);
 			numberOfOutputMappingsProduced++;
 			numberOfExprEvalErrors++;
@@ -95,7 +95,7 @@ public class ExecOpUnfold extends UnaryExecutableOpBaseWithoutBlocking
 
 			if ( CompositeDatatypeList.uri.equals(dtURI)
 			     && lit.isWellFormed() ) {
-				log.info( "Unfolding CDT list" );
+				log.debug( "Unfolding CDT list" );
 				numberOfUnfoldedCDTs++;
 				unfoldList(lit, inputSolMap, sink);
 				return;
@@ -103,7 +103,7 @@ public class ExecOpUnfold extends UnaryExecutableOpBaseWithoutBlocking
 
 			if ( CompositeDatatypeMap.uri.equals(dtURI)
 			     && lit.isWellFormed() ) {
-				log.info( "Unfolding CDT map" );
+				log.debug( "Unfolding CDT map" );
 				numberOfUnfoldedCDTs++;
 				unfoldMap(lit, inputSolMap, sink);
 				return;

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/NaryExecutableOpBase.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/NaryExecutableOpBase.java
@@ -2,9 +2,6 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutableOperatorStats;
@@ -31,8 +28,6 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
  */
 public abstract class NaryExecutableOpBase extends BaseForExecOps implements NaryExecutableOp
 {
-	private static final Logger log = LoggerFactory.getLogger( NaryExecutableOpBase.class );
-
 	protected final int numberOfChildren;
 
 	private boolean[] xthInputConsumed;
@@ -58,13 +53,6 @@ public abstract class NaryExecutableOpBase extends BaseForExecOps implements Nar
 		timeAtCurrentProcStartXthInput         = new long[numberOfChildren];
 
 		resetStats();
-
-		log.info(
-			"Initialized {} with {} children, mayReduce={}, collectExceptions={}.",
-			getClass().getSimpleName(),
-			numberOfChildren,
-			mayReduce,
-			collectExceptions );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/UnaryExecutableOpBase.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/UnaryExecutableOpBase.java
@@ -2,9 +2,6 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutableOperatorStats;
@@ -34,8 +31,6 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
  */
 public abstract class UnaryExecutableOpBase extends BaseForExecOps implements UnaryExecutableOp
 {
-	private static final Logger log = LoggerFactory.getLogger( UnaryExecutableOpBase.class );
-
 	private boolean executionConcluded = false;
 	private long numberOfInputMappingsProcessed = 0L;
 
@@ -43,12 +38,6 @@ public abstract class UnaryExecutableOpBase extends BaseForExecOps implements Un
 	                              final boolean collectExceptions,
 	                              final QueryPlanningInfo qpInfo ) {
 		super(mayReduce, collectExceptions, qpInfo);
-
-		log.info(
-			"Initialized {} (mayReduce={}, collectExceptions={}).",
-			getClass().getSimpleName(),
-			mayReduce,
-			collectExceptions );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/UnaryExecutableOpBaseWithoutBlocking.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/UnaryExecutableOpBaseWithoutBlocking.java
@@ -3,9 +3,6 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 import java.util.Iterator;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
@@ -34,20 +31,12 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
  */
 public abstract class UnaryExecutableOpBaseWithoutBlocking extends UnaryExecutableOpBase
 {
-	private static final Logger log = LoggerFactory.getLogger( UnaryExecutableOpBaseWithoutBlocking.class );
-
 	public static final int MAX_BATCH_SIZE = 100;
 
 	public UnaryExecutableOpBaseWithoutBlocking( final boolean mayReduce,
 	                                             final boolean collectExceptions,
 	                                             final QueryPlanningInfo qpInfo ) {
 		super(mayReduce, collectExceptions, qpInfo);
-
-		log.info(
-			"Initialized {} (mayReduce={}, collectExceptions={}).",
-			getClass().getSimpleName(),
-			mayReduce,
-			collectExceptions );
 	}
 
 	@Override


### PR DESCRIPTION
Changes certain logs added in #607 to `DEBUG` level to reduce verbosity.

Changes were made according to these rules:

> 1. The only log messages at the info level should be
> i. at the beginning of the process.. methods to say something like "Beginning to process X input solution mappings"
> ii. in the conclude..methods to say that the operator has completed
> (I believe that both of these things can be done in the corresponding base classes, but the log messages should also say which actual operator it is)
> 2. Everything else should be at the debug level.
> (Debug-level) log messages about initialization should be only in the constructors of the actual operators, not in the base classes.

Beyond those rules, I kept the logs for `wrapUpForChildX` methods at `INFO` level, with the same reasoning that conclude methods should be in INFO level.

For some operators, I have some logs both at the beginning and the end of `process` methods, these are also `INFO` level.