### PR TITLE
Push DISTINCT into SPARQL request depending on request operator's mayReduce flag

### DIFF
--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/MergeRequests.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/MergeRequests.java
@@ -404,9 +404,11 @@ public class MergeRequests implements HeuristicForLogicalOptimization
 					newProj = op.getVariables();
 				}
 
-				final SPARQLRequest newReq = new SPARQLRequestImpl( req.getQueryPattern(), newProj, req.getDistinctRequired() );
+				final boolean mayReduce = reqOp.mayReduce() || op.mayReduce();
 
-				final LogicalOpRequest<?,?> mergedReqOp = new LogicalOpRequest<>( reqOp.getFederationMember(), op.mayReduce(), newReq );
+				final SPARQLRequest newReq = new SPARQLRequestImpl( req.getQueryPattern(), newProj, req.getDistinctRequired() || mayReduce );
+
+				final LogicalOpRequest<?,?> mergedReqOp = new LogicalOpRequest<>( reqOp.getFederationMember(), mayReduce, newReq );
 				returnPlan = new LogicalPlanWithNullaryRootImpl(mergedReqOp, null);
 			}
 		}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/MergeRequests.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/MergeRequests.java
@@ -404,7 +404,7 @@ public class MergeRequests implements HeuristicForLogicalOptimization
 					newProj = op.getVariables();
 				}
 
-				final boolean mayReduce = reqOp.mayReduce() || op.mayReduce();
+				final boolean mayReduce = reqOp.mayReduce() && op.mayReduce();
 
 				final SPARQLRequest newReq = new SPARQLRequestImpl( req.getQueryPattern(), newProj, req.getDistinctRequired() || mayReduce );
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/ProjectPushDown.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/ProjectPushDown.java
@@ -297,7 +297,7 @@ public class ProjectPushDown implements HeuristicForLogicalOptimization
 					newProj = projectOp.getVariables();
 				}
 
-			final boolean mayReduce = reqOp.mayReduce() || projectOp.mayReduce();
+			final boolean mayReduce = reqOp.mayReduce() && projectOp.mayReduce();
 
 			final SPARQLRequest newReq = new SPARQLRequestImpl( oldReq.getQueryPattern(), newProj, oldReq.getDistinctRequired() || mayReduce );
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/ProjectPushDown.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/ProjectPushDown.java
@@ -297,9 +297,11 @@ public class ProjectPushDown implements HeuristicForLogicalOptimization
 					newProj = projectOp.getVariables();
 				}
 
-			final SPARQLRequest newReq = new SPARQLRequestImpl( oldReq.getQueryPattern(), newProj, oldReq.getDistinctRequired() );
+			final boolean mayReduce = reqOp.mayReduce() || projectOp.mayReduce();
 
-			final LogicalOpRequest<?,?> mergedReqOp = new LogicalOpRequest<>( reqOp.getFederationMember(), projectOp.mayReduce(), newReq );
+			final SPARQLRequest newReq = new SPARQLRequestImpl( oldReq.getQueryPattern(), newProj, oldReq.getDistinctRequired() || mayReduce );
+
+			final LogicalOpRequest<?,?> mergedReqOp = new LogicalOpRequest<>( reqOp.getFederationMember(), mayReduce, newReq );
 			return new LogicalPlanWithNullaryRootImpl(mergedReqOp, null);
 		}
 		return inputPlan;

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/MergeRequestsTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/MergeRequestsTest.java
@@ -601,10 +601,10 @@ public class MergeRequestsTest extends EngineTestBase
 		final FederationMember fm = new SPARQLEndpointForTest("http://ex.org");
 
 		final TriplePattern tp1 = new TriplePatternImpl(v1, v1, v3);
-		final LogicalOpRequest<?,?> reqOp1 = new LogicalOpRequest<>( fm, false, new SPARQLRequestImpl(tp1, Set.of(v1,v3), false) );
+		final LogicalOpRequest<?,?> reqOp1 = new LogicalOpRequest<>( fm, true, new SPARQLRequestImpl(tp1, Set.of(v1,v3), true) );
 
 		final TriplePattern tp2 = new TriplePatternImpl(v2, v2, v3);
-		final LogicalOpRequest<?,?> reqOp2 = new LogicalOpRequest<>( fm, false, new SPARQLRequestImpl(tp2, Set.of(v2), false) );
+		final LogicalOpRequest<?,?> reqOp2 = new LogicalOpRequest<>( fm, true, new SPARQLRequestImpl(tp2, Set.of(v2), true) );
 
 		final LogicalPlan joinSubPlan = LogicalPlanUtils.createPlanWithBinaryJoin(
 			true,
@@ -613,7 +613,7 @@ public class MergeRequestsTest extends EngineTestBase
 			null );
 
 		// Project keeps y
-		final LogicalOpProject projectOp = new LogicalOpProject(Set.of(v3), false);
+		final LogicalOpProject projectOp = new LogicalOpProject(Set.of(v3), true);
 		final LogicalPlan projectPlan = new LogicalPlanWithUnaryRootImpl(projectOp, null, joinSubPlan);
 
 		// test

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/MergeRequestsTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/MergeRequestsTest.java
@@ -582,8 +582,48 @@ public class MergeRequestsTest extends EngineTestBase
 		assertTrue( result.getRootOperator() instanceof LogicalOpRequest );
 
 		final SPARQLRequest resultReq = (SPARQLRequest) ((LogicalOpRequest<?, ?>) result.getRootOperator()).getRequest();
