### PR TITLE
Move INFO level logs to superclasses

### DIFF
--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForUnaryExecOpWithCollectedInput.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForUnaryExecOpWithCollectedInput.java
@@ -70,9 +70,9 @@ public abstract class BaseForUnaryExecOpWithCollectedInput extends UnaryExecutab
 		// If enough solution mappings have been collected, process them now
 		// and, afterwards, remove them from the collection.
 		if ( collectedInputSolMaps.size() == minimumCollectionSize ) {
-			log.info( "Processing collected batch of {} solution mappings in {}.", collectedInputSolMaps.size(), getClass().getSimpleName() );
+			log.debug( "Processing collected batch of {} solution mappings in {}.", collectedInputSolMaps.size(), getClass().getSimpleName() );
 			_processCollectedInput(collectedInputSolMaps, sink, execCxt);
-			log.info( "Finished batch processing in {}.", getClass().getSimpleName() );
+			log.debug( "Finished batch processing in {}.", getClass().getSimpleName() );
 			collectedInputSolMaps.clear();
 			numberOfCollectionsProcessed++;
 		}
@@ -91,9 +91,9 @@ public abstract class BaseForUnaryExecOpWithCollectedInput extends UnaryExecutab
 		// next collection to be processed.
 		if (    inputSolMaps.size() >= minimumCollectionSize
 		     && collectedInputSolMaps.isEmpty()  ) {
-			log.info( "Passing through batch of {} mappings directly in {}.", inputSolMaps.size(), getClass().getSimpleName() );
+			log.debug( "Passing through batch of {} mappings directly in {}.", inputSolMaps.size(), getClass().getSimpleName() );
 			_processCollectedInput(inputSolMaps, sink, execCxt);
-			log.info( "Finished batch processing in {}.", getClass().getSimpleName() );
+			log.debug( "Finished batch processing in {}.", getClass().getSimpleName() );
 			numberOfCollectionsProcessed++;
 			return;
 		}
@@ -104,9 +104,9 @@ public abstract class BaseForUnaryExecOpWithCollectedInput extends UnaryExecutab
 		// If enough solution mappings have been collected, process them now
 		// and, afterwards, remove them from the collection.
 		if ( collectedInputSolMaps.size() >= minimumCollectionSize ) {
-			log.info( "Processing collected batch of {} solution mappings in {}.", collectedInputSolMaps.size(), getClass().getSimpleName() );
+			log.debug( "Processing collected batch of {} solution mappings in {}.", collectedInputSolMaps.size(), getClass().getSimpleName() );
 			_processCollectedInput(collectedInputSolMaps, sink, execCxt);
-			log.info( "Finished batch processing in {}.", getClass().getSimpleName() );
+			log.debug( "Finished batch processing in {}.", getClass().getSimpleName() );
 			collectedInputSolMaps.clear();
 			numberOfCollectionsProcessed++;
 		}
@@ -117,7 +117,7 @@ public abstract class BaseForUnaryExecOpWithCollectedInput extends UnaryExecutab
 	                                         final ExecutionContext execCxt )
 			throws ExecOpExecutionException
 	{
-		log.info( "Concluding execution with remaining batch size {} in {}.", collectedInputSolMaps.size(), getClass().getSimpleName() );
+		log.debug( "Concluding execution with remaining batch size {} in {}.", collectedInputSolMaps.size(), getClass().getSimpleName() );
 		_concludeExecution(collectedInputSolMaps, sink, execCxt);
 
 		if ( ! collectedInputSolMaps.isEmpty() ) {

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForUnaryExecOpWithCollectedInput.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BaseForUnaryExecOpWithCollectedInput.java
@@ -67,12 +67,12 @@ public abstract class BaseForUnaryExecOpWithCollectedInput extends UnaryExecutab
 		// Add the given solution mapping to the current collection.
 		collectedInputSolMaps.add(inputSolMap);
 
-		log.info( "Processing collected batch of {} solution mappings.", collectedInputSolMaps.size() );
-
 		// If enough solution mappings have been collected, process them now
 		// and, afterwards, remove them from the collection.
 		if ( collectedInputSolMaps.size() == minimumCollectionSize ) {
+			log.info( "Processing collected batch of {} solution mappings in {}.", collectedInputSolMaps.size(), getClass().getSimpleName() );
 			_processCollectedInput(collectedInputSolMaps, sink, execCxt);
+			log.info( "Finished batch processing in {}.", getClass().getSimpleName() );
 			collectedInputSolMaps.clear();
 			numberOfCollectionsProcessed++;
 		}
@@ -91,8 +91,9 @@ public abstract class BaseForUnaryExecOpWithCollectedInput extends UnaryExecutab
 		// next collection to be processed.
 		if (    inputSolMaps.size() >= minimumCollectionSize
 		     && collectedInputSolMaps.isEmpty()  ) {
-			log.info( "Passing through batch of {} mappings directly.", inputSolMaps.size() );
+			log.info( "Passing through batch of {} mappings directly in {}.", inputSolMaps.size(), getClass().getSimpleName() );
 			_processCollectedInput(inputSolMaps, sink, execCxt);
+			log.info( "Finished batch processing in {}.", getClass().getSimpleName() );
 			numberOfCollectionsProcessed++;
 			return;
 		}
@@ -103,7 +104,9 @@ public abstract class BaseForUnaryExecOpWithCollectedInput extends UnaryExecutab
 		// If enough solution mappings have been collected, process them now
 		// and, afterwards, remove them from the collection.
 		if ( collectedInputSolMaps.size() >= minimumCollectionSize ) {
+			log.info( "Processing collected batch of {} solution mappings in {}.", collectedInputSolMaps.size(), getClass().getSimpleName() );
 			_processCollectedInput(collectedInputSolMaps, sink, execCxt);
+			log.info( "Finished batch processing in {}.", getClass().getSimpleName() );
 			collectedInputSolMaps.clear();
 			numberOfCollectionsProcessed++;
 		}
@@ -114,7 +117,7 @@ public abstract class BaseForUnaryExecOpWithCollectedInput extends UnaryExecutab
 	                                         final ExecutionContext execCxt )
 			throws ExecOpExecutionException
 	{
-		log.info( "Concluding execution with remaining batch size {}.", collectedInputSolMaps.size() );
+		log.info( "Concluding execution with remaining batch size {} in {}.", collectedInputSolMaps.size(), getClass().getSimpleName() );
 		_concludeExecution(collectedInputSolMaps, sink, execCxt);
 
 		if ( ! collectedInputSolMaps.isEmpty() ) {

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BinaryExecutableOpBase.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BinaryExecutableOpBase.java
@@ -61,7 +61,7 @@ public abstract class BinaryExecutableOpBase extends BaseForExecOps implements B
 			final IntermediateResultElementSink sink,
 			final ExecutionContext execCxt ) throws ExecOpExecutionException
 	{
-		log.info( "Processing input solution mapping from child1 in {}.", getClass().getSimpleName() );
+		log.info( "Processing solution mapping from child1 in {}.", getClass().getSimpleName() );
 
 		timeAtCurrentLeftProcStart = System.currentTimeMillis();
 
@@ -84,6 +84,8 @@ public abstract class BinaryExecutableOpBase extends BaseForExecOps implements B
 		if ( processingTime > maxLeftProcessingTime ) { maxLeftProcessingTime = processingTime; }
 
 		numberOfLeftInputMappingsProcessed++;
+
+		log.info( "Finished processing solution mapping from child1 in {}.", getClass().getSimpleName() );
 	}
 
 	@Override
@@ -107,14 +109,17 @@ public abstract class BinaryExecutableOpBase extends BaseForExecOps implements B
 		}
 
 		numberOfLeftInputMappingsProcessed += inputSolMaps.size();
+
+		log.info( "Finished processing batch from child1 in {}.", getClass().getSimpleName() );
 	}
 
 	@Override
 	public final void wrapUpForChild1( final IntermediateResultElementSink sink,
 	                                   final ExecutionContext execCxt ) throws ExecOpExecutionException {
-		log.info( "Finished processing child1 input in {}.", getClass().getSimpleName() );
+		log.info( "Wrapping up processing of child1 input in {}.", getClass().getSimpleName() );
 		leftInputConsumed = true;
 		_wrapUpForChild1(sink, execCxt);
+		log.info( "Finished processing child1 input in {}.", getClass().getSimpleName() );
 	}
 
 	@Override
