### PR TITLE
Add skipExecution header and use QueryProcContext in server

### DIFF
--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/net/http/HttpConstants.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/net/http/HttpConstants.java
@@ -1,0 +1,6 @@
+package se.liu.ida.hefquin.base.net.http;
+
+public class HttpConstants
+{
+	public static final String X_HEADER_SKIP_EXECUTION = "X-HeFQUIN-Skip-Execution";
+}

--- a/hefquin-cli/pom.xml
+++ b/hefquin-cli/pom.xml
@@ -47,12 +47,6 @@
       <artifactId>hefquin-service</artifactId>
       <version>0.0.12-SNAPSHOT</version>
     </dependency>
-	  <!-- hefquin-base -->
-    <dependency>
-      <groupId>se.liu.research.hefquin</groupId>
-      <artifactId>hefquin-base</artifactId>
-      <version>0.0.12-SNAPSHOT</version>
-    </dependency>
     <dependency>
       <groupId>org.apache.jena</groupId>
       <artifactId>jena-cmds</artifactId>

--- a/hefquin-cli/pom.xml
+++ b/hefquin-cli/pom.xml
@@ -7,7 +7,7 @@
     <artifactId>hefquin</artifactId>
     <version>0.0.12-SNAPSHOT</version>
   </parent>
-  
+
   <artifactId>hefquin-cli</artifactId>
 
   <!-- Project Meta Data -->
@@ -45,6 +45,12 @@
     <dependency>
       <groupId>se.liu.research.hefquin</groupId>
       <artifactId>hefquin-service</artifactId>
+      <version>0.0.12-SNAPSHOT</version>
+    </dependency>
+	  <!-- hefquin-base -->
+    <dependency>
+      <groupId>se.liu.research.hefquin</groupId>
+      <artifactId>hefquin-base</artifactId>
       <version>0.0.12-SNAPSHOT</version>
     </dependency>
     <dependency>

