### PR TITLE
Add DEBUG level logging for query processor related classes

### DIFF
--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/iterbased/IteratorBasedExecutablePlanImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/iterbased/IteratorBasedExecutablePlanImpl.java
@@ -2,6 +2,9 @@ package se.liu.ida.hefquin.engine.queryplan.executable.impl.iterbased;
 
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutablePlan;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutablePlanStats;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionException;
@@ -9,6 +12,8 @@ import se.liu.ida.hefquin.engine.queryproc.QueryResultSink;
 
 public class IteratorBasedExecutablePlanImpl implements ExecutablePlan
 {
+	private static final Logger log = LoggerFactory.getLogger( IteratorBasedExecutablePlanImpl.class );
+
 	protected final ResultElementIterator it;
 
 	public IteratorBasedExecutablePlanImpl( final ResultElementIterator it ) {
@@ -18,6 +23,7 @@ public class IteratorBasedExecutablePlanImpl implements ExecutablePlan
 
 	@Override
 	public void run( final QueryResultSink resultSink ) throws ExecutionException {
+		log.debug( "Starting iterator-based executable plan execution." );
 		try {
 			while ( it.hasNext() ) {
 				resultSink.send( it.next() );
@@ -26,6 +32,7 @@ public class IteratorBasedExecutablePlanImpl implements ExecutablePlan
 		catch ( final ResultElementIterException ex ) {
 			throw new ExecutionException( "An exception occurred during result iteration.", ex.getWrappedExecutionException() );
 		}
+		log.debug( "Iterator-based executable plan execution finished successfully." );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/pushbased/PushBasedExecutablePlanImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/pushbased/PushBasedExecutablePlanImpl.java
@@ -8,6 +8,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutablePlan;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutablePlanStats;
@@ -17,6 +20,8 @@ import se.liu.ida.hefquin.engine.queryproc.QueryResultSink;
 
 public class PushBasedExecutablePlanImpl implements ExecutablePlan
 {
+	private static final Logger log = LoggerFactory.getLogger( PushBasedExecutablePlanImpl.class );
+
 	protected final LinkedList<PushBasedPlanThread> tasks;
 	protected ExecutorService threadPool;
 
@@ -32,6 +37,8 @@ public class PushBasedExecutablePlanImpl implements ExecutablePlan
 		if ( threadPool == null ) {
 			throw new ExecutionException("thread pool missing");
 		}
+
+		log.debug( "Starting push-based executable plan execution with {} tasks.", tasks.size() );
 
 		// Start all tasks, beginning with the last ones (which are the
 		// ones for the leaf node operators), and collect 'Future's to
@@ -56,6 +63,8 @@ public class PushBasedExecutablePlanImpl implements ExecutablePlan
 				throw new ExecutionException("Submitting one of the tasks for execution caused an exception.", e);
 			}
 		}
+
+		log.debug( "Successfully submitted {} push-based tasks to executor service.", tasks.size() );
 
 		// Consume all solution mappings from the root operator
 		// and send them to the result sink.
@@ -114,6 +123,7 @@ public class PushBasedExecutablePlanImpl implements ExecutablePlan
 				future.cancel(true);
 			}
 		}
+		log.debug( "Push-based executable plan execution finished successfully." );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/QueryProcessorImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/QueryProcessorImpl.java
@@ -4,6 +4,9 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.query.Query;
 import se.liu.ida.hefquin.base.utils.Pair;
 import se.liu.ida.hefquin.base.utils.StatsPrinter;
@@ -26,6 +29,8 @@ import se.liu.ida.hefquin.engine.queryproc.QueryResultSink;
  */
 public class QueryProcessorImpl implements QueryProcessor
 {
+	private static final Logger log = LoggerFactory.getLogger( QueryProcessorImpl.class );
+
 	protected final QueryPlanner planner;
 	protected final QueryPlanCompiler planCompiler;
 	protected final ExecutionEngine execEngine;
@@ -60,36 +65,61 @@ public class QueryProcessorImpl implements QueryProcessor
 	                                                       final QueryResultSink resultSink )
 			throws QueryProcException
 	{
+		log.debug("Starting query processing.");
+
 		final long t1 = System.currentTimeMillis();
+		log.debug("Creating physical plan.");
 		final Pair<PhysicalPlan, QueryPlanningStats> qepAndStats = planner.createPlan(query, ctxt);
 		final PhysicalPlan qep = qepAndStats.object1;
 
 		final long t2 = System.currentTimeMillis();
+
+		log.debug( "Physical plan created in {} ms using {}.", (t2 - t1), planner.getClass().getSimpleName() );
 
 		final long t3, t4;
 		final ExecutionStats execStats;
 		final List<Exception> exceptionsCaughtDuringExecution;
 
 		if ( ctxt.skipExecution() || qep instanceof PhysicalPlanWithoutResult ) {
+			log.debug(
+				"Skipping execution (skipExecution={}, planWithoutResult={}).",
+				ctxt.skipExecution(),
+				qep instanceof PhysicalPlanWithoutResult );
 			t3 = System.currentTimeMillis();
 			t4 = System.currentTimeMillis();
 			execStats = null;
 			exceptionsCaughtDuringExecution = null;
 		}
 		else {
+			log.debug("Compiling executable plan.");
+
 			final ExecutablePlan prg = planCompiler.compile(qepAndStats.object1);
 
 			if ( planner.getExecutablePlanPrinter() != null ) {
+				log.debug( "Printing executable plan." );
 				planner.getExecutablePlanPrinter().print( prg );
 			}
 			t3 = System.currentTimeMillis();
+
+			log.debug( "Executable plan compiled in {} ms using {}.", (t3 - t2), planCompiler.getClass().getSimpleName() );
+
+			log.debug( "Starting execution." );
+
 			execStats = execEngine.execute(prg, resultSink);
 
 			t4 = System.currentTimeMillis();
+
+			log.debug( "Execution finished in {} ms.", (t4 - t3) );
+
 			exceptionsCaughtDuringExecution = prg.getExceptionsCaughtDuringExecution();
+
+			if ( ! exceptionsCaughtDuringExecution.isEmpty() )
+				log.debug( "Execution completed with {} caught exception(s).", exceptionsCaughtDuringExecution.size() );
 		}
 
 		final QueryProcessingStatsAndExceptions s = new QueryProcessingStatsAndExceptionsImpl( t4-t1, t2-t1, t3-t2, t4-t3, qepAndStats.object2, execStats, exceptionsCaughtDuringExecution );
+
+		log.debug( "Query processing finished. Total time: {} ms.", (t4 - t1) );
 
 		if ( ctxt.isExperimentRun() ) {
 			StatsPrinter.print( s, System.out, true );
@@ -101,12 +131,16 @@ public class QueryProcessorImpl implements QueryProcessor
 	@Override
 	public void shutdown() {
 		final ExecutorService threadPool = ctxt.getExecutorServiceForPlanTasks();
+		log.debug( "Shutting down query processor thread pool." );
 		threadPool.shutdown();
 		try {
 			if ( ! threadPool.awaitTermination(500L, TimeUnit.MILLISECONDS) ) {
+				log.debug( "Thread pool did not terminate gracefully; forcing shutdown." );
 				threadPool.shutdownNow();
 			}
+			else log.debug( "Thread pool terminated gracefully." );
 		} catch ( InterruptedException ex ) {
+			log.debug( "Interrupted while waiting for thread pool termination.", ex );
 			Thread.currentThread().interrupt();
 			threadPool.shutdownNow();
 		}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/QueryProcessorImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/QueryProcessorImpl.java
@@ -113,8 +113,10 @@ public class QueryProcessorImpl implements QueryProcessor
 
 			exceptionsCaughtDuringExecution = prg.getExceptionsCaughtDuringExecution();
 
-			if ( ! exceptionsCaughtDuringExecution.isEmpty() )
-				log.debug( "Execution completed with {} caught exception(s).", exceptionsCaughtDuringExecution.size() );
+			if ( log.isDebugEnabled() ) {
+				if ( ! exceptionsCaughtDuringExecution.isEmpty() )
+					log.debug( "Execution completed with {} caught exception(s).", exceptionsCaughtDuringExecution.size() );
+			}
 		}
 
 		final QueryProcessingStatsAndExceptions s = new QueryProcessingStatsAndExceptionsImpl( t4-t1, t2-t1, t3-t2, t4-t3, qepAndStats.object2, execStats, exceptionsCaughtDuringExecution );

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/compiler/QueryPlanCompilerForIteratorBasedExecution.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/compiler/QueryPlanCompilerForIteratorBasedExecution.java
@@ -1,5 +1,8 @@
 package se.liu.ida.hefquin.engine.queryproc.impl.compiler;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.engine.queryplan.executable.BinaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutablePlan;
 import se.liu.ida.hefquin.engine.queryplan.executable.NullaryExecutableOp;
@@ -17,6 +20,8 @@ import se.liu.ida.hefquin.engine.queryproc.QueryProcContext;
 
 public class QueryPlanCompilerForIteratorBasedExecution extends QueryPlanCompilerBase
 {
+	private static final Logger log = LoggerFactory.getLogger( QueryPlanCompilerForIteratorBasedExecution.class );
+
 	public QueryPlanCompilerForIteratorBasedExecution( final QueryProcContext ctxt ) {
 		super(ctxt);
 	}
@@ -25,6 +30,7 @@ public class QueryPlanCompilerForIteratorBasedExecution extends QueryPlanCompile
 	public ExecutablePlan compile( final PhysicalPlan qep )
 			throws QueryCompilationException
 	{
+		log.debug("Compiling physical plan using iterator-based execution model.");
 		final ExecutionContext execCxt = createExecContext();
 		final ResultElementIterator it = compile( qep, execCxt );
 		return new IteratorBasedExecutablePlanImpl(it);
@@ -70,6 +76,10 @@ public class QueryPlanCompilerForIteratorBasedExecution extends QueryPlanCompile
 		}
 		else
 		{
+			log.debug(
+				"Unsupported operator arity: {} for operator {}",
+				qep.numberOfSubPlans(),
+				qep.getRootOperator().getClass().getSimpleName() );
 			throw new IllegalArgumentException();
 		}
 	}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/compiler/QueryPlanCompilerForPushBasedExecution.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/compiler/QueryPlanCompilerForPushBasedExecution.java
@@ -4,6 +4,9 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.executable.BinaryExecutableOp;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutablePlan;
@@ -29,12 +32,15 @@ import se.liu.ida.hefquin.engine.queryproc.QueryProcContext;
 
 public class QueryPlanCompilerForPushBasedExecution extends QueryPlanCompilerBase
 {
+	private static final Logger log = LoggerFactory.getLogger( QueryPlanCompilerForPushBasedExecution.class );
+
 	public QueryPlanCompilerForPushBasedExecution( final QueryProcContext ctxt ) {
 		super(ctxt);
 	}
 
 	@Override
 	public ExecutablePlan compile( final PhysicalPlan qep ) {
+		log.debug("Compiling physical plan using push-based execution model.");
 		final ExecutionContext execCtxt = createExecContext();
 		final LinkedList<PushBasedPlanThread> threads = createThreads(qep, execCtxt);
 		return new PushBasedExecutablePlanImpl(threads, execCtxt);
@@ -52,6 +58,10 @@ public class QueryPlanCompilerForPushBasedExecution extends QueryPlanCompilerBas
 				threads2.add(t);
 			}
 		}
+		log.debug(
+			"Push-based construction produced {} thread nodes (incl. connectors) and {} executable worker threads.",
+			threads.size(),
+			threads2.size() );
 
 		return threads2;
 	}
@@ -82,6 +92,7 @@ public class QueryPlanCompilerForPushBasedExecution extends QueryPlanCompilerBas
 				threads.addFirst(t);
 			}
 			else {
+				log.debug( "Reusing existing push-based thread for shared subplan." );
 				// If we have indeed seen the given QEP before, then reuse
 				// the thread that we have already created for it, ...
 				final PushBasedPlanThread existingThread = convertedSubPlans.get(qep);
@@ -156,6 +167,7 @@ public class QueryPlanCompilerForPushBasedExecution extends QueryPlanCompilerBas
 			}
 			else
 			{
+				log.debug( "Unsupported physical operator encountered during push-based compilation: {}", pop.getClass().getName() );
 				throw new IllegalArgumentException();
 			}
 		}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/execution/ExecutionEngineImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/execution/ExecutionEngineImpl.java
@@ -1,5 +1,8 @@
 package se.liu.ida.hefquin.engine.queryproc.impl.execution;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecutablePlan;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionEngine;
 import se.liu.ida.hefquin.engine.queryproc.ExecutionException;
@@ -8,11 +11,17 @@ import se.liu.ida.hefquin.engine.queryproc.QueryResultSink;
 
 public class ExecutionEngineImpl implements ExecutionEngine
 {
+	private static final Logger log = LoggerFactory.getLogger( ExecutionEngineImpl.class );
+
 	@Override
 	public ExecutionStats execute( final ExecutablePlan plan, final QueryResultSink resultSink )
 			throws ExecutionException
 	{
+		log.debug("Starting executable plan execution.");
+
 		plan.run(resultSink);
+
+		log.debug("Executable plan execution finished.");
 
 		return new ExecutionStatsImpl( plan.getStats() );
 	}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/planning/QueryPlannerImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/planning/QueryPlannerImpl.java
@@ -69,7 +69,7 @@ public class QueryPlannerImpl implements QueryPlanner
 	@Override
 	public Pair<PhysicalPlan, QueryPlanningStats> createPlan( final Query query,
 	                                                          final QueryProcContext ctxt ) throws QueryPlanningException {
-		log.debug("Starting source assignment phase.");
+		log.debug("Starting source selection phase.");
 
 		final long t1 = System.currentTimeMillis();
 		final Pair<LogicalPlan, SourcePlanningStats> saAndStats = sourcePlanner.createSourceAssignment(query, ctxt);
@@ -78,7 +78,7 @@ public class QueryPlannerImpl implements QueryPlanner
 			srcasgPrinter.print( saAndStats.object1, LogicalPlanStage.SOURCE_ASSIGNMENT );
 		}
 		final long t2 = System.currentTimeMillis();
-		log.debug( "Source assignment completed in {} ms.", (t2 - t1) );
+		log.debug( "Source selection completed in {} ms.", (t2 - t1) );
 		log.debug( "Starting logical optimization phase." );
 		final LogicalPlan lp;
 		if ( loptimizer != null ) {
@@ -103,7 +103,7 @@ public class QueryPlannerImpl implements QueryPlanner
 		if ( lp instanceof LogicalPlanWithoutResult ) {
 			planAndStats = new Pair<>( PhysicalPlanWithoutResult.getInstance(),
 			                           null );  // no stats
-			log.debug( "Logical optimization produced a plan without results; skipping physical optimization." );
+			log.debug( "Logical optimization returned a plan that produces the empty result; skipping physical optimization." );
 		}
 		else
 			planAndStats = poptimizer.optimize(lp, ctxt);

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/planning/QueryPlannerImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/planning/QueryPlannerImpl.java
@@ -1,5 +1,8 @@
 package se.liu.ida.hefquin.engine.queryproc.impl.planning;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.query.Query;
 import se.liu.ida.hefquin.base.utils.Pair;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlan;
@@ -25,6 +28,8 @@ import se.liu.ida.hefquin.engine.queryproc.SourcePlanningStats;
  */
 public class QueryPlannerImpl implements QueryPlanner
 {
+	private static final Logger log = LoggerFactory.getLogger( QueryPlannerImpl.class );
+
 	protected final SourcePlanner sourcePlanner;
 	protected final LogicalOptimizer loptimizer;
 	protected final PhysicalOptimizer poptimizer;
@@ -64,6 +69,8 @@ public class QueryPlannerImpl implements QueryPlanner
 	@Override
 	public Pair<PhysicalPlan, QueryPlanningStats> createPlan( final Query query,
 	                                                          final QueryProcContext ctxt ) throws QueryPlanningException {
+		log.debug("Starting source assignment phase.");
+
 		final long t1 = System.currentTimeMillis();
 		final Pair<LogicalPlan, SourcePlanningStats> saAndStats = sourcePlanner.createSourceAssignment(query, ctxt);
 
@@ -71,29 +78,38 @@ public class QueryPlannerImpl implements QueryPlanner
 			srcasgPrinter.print( saAndStats.object1, LogicalPlanStage.SOURCE_ASSIGNMENT );
 		}
 		final long t2 = System.currentTimeMillis();
+		log.debug( "Source assignment completed in {} ms.", (t2 - t1) );
+		log.debug( "Starting logical optimization phase." );
 		final LogicalPlan lp;
 		if ( loptimizer != null ) {
 			final boolean keepNaryOperators = poptimizer.assumesLogicalMultiwayJoins();
 			lp = loptimizer.optimize(saAndStats.object1, keepNaryOperators, ctxt);
+			log.debug( "Logical optimizer invoked with keepNaryOperators={}.", keepNaryOperators );
 		}
 		else {
 			lp = saAndStats.object1;
+			log.debug( "No logical optimizer configured; using source assignment directly." );
 		}
-		
+
 		if ( lplanPrinter != null ) {
 			lplanPrinter.print( lp, LogicalPlanStage.FINAL_LOGICAL_PLAN );
 		}
 
 		final long t3 = System.currentTimeMillis();
+		log.debug( "Logical optimization completed in {} ms.", (t3 - t2) );
+		log.debug( "Starting physical optimization phase." );
 
 		final Pair<PhysicalPlan, PhysicalOptimizationStats> planAndStats;
-		if ( lp instanceof LogicalPlanWithoutResult )
+		if ( lp instanceof LogicalPlanWithoutResult ) {
 			planAndStats = new Pair<>( PhysicalPlanWithoutResult.getInstance(),
 			                           null );  // no stats
+			log.debug( "Logical optimization produced a plan without results; skipping physical optimization." );
+		}
 		else
 			planAndStats = poptimizer.optimize(lp, ctxt);
 
 		final long t4 = System.currentTimeMillis();
+		log.debug( "Physical optimization completed in {} ms.", (t4 - t3) );
 
 		if ( pplanPrinter != null ) {
 			pplanPrinter.print( planAndStats.object1 );

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/PhysicalOptimizerBase.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/PhysicalOptimizerBase.java
@@ -1,5 +1,8 @@
 package se.liu.ida.hefquin.engine.queryproc.impl.poptimizer;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.utils.Pair;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
@@ -11,11 +14,15 @@ import se.liu.ida.hefquin.engine.queryproc.QueryProcContext;
 
 public abstract class PhysicalOptimizerBase implements PhysicalOptimizer
 {
+	private static final Logger log = LoggerFactory.getLogger( PhysicalOptimizerBase.class );
+
 	@Override
 	public final Pair<PhysicalPlan, PhysicalOptimizationStats> optimize( final LogicalPlan lp,
 	                                                                     final QueryProcContext ctxt )
 			throws PhysicalOptimizationException {
 		final boolean keepMultiwayJoins = keepMultiwayJoinsInInitialPhysicalPlan();
+
+		log.debug( "Converting logical plan to physical plan (keepMultiwayJoins={})", keepMultiwayJoins );
 
 		final LogicalToPhysicalPlanConverter lp2pp = ctxt.getLogicalToPhysicalPlanConverter();
 		final PhysicalPlan initialPhysicalPlan = lp2pp.convert(lp, keepMultiwayJoins, ctxt);

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/PhysicalOptimizerWithoutOptimization.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/PhysicalOptimizerWithoutOptimization.java
@@ -1,5 +1,8 @@
 package se.liu.ida.hefquin.engine.queryproc.impl.poptimizer;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import se.liu.ida.hefquin.base.utils.Pair;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
 import se.liu.ida.hefquin.engine.queryproc.PhysicalOptimizationException;
@@ -8,6 +11,8 @@ import se.liu.ida.hefquin.engine.queryproc.QueryProcContext;
 
 public class PhysicalOptimizerWithoutOptimization extends PhysicalOptimizerBase
 {
+	private static final Logger log = LoggerFactory.getLogger( PhysicalOptimizerWithoutOptimization.class );
+
 	@Override
 	public boolean assumesLogicalMultiwayJoins() {
 		return false;
@@ -24,6 +29,7 @@ public class PhysicalOptimizerWithoutOptimization extends PhysicalOptimizerBase
 			final QueryProcContext ctxt )
 					throws PhysicalOptimizationException
 	{
+		log.debug( "Skipping physical optimization (identity optimizer)." );
 		return new Pair<>( initialPlan, new PhysicalOptimizationStatsImpl() );
 	}
 


### PR DESCRIPTION
Addresses #633 by adding logging for:
- `QueryProcessorImpl`
- `PhysicalOptimizerWithoutOptimization`
- `QueryPlanCompilerForPushBasedExecution` (and also the iterator-based compiler)

as well as relevant helper classes for these classes.