@@ -123,7 +128,7 @@ public abstract class BinaryExecutableOpBase extends BaseForExecOps implements B
 			final IntermediateResultElementSink sink,
 			final ExecutionContext execCxt ) throws ExecOpExecutionException
 	{
-		log.info( "Processing input solution mapping from child2 in {}.", getClass().getSimpleName() );
+		log.info( "Processing solution mapping from child2 in {}.", getClass().getSimpleName() );
 
 		timeAtCurrentRightProcStart = System.currentTimeMillis();
 
@@ -146,6 +151,8 @@ public abstract class BinaryExecutableOpBase extends BaseForExecOps implements B
 		if ( processingTime > maxRightProcessingTime ) { maxRightProcessingTime = processingTime; }
 
 		numberOfRightInputMappingsProcessed++;
+
+		log.info( "Finished processing solution mapping from child2 in {}.", getClass().getSimpleName() );
 	}
 
 	@Override
@@ -169,14 +176,17 @@ public abstract class BinaryExecutableOpBase extends BaseForExecOps implements B
 		}
 
 		numberOfRightInputMappingsProcessed += inputSolMaps.size();
+
+		log.info( "Finished processing batch from child2 in {}.", getClass().getSimpleName() );
 	}
 
 	@Override
 	public final void wrapUpForChild2( final IntermediateResultElementSink sink,
 	                                   final ExecutionContext execCxt ) throws ExecOpExecutionException {
-		log.info( "Finished processing child2 input in {}.", getClass().getSimpleName() );
+		log.info( "Wrapping up processing of child2 input in {}.", getClass().getSimpleName() );
 		rightInputConsumed = true;
 		_wrapUpForChild2(sink, execCxt);
+		log.info( "Finished processing child2 input in {}.", getClass().getSimpleName() );
 	}
 
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BinaryExecutableOpBase.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/BinaryExecutableOpBase.java
@@ -2,6 +2,9 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.BinaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
@@ -29,6 +32,8 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
  */
 public abstract class BinaryExecutableOpBase extends BaseForExecOps implements BinaryExecutableOp
 {
+	private static final Logger log = LoggerFactory.getLogger( BinaryExecutableOpBase.class );
+
 	private boolean leftInputConsumed           = false;
 	private boolean rightInputConsumed          = false;
 
@@ -56,6 +61,8 @@ public abstract class BinaryExecutableOpBase extends BaseForExecOps implements B
 			final IntermediateResultElementSink sink,
 			final ExecutionContext execCxt ) throws ExecOpExecutionException
 	{
+		log.info( "Processing input solution mapping from child1 in {}.", getClass().getSimpleName() );
+
 		timeAtCurrentLeftProcStart = System.currentTimeMillis();
 
 		if ( collectExceptions ) {
@@ -85,6 +92,8 @@ public abstract class BinaryExecutableOpBase extends BaseForExecOps implements B
 			final IntermediateResultElementSink sink,
 			final ExecutionContext execCxt ) throws ExecOpExecutionException
 	{
+		log.info( "Processing batch of {} solution mappings from child1 in {}.", inputSolMaps.size(), getClass().getSimpleName() );
+
 		if ( collectExceptions ) {
 			try {
 				_processInputFromChild1(inputSolMaps, sink, execCxt);
@@ -103,6 +112,7 @@ public abstract class BinaryExecutableOpBase extends BaseForExecOps implements B
 	@Override
 	public final void wrapUpForChild1( final IntermediateResultElementSink sink,
 	                                   final ExecutionContext execCxt ) throws ExecOpExecutionException {
+		log.info( "Finished processing child1 input in {}.", getClass().getSimpleName() );
 		leftInputConsumed = true;
 		_wrapUpForChild1(sink, execCxt);
 	}
@@ -113,6 +123,8 @@ public abstract class BinaryExecutableOpBase extends BaseForExecOps implements B
 			final IntermediateResultElementSink sink,
 			final ExecutionContext execCxt ) throws ExecOpExecutionException
 	{
+		log.info( "Processing input solution mapping from child2 in {}.", getClass().getSimpleName() );
+
 		timeAtCurrentRightProcStart = System.currentTimeMillis();
 
 		if ( collectExceptions ) {
@@ -142,6 +154,8 @@ public abstract class BinaryExecutableOpBase extends BaseForExecOps implements B
 			final IntermediateResultElementSink sink,
 			final ExecutionContext execCxt ) throws ExecOpExecutionException
 	{
+		log.info( "Processing batch of {} solution mappings from child2 in {}.", inputSolMaps.size(), getClass().getSimpleName() );
+
 		if ( collectExceptions ) {
 			try {
 				_processInputFromChild2(inputSolMaps, sink, execCxt);
@@ -160,6 +174,7 @@ public abstract class BinaryExecutableOpBase extends BaseForExecOps implements B
 	@Override
 	public final void wrapUpForChild2( final IntermediateResultElementSink sink,
 	                                   final ExecutionContext execCxt ) throws ExecOpExecutionException {
+		log.info( "Finished processing child2 input in {}.", getClass().getSimpleName() );
 		rightInputConsumed = true;
 		_wrapUpForChild2(sink, execCxt);
 	}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBinaryUnion.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBinaryUnion.java
@@ -41,7 +41,6 @@ public class ExecOpBinaryUnion extends BinaryExecutableOpBase
 	protected void _processInputFromChild1( final SolutionMapping inputSolMap,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
-		log.info( "Processing input solution mapping from child1." );
 		numberOfOutputMappingsProduced++;
 		sink.send(inputSolMap);
 	}
@@ -50,7 +49,6 @@ public class ExecOpBinaryUnion extends BinaryExecutableOpBase
 	protected void _processInputFromChild1( final List<SolutionMapping> inputSolMaps,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
-		log.info( "Processing batch of {} solution mappings from child1.", inputSolMaps.size() );
 		numberOfOutputMappingsProduced += inputSolMaps.size();
 		sink.send(inputSolMaps);
 	}
@@ -59,14 +57,12 @@ public class ExecOpBinaryUnion extends BinaryExecutableOpBase
 	protected void _wrapUpForChild1( final IntermediateResultElementSink sink,
 	                                 final ExecutionContext execCxt ) {
 		// nothing to be done here
-		log.info( "Finished processing child1 input." );
 	}
 
 	@Override
 	protected void _processInputFromChild2( final SolutionMapping inputSolMap,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
-		log.info( "Processing input solution mapping from child2." );
 		numberOfOutputMappingsProduced++;
 		sink.send(inputSolMap);
 	}
@@ -75,7 +71,6 @@ public class ExecOpBinaryUnion extends BinaryExecutableOpBase
 	protected void _processInputFromChild2( final List<SolutionMapping> inputSolMaps,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
-		log.info( "Processing batch of {} solution mappings from child2.", inputSolMaps.size() );
 		numberOfOutputMappingsProduced += inputSolMaps.size();
 		sink.send(inputSolMaps);
 	}
@@ -84,7 +79,6 @@ public class ExecOpBinaryUnion extends BinaryExecutableOpBase
 	protected void _wrapUpForChild2( final IntermediateResultElementSink sink,
 	                                 final ExecutionContext execCxt ) {
 		// nothing to be done here
-		log.info( "Finished ExecOpBinaryUnion. Produced {} output mappings.", numberOfOutputMappingsProduced );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBind.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpBind.java
@@ -71,9 +71,7 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 	                         final IntermediateResultElementSink sink,
 	                         final ExecutionContext execCxt )
 			 throws ExecOpExecutionException {
-		log.info( "Processing solution mapping in ExecOpBind." );
 		sink.send( worker.extend(inputSolMap) );
-		log.info( "Produced extended solution mapping." );
 		numberOfOutputMappingsProduced++;
 	}
 
@@ -84,7 +82,6 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 	                         final ExecutionContext execCxt )
 		 throws ExecOpExecutionException
 	{
-		log.info( "Processing batch of solution mappings with max batch size {}.", maxBatchSize );
 		final List<SolutionMapping> output = new ArrayList<>();
 
 		// Produce the output solution mappings
@@ -98,7 +95,6 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 		}
 
 		numberOfOutputMappingsProduced += output.size();
-		log.info( "Produced {} output solution mappings in batch.", output.size() );
 		sink.send(output);
 	}
 
@@ -106,7 +102,6 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 	protected void _concludeExecution( final IntermediateResultElementSink sink,
 	                                   final ExecutionContext execCxt ) {
 		// nothing to be done here
-		log.info( "ExecOpBind execution concluded. Produced {} output mappings.", numberOfOutputMappingsProduced );
 	}
 
 	@Override
@@ -144,7 +139,7 @@ public class ExecOpBind extends UnaryExecutableOpBaseWithoutBlocking
 			final Binding sm = solmap.asJenaBinding();
 
 			if ( sm.contains(var) ) {
-				log.info( "Cannot bind variable {} because it is already bound.", var );
+				log.debug( "Cannot bind variable {} because it is already bound.", var );
 				throwExecOpExecutionException( "Variable '" + var.getVarName() + "' already bound in the given solution mapping." );
 			}
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpDuplicateRemoval.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpDuplicateRemoval.java
@@ -37,7 +37,6 @@ public class ExecOpDuplicateRemoval extends UnaryExecutableOpBase
 	protected void _process( final SolutionMapping inputSolMap,
 	                         final IntermediateResultElementSink sink,
 	                         final ExecutionContext execCxt ) {
-		log.info( "Processing solution mapping in ExecOpDuplicateRemoval." );
 		if ( distinctSolMaps.add(inputSolMap) ) {
 			sink.send(inputSolMap);
 			numberOfOutputMappingsProduced++;
@@ -48,12 +47,6 @@ public class ExecOpDuplicateRemoval extends UnaryExecutableOpBase
 	@Override
 	protected void _concludeExecution( final IntermediateResultElementSink sink,
 	                                   final ExecutionContext execCxt ) {
-		log.info(
-			"Distinct operator finishing. Produced={}, duplicates={}, uniqueSize={}.",
-			numberOfOutputMappingsProduced,
-			numberOfDuplicates,
-			distinctSolMaps.size() );
-
 		distinctSolMaps.clear();
 	}
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpFilter.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpFilter.java
@@ -89,7 +89,6 @@ public class ExecOpFilter extends UnaryExecutableOpBaseWithoutBlocking
 			}
 		}
 
-		log.info( "Processing batch of {} solution mappings in ExecOpFilter.", cnt );
 
 		// Continue consuming the rest of the batch (if any). If we find
 		// further solution mappings that can be passed on as output, we
@@ -123,18 +122,12 @@ public class ExecOpFilter extends UnaryExecutableOpBaseWithoutBlocking
 			sink.send(firstOutput);
 			numberOfOutputMappingsProduced++;
 		}
-
-		log.info(
-			"Batch processed: {} input, {} output mappings.",
-			cnt,
-			(allOutput != null ? allOutput.size() : (firstOutput != null ? 1 : 0)) );
 	}
 
 	@Override
 	protected void _concludeExecution( final IntermediateResultElementSink sink,
 	                                   final ExecutionContext execCxt ) {
 		// nothing to be done here
-		log.info( "ExecOpFilter concluded execution." );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpGlobalToLocal.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpGlobalToLocal.java
@@ -41,7 +41,6 @@ public class ExecOpGlobalToLocal extends UnaryExecutableOpBaseWithoutBlocking
 	protected void _process( final SolutionMapping inputSolMap,
 	                         final IntermediateResultElementSink sink,
 	                         final ExecutionContext execCxt ) {
-		log.info( "Processing solution mapping in ExecOpGlobalToLocal." );
 		final Set<SolutionMapping> output = vm.translateSolutionMappingFromGlobal(inputSolMap);
 		numberOfOutputMappingsProduced += output.size();
 		sink.send(output);
@@ -52,7 +51,6 @@ public class ExecOpGlobalToLocal extends UnaryExecutableOpBaseWithoutBlocking
 	                         final int maxBatchSize,
 	                         final IntermediateResultElementSink sink,
 	                         final ExecutionContext execCxt ) {
-		log.info( "Processing batch of up to {} solution mappings (GlobalToLocal).", maxBatchSize );
 		final List<SolutionMapping> output = new ArrayList<>();
 
 		// Produce the output solution mappings
@@ -66,18 +64,12 @@ public class ExecOpGlobalToLocal extends UnaryExecutableOpBaseWithoutBlocking
 
 		numberOfOutputMappingsProduced += output.size();
 		sink.send(output);
-
-		log.info(
-			"Batch translated: {} output mappings produced from {} input mappings.",
-			output.size(),
-			cnt );
 	}
 
 	@Override
 	protected void _concludeExecution( final IntermediateResultElementSink sink,
 	                                   final ExecutionContext execCxt ) {
 		// nothing to be done here
-		log.info( "ExecOpGlobalToLocal concluded execution." );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashJoin1.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashJoin1.java
@@ -49,14 +49,12 @@ public class ExecOpHashJoin1 extends BaseForExecOpHashJoin
 	protected void _processInputFromChild1( final SolutionMapping inputSolMap,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
-		log.info( "Adding solution mapping to hash join index." );
 		index.add(inputSolMap);
 	}
 
 	@Override
 	protected void _wrapUpForChild1( final IntermediateResultElementSink sink,
 	                                 final ExecutionContext execCxt ) {
-		log.info( "Completed build phase for hash join index." );
 		this.child1InputComplete = true;
 	}
 
@@ -67,8 +65,6 @@ public class ExecOpHashJoin1 extends BaseForExecOpHashJoin
 		if ( child1InputComplete == false ) {
 			throw new IllegalStateException();
 		}
-
-		log.info( "Processing probe-side solution mapping." );
 
 		final List<SolutionMapping> output = new ArrayList<>();
 		produceOutput(inputSolMap, output);
@@ -84,8 +80,6 @@ public class ExecOpHashJoin1 extends BaseForExecOpHashJoin
 			throw new IllegalStateException();
 		}
 
-		log.info( "Processing batch of {} probe-side solution mappings.", inputSolMaps.size() );
-
 		final List<SolutionMapping> output = new ArrayList<>();
 		for ( final SolutionMapping inputSolMap : inputSolMaps ) {
 			produceOutput(inputSolMap, output);
@@ -97,13 +91,11 @@ public class ExecOpHashJoin1 extends BaseForExecOpHashJoin
 	@Override
 	protected void _wrapUpForChild2( final IntermediateResultElementSink sink,
 	                                 final ExecutionContext execCxt ) {
-		log.info( "Hash join execution completed. Clearing index." );
 		child2InputComplete = true;
 
 		// clear the index to enable the GC to release memory early,
 		// but make sure we keep the final stats of the index
 		statsOfIndex = index.getStats();
-		log.info( "Final index statistics: {}.", statsOfIndex );
 		index.clear();
 	}
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashJoin2.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpHashJoin2.java
@@ -54,14 +54,12 @@ public class ExecOpHashJoin2 extends BaseForExecOpHashJoin
 	protected void _processInputFromChild2( final SolutionMapping inputSolMap,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
-		log.info( "Adding solution mapping to hash join index." );
 		index.add(inputSolMap);
 	}
 
 	@Override
 	protected void _wrapUpForChild2( final IntermediateResultElementSink sink,
 	                                 final ExecutionContext execCxt ) {
-		log.info( "Completed build phase for hash join index." );
 		this.child2InputComplete = true;
 	}
 
@@ -72,8 +70,6 @@ public class ExecOpHashJoin2 extends BaseForExecOpHashJoin
 		if ( child2InputComplete == false ) {
 			throw new IllegalStateException();
 		}
-
-		log.info( "Processing probe-side solution mapping." );
 
 		final List<SolutionMapping> output = new ArrayList<>();
 		produceOutput(inputSolMap, output);
@@ -89,8 +85,6 @@ public class ExecOpHashJoin2 extends BaseForExecOpHashJoin
 			throw new IllegalStateException();
 		}
 
-		log.info( "Processing batch of {} probe-side solution mappings.", inputSolMaps.size() );
-
 		final List<SolutionMapping> output = new ArrayList<>();
 		for ( final SolutionMapping inputSolMap : inputSolMaps ) {
 			produceOutput(inputSolMap, output);
@@ -102,13 +96,11 @@ public class ExecOpHashJoin2 extends BaseForExecOpHashJoin
 	@Override
 	protected void _wrapUpForChild1( final IntermediateResultElementSink sink,
 	                                 final ExecutionContext execCxt ) {
-		log.info( "Hash join execution completed. Clearing index." );
 		child1InputComplete = true;
 
 		// clear the index to enable the GC to release memory early,
 		// but make sure we keep the final stats of the index
 		statsOfIndex = index.getStats();
-		log.info( "Final index statistics: {}.", statsOfIndex );
 		index.clear();
 	}
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLocalToGlobal.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLocalToGlobal.java
@@ -41,7 +41,6 @@ public class ExecOpLocalToGlobal extends UnaryExecutableOpBaseWithoutBlocking
 	protected void _process( final SolutionMapping inputSolMap,
 	                         final IntermediateResultElementSink sink,
 	                         final ExecutionContext execCxt ) {
-		log.info( "Processing solution mapping in ExecOpLocalToGlobal." );
 		final Set<SolutionMapping> output = vm.translateSolutionMapping(inputSolMap);
 		numberOfOutputMappingsProduced += output.size();
 		sink.send(output);
@@ -52,7 +51,6 @@ public class ExecOpLocalToGlobal extends UnaryExecutableOpBaseWithoutBlocking
 	                         final int maxBatchSize,
 	                         final IntermediateResultElementSink sink,
 	                         final ExecutionContext execCxt ) {
-		log.info( "Processing batch of up to {} solution mappings (LocalToGlobal).", maxBatchSize );
 		final List<SolutionMapping> output = new ArrayList<>();
 
 		// Produce the output solution mappings
@@ -66,18 +64,12 @@ public class ExecOpLocalToGlobal extends UnaryExecutableOpBaseWithoutBlocking
 
 		numberOfOutputMappingsProduced += output.size();
 		sink.send(output);
-
-		log.info(
-			"Batch translated: {} output mappings produced from {} input mappings.",
-			output.size(),
-			cnt );
 	}
 
 	@Override
 	protected void _concludeExecution( final IntermediateResultElementSink sink,
 	                                   final ExecutionContext execCxt ) {
 		// nothing to be done here
-		log.info( "ExecOpLocalToGlobal concluded execution." );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLookupJoinViaWrapperWithParamVars.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLookupJoinViaWrapperWithParamVars.java
@@ -119,11 +119,10 @@ public class ExecOpLookupJoinViaWrapperWithParamVars
 
 	@Override
 	protected void _processCollectedInput( final List<SolutionMapping> input,
-	                              final IntermediateResultElementSink sink,
-	                              final ExecutionContext execCxt )
+	                                       final IntermediateResultElementSink sink,
+	                                       final ExecutionContext execCxt )
 			throws ExecOpExecutionException
 	{
-		log.info( "Executing lookup join batch (with param vars) against {}", fm );
 		final Map<Map<String,Node>, List<SolutionMapping>> paramsForRequests = new HashMap<>();
 		for ( final SolutionMapping sm : input ) {
 			final Map<String,Node> paramValues = extractParamValues(sm);
@@ -201,7 +200,7 @@ public class ExecOpLookupJoinViaWrapperWithParamVars
 		catch ( final ExecutionException e ) {
 			throw new ExecOpExecutionException("The execution of the futures that perform the requests and process the responses caused an exception.", e, this);
 		}
-		log.info( "Completed lookup join batch for {} (requests={})", fm, numberOfRequestsIssued );
+		log.debug( "Completed lookup join batch for {} (requests={})", fm, numberOfRequestsIssued );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLookupJoinViaWrapperWithoutParamVars.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpLookupJoinViaWrapperWithoutParamVars.java
@@ -68,7 +68,6 @@ public class ExecOpLookupJoinViaWrapperWithoutParamVars
 	                         final IntermediateResultElementSink sink,
 	                         final ExecutionContext execCxt )
 			throws ExecOpExecutionException {
-		log.info( "Executing lookup join (without param vars) against {}", fm );
 		if ( solmapsFromRequest == null ) {
 			solmapsFromRequest = performRequest(execCxt);
 		}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpMultiwayUnion.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpMultiwayUnion.java
@@ -22,7 +22,7 @@ public class ExecOpMultiwayUnion extends NaryExecutableOpBase
 	                            final QueryPlanningInfo qpInfo ) {
 		super(numberOfChildren, mayReduce, collectExceptions, qpInfo);
 
-		log.info(
+		log.debug(
 			"Initialized ExecOpMultiwayUnion with {} children (mayReduce={}, collectExceptions={}).",
 			numberOfChildren,
 			mayReduce,
@@ -34,7 +34,6 @@ public class ExecOpMultiwayUnion extends NaryExecutableOpBase
 	                                          final SolutionMapping inputSolMap,
 	                                          final IntermediateResultElementSink sink,
 	                                          final ExecutionContext execCxt) {
-		log.info( "Processing input solution mapping from child{}.", x );
 		numberOfOutputMappingsProduced++;
 		sink.send(inputSolMap);
 	}
@@ -44,7 +43,6 @@ public class ExecOpMultiwayUnion extends NaryExecutableOpBase
 	                                          final List<SolutionMapping> inputSolMaps,
 	                                          final IntermediateResultElementSink sink,
 	                                          final ExecutionContext execCxt) {
-		log.info( "Processing batch of {} solution mappings from child{}.", inputSolMaps.size(), x );
 		numberOfOutputMappingsProduced += inputSolMaps.size();
 		sink.send(inputSolMaps);
 	}
@@ -54,7 +52,6 @@ public class ExecOpMultiwayUnion extends NaryExecutableOpBase
 	                                   final IntermediateResultElementSink sink,
 	                                   final ExecutionContext execCxt ) {
 		// nothing to be done here
-		log.info( "Finished processing child{} input.", x );
 	}
 
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpNaiveNestedLoopsJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpNaiveNestedLoopsJoin.java
@@ -52,7 +52,6 @@ public class ExecOpNaiveNestedLoopsJoin extends BinaryExecutableOpBase
 	protected void _processInputFromChild1( final SolutionMapping inputSolMap,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
-		log.info( "Adding solution mapping to left-hand-side input." );
 		inputLHS.add(inputSolMap);
 	}
 
@@ -60,14 +59,12 @@ public class ExecOpNaiveNestedLoopsJoin extends BinaryExecutableOpBase
 	protected void _wrapUpForChild1( final IntermediateResultElementSink sink,
 	                                 final ExecutionContext execCxt ) {
 		// nothing to be done here
-		log.info( "Completed build phase for child 1 with {} solution mappings.", inputLHS.size() );
 	}
 
 	@Override
 	protected void _processInputFromChild2( final SolutionMapping inputSolMap,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
-		log.info( "Processing probe-side solution mapping." );
 		final List<SolutionMapping> output = new ArrayList<>();
 		for ( final SolutionMapping smL : inputLHS ) {
 			if ( SolutionMappingUtils.compatible(smL,inputSolMap) ) {
@@ -75,7 +72,6 @@ public class ExecOpNaiveNestedLoopsJoin extends BinaryExecutableOpBase
 			}
 		}
 
-		log.info( "Produced {} joined solution mappings.", output.size() );
 		sink.send(output);
 	}
 
@@ -83,7 +79,6 @@ public class ExecOpNaiveNestedLoopsJoin extends BinaryExecutableOpBase
 	protected void _processInputFromChild2( final List<SolutionMapping> inputSolMaps,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
-		log.info( "Processing batch of {} probe-side solution mappings.", inputSolMaps.size() );
 		final List<SolutionMapping> output = new ArrayList<>();
 		for ( final SolutionMapping inputSolMap : inputSolMaps ) {
 			for ( final SolutionMapping smL : inputLHS ) {
@@ -93,7 +88,6 @@ public class ExecOpNaiveNestedLoopsJoin extends BinaryExecutableOpBase
 			}
 		}
 
-		log.info( "Produced {} joined solution mappings.", output.size() );
 		sink.send(output);
 	}
 
@@ -102,7 +96,6 @@ public class ExecOpNaiveNestedLoopsJoin extends BinaryExecutableOpBase
 	                                 final ExecutionContext execCxt ) {
 		// clear the list of collected first-input solution
 		// mappings to enable the GC to release memory early
-		log.info( "Nested loops join execution completed. Clearing left-hand-side input." );
 		inputLHS.clear();
 	}
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpParallelMultiwayLeftJoin.java
@@ -110,13 +110,9 @@ public class ExecOpParallelMultiwayLeftJoin extends BaseForUnaryExecOpWithCollec
 
 	@Override
 	protected void _processCollectedInput( final List<SolutionMapping> input,
-	                              final IntermediateResultElementSink sink,
-	                              final ExecutionContext execCxt ) throws ExecOpExecutionException {
-		log.info( "Processing batch of {} input solution mappings.", input.size() );
-
+	                                       final IntermediateResultElementSink sink,
+	                                       final ExecutionContext execCxt ) throws ExecOpExecutionException {
 		final List<SolutionMapping> inputForParallelProcess = determineInputForParallelProcess(input);
-
-		log.info( "Reduced batch to {} unique join-key bindings for parallel phase.", inputForParallelProcess.size() );
 
 		if ( inputForParallelProcess.size() > 0 ) {
 			parallelPhase(inputForParallelProcess, execCxt);

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSymmetricHashJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSymmetricHashJoin.java
@@ -119,14 +119,11 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 	protected void _processInputFromChild1( final SolutionMapping inputSolMap,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
-		log.info( "Processing solution mapping from child 1." );
-
 		buffer.clear();
 
 		_processInputSolMap(inputSolMap, indexForChild1, indexForChild2, buffer);
 
 		numberOfOutputMappingsProduced += buffer.size();
-		log.info( "Produced {} joined solution mappings.", buffer.size() );
 		sink.send(buffer);
 
 		buffer.clear();
@@ -136,8 +133,6 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 	protected void _processInputFromChild1( final List<SolutionMapping> inputSolMaps,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
-		log.info( "Processing batch of {} solution mappings from child 1.", inputSolMaps.size() );
-
 		buffer.clear();
 
 		for ( final SolutionMapping inputSolMap : inputSolMaps ) {
@@ -145,7 +140,6 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 		}
 
 		numberOfOutputMappingsProduced += buffer.size();
-		log.info( "Produced {} joined solution mappings.", buffer.size() );
 		sink.send(buffer);
 
 		buffer.clear();
@@ -166,14 +160,11 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 	protected void _processInputFromChild2( final SolutionMapping inputSolMap,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
-		log.info( "Processing solution mapping from child 2." );
-
 		buffer.clear();
 
 		_processInputSolMap(inputSolMap, indexForChild2, indexForChild1, buffer);
 
 		numberOfOutputMappingsProduced += buffer.size();
-		log.info( "Produced {} joined solution mappings.", buffer.size() );
 		sink.send(buffer);
 
 		buffer.clear();
@@ -183,8 +174,6 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 	protected void _processInputFromChild2( final List<SolutionMapping> inputSolMaps,
 	                                        final IntermediateResultElementSink sink,
 	                                        final ExecutionContext execCxt ) {
-		log.info( "Processing batch of {} solution mappings from child 2.", inputSolMaps.size() );
-
 		buffer.clear();
 
 		for ( final SolutionMapping inputSolMap : inputSolMaps ) {
@@ -192,7 +181,6 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 		}
 
 		numberOfOutputMappingsProduced += buffer.size();
-		log.info( "Produced {} joined solution mappings.", buffer.size() );
 		sink.send(buffer);
 
 		buffer.clear();
@@ -201,7 +189,6 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 	@Override
 	protected void _wrapUpForChild2( final IntermediateResultElementSink sink,
 	                                 final ExecutionContext execCxt ) {
-		log.info( "Completed input processing for child 2." );
 		child2InputComplete = true;
 
 		if ( child1InputComplete ) {

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSymmetricHashJoin.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpSymmetricHashJoin.java
@@ -148,7 +148,6 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 	@Override
 	protected void _wrapUpForChild1( final IntermediateResultElementSink sink,
 									 final ExecutionContext execCxt ) {
-		log.info( "Completed input processing for child 1." );
 		child1InputComplete = true;
 
 		if ( child2InputComplete ) {
@@ -199,12 +198,12 @@ public class ExecOpSymmetricHashJoin extends BinaryExecutableOpBase
 	protected void wrapUp() {
 		// clear both indexes to enable the GC to release memory early,
 		// but make sure we keep the final stats of the indexes
-		log.info( "Symmetric hash join execution completed. Clearing indexes." );
+		log.debug( "Symmetric hash join execution completed. Clearing indexes." );
 
 		statsOfIndexForChild1 = indexForChild1.getStats();
 		statsOfIndexForChild2 = indexForChild2.getStats();
-		log.info( "Final index statistics for child 1: {}.", statsOfIndexForChild1 );
-		log.info( "Final index statistics for child 2: {}.", statsOfIndexForChild2 );
+		log.debug( "Final index statistics for child 1: {}.", statsOfIndexForChild1 );
+		log.debug( "Final index statistics for child 2: {}.", statsOfIndexForChild2 );
 
 		indexForChild1.clear();
 		indexForChild2.clear();

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/NaryExecutableOpBase.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/NaryExecutableOpBase.java
@@ -70,7 +70,7 @@ public abstract class NaryExecutableOpBase extends BaseForExecOps implements Nar
 		assert x >= 0;
 		assert x < numberOfChildren;
 
-		log.info( "Processing input solution mapping from child{} in {}.", x, getClass().getSimpleName() );
+		log.info( "Processing solution mapping from child{} in {}.", x, getClass().getSimpleName() );
 
 		timeAtCurrentProcStartXthInput[x] = System.currentTimeMillis();
 
@@ -93,6 +93,8 @@ public abstract class NaryExecutableOpBase extends BaseForExecOps implements Nar
 		if ( processingTime > maxProcessingTimeXthInput[x] ) { maxProcessingTimeXthInput[x] = processingTime; }
 
 		numberOfMappingsFromXthInputProcessed[x]++;
+
+		log.info( "Finished processing solution mapping from child{} in {}.", x, getClass().getSimpleName() );
 	}
 
 	@Override
@@ -120,6 +122,8 @@ public abstract class NaryExecutableOpBase extends BaseForExecOps implements Nar
 		}
 
 		numberOfMappingsFromXthInputProcessed[x] += inputSolMaps.size();
+
+		log.info( "Finished processing batch from child{} in {}.", x, getClass().getSimpleName() );
 	}
 
 	@Override
@@ -131,10 +135,10 @@ public abstract class NaryExecutableOpBase extends BaseForExecOps implements Nar
 		assert x >= 0;
 		assert x < numberOfChildren;
 
-		log.info( "Finished processing child{} input in {}.", x, getClass().getSimpleName() );
-
+		log.info( "Wrapping up processing of child{} input in {}.", x, getClass().getSimpleName() );
 		xthInputConsumed[x] = true;
 		_wrapUpForXthChild(x, sink, execCxt);
+		log.info( "Finished processing child{} input in {}.", x, getClass().getSimpleName() );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/NaryExecutableOpBase.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/NaryExecutableOpBase.java
@@ -2,6 +2,9 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutableOperatorStats;
@@ -28,6 +31,8 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
  */
 public abstract class NaryExecutableOpBase extends BaseForExecOps implements NaryExecutableOp
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecOpMultiwayUnion.class );
+
 	protected final int numberOfChildren;
 
 	private boolean[] xthInputConsumed;
@@ -65,6 +70,8 @@ public abstract class NaryExecutableOpBase extends BaseForExecOps implements Nar
 		assert x >= 0;
 		assert x < numberOfChildren;
 
+		log.info( "Processing input solution mapping from child{} in {}.", x, getClass().getSimpleName() );
+
 		timeAtCurrentProcStartXthInput[x] = System.currentTimeMillis();
 
 		if ( collectExceptions ) {
@@ -98,6 +105,8 @@ public abstract class NaryExecutableOpBase extends BaseForExecOps implements Nar
 		assert x >= 0;
 		assert x < numberOfChildren;
 
+		log.info( "Processing batch of {} solution mappings from child{} in {}.", inputSolMaps.size(), x, getClass().getSimpleName() );
+
 		if ( collectExceptions ) {
 			try {
 				_processInputFromXthChild(x, inputSolMaps, sink, execCxt);
@@ -121,6 +130,8 @@ public abstract class NaryExecutableOpBase extends BaseForExecOps implements Nar
 	{
 		assert x >= 0;
 		assert x < numberOfChildren;
+
+		log.info( "Finished processing child{} input in {}.", x, getClass().getSimpleName() );
 
 		xthInputConsumed[x] = true;
 		_wrapUpForXthChild(x, sink, execCxt);

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/NullaryExecutableOpBase.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/NullaryExecutableOpBase.java
@@ -1,5 +1,8 @@
 package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutableOperatorStats;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
@@ -23,6 +26,8 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
  */
 public abstract class NullaryExecutableOpBase extends BaseForExecOps implements NullaryExecutableOp
 {
+	private static final Logger log = LoggerFactory.getLogger( NullaryExecutableOpBase.class );
+
 	private int numberOfInvocations = 0;
 	protected long timeAtExecStart  = 0L;
 	protected long timeAtExecEnd    = 0L;
@@ -37,6 +42,7 @@ public abstract class NullaryExecutableOpBase extends BaseForExecOps implements 
 	public final void execute( final IntermediateResultElementSink sink,
 	                           final ExecutionContext execCxt ) throws ExecOpExecutionException
 	{
+		log.info( "Executing {}.", getClass().getSimpleName() );
 		numberOfInvocations++;
 		timeAtExecStart = System.currentTimeMillis();
 
@@ -53,6 +59,8 @@ public abstract class NullaryExecutableOpBase extends BaseForExecOps implements 
 		}
 
 		timeAtExecEnd = System.currentTimeMillis();
+
+		log.info( "Finished executing {}.", getClass().getSimpleName() );
 	}
 
 	/**

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/UnaryExecutableOpBase.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/UnaryExecutableOpBase.java
@@ -2,6 +2,9 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutableOperatorStats;
@@ -31,6 +34,7 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
  */
 public abstract class UnaryExecutableOpBase extends BaseForExecOps implements UnaryExecutableOp
 {
+	private static final Logger log = LoggerFactory.getLogger( UnaryExecutableOpBaseWithoutBlocking.class );
 	private boolean executionConcluded = false;
 	private long numberOfInputMappingsProcessed = 0L;
 
@@ -46,6 +50,8 @@ public abstract class UnaryExecutableOpBase extends BaseForExecOps implements Un
 	                           final ExecutionContext execCxt )
 			throws ExecOpExecutionException
 	{
+		log.info( "Processing solution mapping in {}.", getClass().getSimpleName() );
+
 		if ( collectExceptions ) {
 			try {
 				_process(inputSolMap, sink, execCxt);
@@ -59,6 +65,7 @@ public abstract class UnaryExecutableOpBase extends BaseForExecOps implements Un
 		}
 
 		numberOfInputMappingsProcessed++;
+		log.info( "Finished processing solution mapping in {}.", getClass().getSimpleName() );
 	}
 
 	@Override
@@ -67,6 +74,8 @@ public abstract class UnaryExecutableOpBase extends BaseForExecOps implements Un
 	                           final ExecutionContext execCxt )
 			throws ExecOpExecutionException
 	{
+		log.info( "Processing batch of {} solution mappings in {}.", inputSolMaps.size(), getClass().getSimpleName() );
+
 		if ( collectExceptions ) {
 			try {
 				_process(inputSolMaps, sink, execCxt);
@@ -80,11 +89,14 @@ public abstract class UnaryExecutableOpBase extends BaseForExecOps implements Un
 		}
 
 		numberOfInputMappingsProcessed += inputSolMaps.size();
+		log.info( "Finished processing batch in {}.", getClass().getSimpleName() );
 	}
 
 	@Override
 	public final void concludeExecution( final IntermediateResultElementSink sink,
 	                                     final ExecutionContext execCxt ) throws ExecOpExecutionException {
+		log.info( "Concluding execution for {}.", getClass().getSimpleName() );
+
 		if ( collectExceptions ) {
 			try {
 				_concludeExecution(sink, execCxt);
@@ -98,6 +110,8 @@ public abstract class UnaryExecutableOpBase extends BaseForExecOps implements Un
 		}
 
 		executionConcluded = true;
+
+		log.info( "Execution concluded for {}.", getClass().getSimpleName() );
 	}
 
 	/**

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/UnaryExecutableOpBaseWithoutBlocking.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/UnaryExecutableOpBaseWithoutBlocking.java
@@ -3,9 +3,6 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 import java.util.Iterator;
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
@@ -34,7 +31,6 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
  */
 public abstract class UnaryExecutableOpBaseWithoutBlocking extends UnaryExecutableOpBase
 {
-	private static final Logger log = LoggerFactory.getLogger( UnaryExecutableOpBaseWithoutBlocking.class );
 	public static final int MAX_BATCH_SIZE = 100;
 
 	public UnaryExecutableOpBaseWithoutBlocking( final boolean mayReduce,
@@ -57,18 +53,14 @@ public abstract class UnaryExecutableOpBaseWithoutBlocking extends UnaryExecutab
 			// of this class would otherwise create a list for collecting
 			// the output (but does not do so in its single-input version
 			// of the _process method).
-			log.info( "Processing solution mapping in {}.", getClass().getSimpleName() );
 			final SolutionMapping inputSolMap = inputSolMaps.get(0);
 			_process(inputSolMap, sink, execCxt);
-			log.info( "Finished processing solution mapping in {}.", getClass().getSimpleName() );
 		}
 		else if ( inputSize > 1 ) {
-			log.info( "Processing batch of solution mappings with max batch size {} in {}.", MAX_BATCH_SIZE, getClass().getSimpleName() );
 			final Iterator<SolutionMapping> it = inputSolMaps.iterator();
 			while ( it.hasNext() ) {
 				_process(it, MAX_BATCH_SIZE, sink, execCxt);
 			}
-			log.info( "Finished processing batch in {}.", getClass().getSimpleName() );
 		}
 		// no else case here - nothing to do if inputSolMaps is empty
 	}
@@ -93,7 +85,6 @@ public abstract class UnaryExecutableOpBaseWithoutBlocking extends UnaryExecutab
 	                         final IntermediateResultElementSink sink,
 	                         final ExecutionContext execCxt )
 			throws ExecOpExecutionException {
-		log.info( "Processing batch of solution mappings in {}.", getClass().getSimpleName() );
 		int cnt = 0;
 		while ( cnt < maxBatchSize && inputSolMaps.hasNext() ) {
 			final SolutionMapping inputSolMap = inputSolMaps.next();

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/UnaryExecutableOpBaseWithoutBlocking.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/UnaryExecutableOpBaseWithoutBlocking.java
@@ -3,6 +3,9 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 import java.util.Iterator;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
@@ -31,6 +34,7 @@ import se.liu.ida.hefquin.engine.queryproc.ExecutionContext;
  */
 public abstract class UnaryExecutableOpBaseWithoutBlocking extends UnaryExecutableOpBase
 {
+	private static final Logger log = LoggerFactory.getLogger( UnaryExecutableOpBaseWithoutBlocking.class );
 	public static final int MAX_BATCH_SIZE = 100;
 
 	public UnaryExecutableOpBaseWithoutBlocking( final boolean mayReduce,
@@ -53,14 +57,18 @@ public abstract class UnaryExecutableOpBaseWithoutBlocking extends UnaryExecutab
 			// of this class would otherwise create a list for collecting
 			// the output (but does not do so in its single-input version
 			// of the _process method).
+			log.info( "Processing solution mapping in {}.", getClass().getSimpleName() );
 			final SolutionMapping inputSolMap = inputSolMaps.get(0);
 			_process(inputSolMap, sink, execCxt);
+			log.info( "Finished processing solution mapping in {}.", getClass().getSimpleName() );
 		}
 		else if ( inputSize > 1 ) {
+			log.info( "Processing batch of solution mappings with max batch size {} in {}.", MAX_BATCH_SIZE, getClass().getSimpleName() );
 			final Iterator<SolutionMapping> it = inputSolMaps.iterator();
 			while ( it.hasNext() ) {
 				_process(it, MAX_BATCH_SIZE, sink, execCxt);
 			}
+			log.info( "Finished processing batch in {}.", getClass().getSimpleName() );
 		}
 		// no else case here - nothing to do if inputSolMaps is empty
 	}
@@ -85,6 +93,7 @@ public abstract class UnaryExecutableOpBaseWithoutBlocking extends UnaryExecutab
 	                         final IntermediateResultElementSink sink,
 	                         final ExecutionContext execCxt )
 			throws ExecOpExecutionException {
+		log.info( "Processing batch of solution mappings in {}.", getClass().getSimpleName() );
 		int cnt = 0;
 		while ( cnt < maxBatchSize && inputSolMaps.hasNext() ) {
 			final SolutionMapping inputSolMap = inputSolMaps.next();


### PR DESCRIPTION
Addresses #607 by moving the `INFO` level logs of each executable operator to its superclasses. 

However, I kept some `INFO` level logs in `ExecOpSymmetricHashJoin` since `wrapUp()` isn't a method that overrides a method in any superclass. Let me know if these should be deleted or if there is some other solution!