-		assertEquals( Set.of(v3), resultReq.getProjectionVars());
+		assertEquals( Set.of(v3), resultReq.getProjectionVars() );
 		assertFalse( resultReq.getDistinctRequired() );
+	}
+
+	@Test
+	public void mergeProjectDistinct() {
+		// two request operators under a duplicate-reducing JOIN,
+		// wrapped by a PROJECT operator and targeting the same
+		// federation member, should be merged into a single request
+		// operator with the DISTINCT pushed down into the merged request
+
+		// setup
+		final Var v1 = Var.alloc("x");
+		final Var v2 = Var.alloc("y");
+		final Var v3 = Var.alloc("z");
+
+		final FederationMember fm = new SPARQLEndpointForTest("http://ex.org");
+
+		final TriplePattern tp1 = new TriplePatternImpl(v1, v1, v3);
+		final LogicalOpRequest<?,?> reqOp1 = new LogicalOpRequest<>( fm, false, new SPARQLRequestImpl(tp1, Set.of(v1,v3), false) );
+
+		final TriplePattern tp2 = new TriplePatternImpl(v2, v2, v3);
+		final LogicalOpRequest<?,?> reqOp2 = new LogicalOpRequest<>( fm, false, new SPARQLRequestImpl(tp2, Set.of(v2), false) );
+
+		final LogicalPlan joinSubPlan = LogicalPlanUtils.createPlanWithBinaryJoin(
+			true,
+			new LogicalPlanWithNullaryRootImpl(reqOp1, null),
+			new LogicalPlanWithNullaryRootImpl(reqOp2, null),
+			null );
+
+		// Project keeps y
+		final LogicalOpProject projectOp = new LogicalOpProject(Set.of(v3), false);
+		final LogicalPlan projectPlan = new LogicalPlanWithUnaryRootImpl(projectOp, null, joinSubPlan);
+
+		// test
+		final LogicalPlan result = new MergeRequests().apply(projectPlan);
+
+		// check
+		assertTrue( result.getRootOperator() instanceof LogicalOpRequest );
+
+		final SPARQLRequest resultReq = (SPARQLRequest) ((LogicalOpRequest<?, ?>) result.getRootOperator()).getRequest();
+		assertTrue( resultReq.getDistinctRequired() );
 	}
 
 	@Test

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/ProjectPushDownTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/ProjectPushDownTest.java
@@ -100,11 +100,11 @@ public class ProjectPushDownTest extends EngineTestBase
 		final LogicalOpRequest<?,?> reqOp1 = new LogicalOpRequest<>(
 			new SPARQLEndpointForTest("http://exA.org"),
 			true,
-			new SPARQLRequestImpl(tp1) );
+			new SPARQLRequestImpl(tp1, null, true) );
 		final LogicalPlan reqPlan = new LogicalPlanWithNullaryRootImpl(reqOp1, null);
 
 		// Project keeps y
-		final LogicalOpProject projectOp = new LogicalOpProject(Set.of(v2), false);
+		final LogicalOpProject projectOp = new LogicalOpProject(Set.of(v2), true);
 		final LogicalPlan projectPlan = new LogicalPlanWithUnaryRootImpl(projectOp, null, reqPlan);
 
 		// test

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/ProjectPushDownTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/ProjectPushDownTest.java
@@ -86,6 +86,38 @@ public class ProjectPushDownTest extends EngineTestBase
 	}
 
 	@Test
+	public void pushDistinctIntoRequest() {
+		// A project on top of a request to a SPARQL endpoint;
+		// the request operator has the mayReduce flag set and
+		// so the request is expected to be DISTINCT.
+
+		// set up
+		final Var v1 = Var.alloc("x");
+		final Var v2 = Var.alloc("y");
+
+		// Left request produces x
+		final TriplePattern tp1 = new TriplePatternImpl(v1, v1, v1);
+		final LogicalOpRequest<?,?> reqOp1 = new LogicalOpRequest<>(
+			new SPARQLEndpointForTest("http://exA.org"),
+			true,
+			new SPARQLRequestImpl(tp1) );
+		final LogicalPlan reqPlan = new LogicalPlanWithNullaryRootImpl(reqOp1, null);
+
+		// Project keeps y
+		final LogicalOpProject projectOp = new LogicalOpProject(Set.of(v2), false);
+		final LogicalPlan projectPlan = new LogicalPlanWithUnaryRootImpl(projectOp, null, reqPlan);
+
+		// test
+		final LogicalPlan result = new ProjectPushDown().apply(projectPlan);
+
+		// check
+		assertTrue( result.getRootOperator() instanceof LogicalOpRequest );
+
+		final SPARQLRequest resultReq = (SPARQLRequest) ((LogicalOpRequest<?, ?>) result.getRootOperator()).getRequest();
+		assertTrue( resultReq.getDistinctRequired() );
+	}
+
+	@Test
 	public void pushProjectIntoFixedSolMapEqual() {
 		// A project on top of a fixed solution mapping operator;
 		// set of project variables equal to the set of variables


### PR DESCRIPTION
Closes #570.

Not certain if this is what was meant by the comment you made in the issue but the heuristics now also consider the original request operator's `mayReduce` flag in addition to the project operator's `mayReduce` flag.