--- a/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunHttpQuery.java
+++ b/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunHttpQuery.java
@@ -54,11 +54,12 @@ import se.liu.ida.hefquin.jenaext.sparql.lang.sparql_12_hefquin.ParserSPARQL12He
  */
 public class RunHttpQuery extends CmdARQ
 {
-	protected final ModTime       modTime =    new ModTime();
-	protected final ModResultsOut modResults = new ModResultsOut();
-	protected final ModQuery      modQuery =   new ModQuery();
+	protected final ModTime        modTime =     new ModTime();
+	protected final ModQuery       modQuery =    new ModQuery();
+	protected final ModResultsOut  modResults =  new ModResultsOut();
 
 	protected final ArgDecl argSuppressResultPrintout = new ArgDecl( ArgDecl.NoValue, "suppressResultPrintout" );
+	protected final ArgDecl argSkipExecution = new ArgDecl( ArgDecl.NoValue, "skipExecution" );
 	protected final ArgDecl argServerAddress = new ArgDecl( ArgDecl.HasValue, "server" );
 	protected final ArgDecl argOutputToFile =  new ArgDecl( ArgDecl.HasValue, "outputToFile" );
 
@@ -77,6 +78,7 @@ public class RunHttpQuery extends CmdARQ
 		addModule( modResults );
 
 		add( argSuppressResultPrintout, "--suppressResultPrintout", "Do not print out the query result" );
+		add( argSkipExecution, "--skipExecution", "Do not execute the query (but create the execution plan)" );
 		add( argServerAddress, "--server", "Address of HeFQUIN service" );
 		add( argOutputToFile, "--outputToFile", "Output file (optional, printing to stdout if omitted)" );
 
@@ -175,12 +177,18 @@ public class RunHttpQuery extends CmdARQ
 			.connectTimeout( Duration.ofMillis(5000) )
 			.build();
 
-		final HttpRequest request = HttpRequest.newBuilder()
+		final HttpRequest.Builder builder = HttpRequest.newBuilder()
 			.uri( URI.create(serverURI) )
 			.header( "Content-Type", "application/sparql-query" )
 			.header( "Accept", "application/sparql-results+json" )
 			.timeout( Duration.ofSeconds(60) )
-			.POST( HttpRequest.BodyPublishers.ofString(prepareQuery( query )) )
+			.POST( HttpRequest.BodyPublishers.ofString(prepareQuery( query )) );
+
+		if ( contains(argSkipExecution) )
+			builder.header( "X-HeFQUIN-Skip-Execution", "true" );
+
+		final HttpRequest request = builder
+			.POST( HttpRequest.BodyPublishers.ofString(query.toString()) )
 			.build();
 
 		final HttpResponse<InputStream> response;

--- a/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunHttpQuery.java
+++ b/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunHttpQuery.java
@@ -35,6 +35,7 @@ import org.apache.jena.sparql.util.QueryExecUtils;
 import arq.cmdline.CmdARQ;
 import arq.cmdline.ModResultsOut;
 import arq.cmdline.ModTime;
+import se.liu.ida.hefquin.base.net.http.HttpConstants;
 import se.liu.ida.hefquin.cli.modules.ModQuery;
 import se.liu.ida.hefquin.jenaext.query.SyntaxForHeFQUIN;
 import se.liu.ida.hefquin.jenaext.sparql.lang.sparql_12_hefquin.ParserSPARQL12HeFQUIN;
@@ -185,11 +186,9 @@ public class RunHttpQuery extends CmdARQ
 			.POST( HttpRequest.BodyPublishers.ofString(prepareQuery( query )) );
 
 		if ( contains(argSkipExecution) )
-			builder.header( "X-HeFQUIN-Skip-Execution", "true" );
+			builder.header( HttpConstants.X_HEADER_SKIP_EXECUTION, "true" );
 
-		final HttpRequest request = builder
-			.POST( HttpRequest.BodyPublishers.ofString(query.toString()) )
-			.build();
+		final HttpRequest request = builder.build();
 
 		final HttpResponse<InputStream> response;
 		try {

--- a/hefquin-service/src/main/java/se/liu/ida/hefquin/service/SparqlServlet.java
+++ b/hefquin-service/src/main/java/se/liu/ida/hefquin/service/SparqlServlet.java
@@ -23,6 +23,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import se.liu.ida.hefquin.base.net.http.HttpConstants;
 import se.liu.ida.hefquin.engine.HeFQUINEngine;
 import se.liu.ida.hefquin.engine.IllegalQueryException;
 import se.liu.ida.hefquin.engine.QueryProcessingStatsAndExceptions;
@@ -141,7 +142,7 @@ public class SparqlServlet extends HttpServlet {
 
 		// Create QueryProcContext using request-specific execution settings
 		final QueryProcContextBuilder ctxBuilder = engine.getQueryProcContextBuilder()
-					.setSkipExecution( Boolean.parseBoolean( request.getHeader("X-HeFQUIN-Skip-Execution") ) );
+					.setSkipExecution( Boolean.parseBoolean( request.getHeader(HttpConstants.X_HEADER_SKIP_EXECUTION) ) );
 		final QueryProcContext ctx = ctxBuilder.build();
 
 		try {

--- a/hefquin-service/src/main/java/se/liu/ida/hefquin/service/SparqlServlet.java
+++ b/hefquin-service/src/main/java/se/liu/ida/hefquin/service/SparqlServlet.java
@@ -141,7 +141,7 @@ public class SparqlServlet extends HttpServlet {
 
 		// Create QueryProcContext using request-specific execution settings
 		final QueryProcContextBuilder ctxBuilder = engine.getQueryProcContextBuilder()
-					.setSkipExecution( Boolean.valueOf( request.getHeader("X-HeFQUIN-Skip-Execution") ) );
+					.setSkipExecution( Boolean.parseBoolean( request.getHeader("X-HeFQUIN-Skip-Execution") ) );
 		final QueryProcContext ctx = ctxBuilder.build();
 
 		try {

--- a/hefquin-service/src/main/java/se/liu/ida/hefquin/service/SparqlServlet.java
+++ b/hefquin-service/src/main/java/se/liu/ida/hefquin/service/SparqlServlet.java
@@ -27,6 +27,8 @@ import se.liu.ida.hefquin.engine.HeFQUINEngine;
 import se.liu.ida.hefquin.engine.IllegalQueryException;
 import se.liu.ida.hefquin.engine.QueryProcessingStatsAndExceptions;
 import se.liu.ida.hefquin.engine.UnsupportedQueryException;
+import se.liu.ida.hefquin.engine.queryproc.QueryProcContext;
+import se.liu.ida.hefquin.engine.queryproc.QueryProcContextBuilder;
 import se.liu.ida.hefquin.jenaext.query.SyntaxForHeFQUIN;
 
 /**
@@ -137,10 +139,15 @@ public class SparqlServlet extends HttpServlet {
 			return;
 		}
 
+		// Create QueryProcContext using request-specific execution settings
+		final QueryProcContextBuilder ctxBuilder = engine.getQueryProcContextBuilder()
+					.setSkipExecution( Boolean.valueOf( request.getHeader("X-HeFQUIN-Skip-Execution") ) );
+		final QueryProcContext ctx = ctxBuilder.build();
+
 		try {
 			logger.debug( "Received SPARQL query: {}", query );
 
-			final JsonObject result = execute( query, mimeType );
+			final JsonObject result = execute( query, mimeType, ctx );
 			if ( ! result.get( "exceptions" ).getAsArray().isEmpty() ) {
 				writeJsonError( response, 500, result.get( "exceptions" ) );
 				return;
@@ -200,7 +207,7 @@ public class SparqlServlet extends HttpServlet {
 	 * @param mimeType    the MIME type for the response format
 	 * @return the query result and exceptions in JSON format
 	 */
-	private static JsonObject execute( final String queryString, final String mimeType )
+	private static JsonObject execute( final String queryString, final String mimeType, final QueryProcContext ctx )
 			throws UnsupportedQueryException, IllegalQueryException
 	{
 		final Query query = QueryFactory.create( queryString, SyntaxForHeFQUIN.syntaxSPARQL_12_HeFQUIN );
@@ -209,7 +216,7 @@ public class SparqlServlet extends HttpServlet {
 
 		final QueryProcessingStatsAndExceptions statsAndExceptions;
 		try ( PrintStream ps = new PrintStream( baos, true, StandardCharsets.UTF_8 ) ) {
-			statsAndExceptions = engine.executeQueryAndPrintResult(query, resultsFormat, ps);
+			statsAndExceptions = engine.executeQueryAndPrintResult(query, resultsFormat, ps, ctx);
 		}
 
 		final JsonObject res = new JsonObject();

--- a/hefquin-service/src/main/java/se/liu/ida/hefquin/service/SparqlServlet.java
+++ b/hefquin-service/src/main/java/se/liu/ida/hefquin/service/SparqlServlet.java
@@ -205,6 +205,7 @@ public class SparqlServlet extends HttpServlet {
 	 *
 	 * @param queryString the SPARQL query string
 	 * @param mimeType    the MIME type for the response format
+	 * @param ctx         the processing context
 	 * @return the query result and exceptions in JSON format
 	 */
 	private static JsonObject execute( final String queryString, final String mimeType, final QueryProcContext ctx )


### PR DESCRIPTION
Addresses #641 by extending `bin/hefquin-client` with the `skipExecution` feature. 