### PR TITLE
Extend bin/hefquin-client to include plan printing flags

### DIFF
--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/net/http/HttpConstants.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/net/http/HttpConstants.java
@@ -2,5 +2,18 @@ package se.liu.ida.hefquin.base.net.http;
 
 public class HttpConstants
 {
+	// request headers
 	public static final String X_HEADER_SKIP_EXECUTION = "X-HeFQUIN-Skip-Execution";
+	public static final String X_HEADER_PRINT_SOURCE_ASSIGNMENT = "X-HeFQUIN-Print-Source-Assignment";
+	public static final String X_HEADER_PRINT_LOGICAL_PLAN = "X-HeFQUIN-Print-Logical-Plan";
+	public static final String X_HEADER_PRINT_PHYSICAL_PLAN = "X-HeFQUIN-Print-Physical-Plan";
+	public static final String X_HEADER_PRINT_EXECUTABLE_PLAN = "X-HeFQUIN-Print-Executable-Plan";
+
+	// response JSON fields
+	public static final String JSON_RESULT = "result";
+	public static final String JSON_SOURCE_ASSIGNMENT = "sourceAssignment";
+	public static final String JSON_LOGICAL_PLAN = "logicalPlan";
+	public static final String JSON_PHYSICAL_PLAN = "physicalPlan";
+	public static final String JSON_EXECUTABLE_PLAN = "executablePlan";
+	public static final String JSON_EXCEPTIONS = "exceptions";
 }

--- a/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunHttpQuery.java
+++ b/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunHttpQuery.java
@@ -1,5 +1,6 @@
 package se.liu.ida.hefquin.cli;
 
+import java.io.ByteArrayInputStream;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -9,11 +10,15 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.output.NullPrintStream;
 import org.apache.jena.atlas.io.IndentedWriter;
+import org.apache.jena.atlas.json.JSON;
+import org.apache.jena.atlas.json.JsonObject;
+import org.apache.jena.atlas.json.JsonValue;
 import org.apache.jena.cmd.ArgDecl;
 import org.apache.jena.cmd.TerminationException;
 import org.apache.jena.query.ARQ;
@@ -36,6 +41,7 @@ import arq.cmdline.CmdARQ;
 import arq.cmdline.ModResultsOut;
 import arq.cmdline.ModTime;
 import se.liu.ida.hefquin.base.net.http.HttpConstants;
+import se.liu.ida.hefquin.cli.modules.ModPlanPrinting;
 import se.liu.ida.hefquin.cli.modules.ModQuery;
 import se.liu.ida.hefquin.jenaext.query.SyntaxForHeFQUIN;
 import se.liu.ida.hefquin.jenaext.sparql.lang.sparql_12_hefquin.ParserSPARQL12HeFQUIN;
@@ -55,9 +61,10 @@ import se.liu.ida.hefquin.jenaext.sparql.lang.sparql_12_hefquin.ParserSPARQL12He
  */
 public class RunHttpQuery extends CmdARQ
 {
-	protected final ModTime        modTime =     new ModTime();
-	protected final ModQuery       modQuery =    new ModQuery();
-	protected final ModResultsOut  modResults =  new ModResultsOut();
+	protected final ModTime          modTime =          new ModTime();
+	protected final ModPlanPrinting  modPlanPrinting =  new ModPlanPrinting();
+	protected final ModResultsOut    modResults =       new ModResultsOut();
+	protected final ModQuery         modQuery =         new ModQuery();
 
 	protected final ArgDecl argSuppressResultPrintout = new ArgDecl( ArgDecl.NoValue, "suppressResultPrintout" );
 	protected final ArgDecl argSkipExecution = new ArgDecl( ArgDecl.NoValue, "skipExecution" );
@@ -76,6 +83,7 @@ public class RunHttpQuery extends CmdARQ
 		registerHeFQUINJenaIntegration();
 
 		addModule( modTime );
+		addModule( modPlanPrinting );
 		addModule( modResults );
 
 		add( argSuppressResultPrintout, "--suppressResultPrintout", "Do not print out the query result" );
@@ -188,6 +196,18 @@ public class RunHttpQuery extends CmdARQ
 		if ( contains(argSkipExecution) )
 			builder.header( HttpConstants.X_HEADER_SKIP_EXECUTION, "true" );
 
+		if ( modPlanPrinting.getSourceAssignmentPrinter() != null )
+			builder.header( HttpConstants.X_HEADER_PRINT_SOURCE_ASSIGNMENT, "true" );
+
+		if ( modPlanPrinting.getLogicalPlanPrinter() != null )
+			builder.header( HttpConstants.X_HEADER_PRINT_LOGICAL_PLAN, "true" );
+
+		if ( modPlanPrinting.getPhysicalPlanPrinter() != null )
+			builder.header( HttpConstants.X_HEADER_PRINT_PHYSICAL_PLAN, "true" );
+
+		if ( modPlanPrinting.getExecutablePlanPrinter() != null )
+			builder.header( HttpConstants.X_HEADER_PRINT_EXECUTABLE_PLAN, "true" );
+
 		final HttpRequest request = builder.build();
 
 		final HttpResponse<InputStream> response;
@@ -195,11 +215,11 @@ public class RunHttpQuery extends CmdARQ
 			response = client.send( request, HttpResponse.BodyHandlers.ofInputStream() );
 		}
 		catch ( final IOException e ) {
-			cmdError( "Request to address at <" + serverURI.toString() + "> failed: " + e.getMessage(), true );
+			cmdError( "Request to address at <" + serverURI + "> failed: " + e.getMessage(), true );
 			return;
 		}
 		catch ( final InterruptedException e ) {
-			cmdError( "Request to address at <" + serverURI.toString() + "> failed: " + e.getMessage(), true );
+			cmdError( "Request to address at <" + serverURI + "> failed: " + e.getMessage(), true );
 			return;
 		}
 
@@ -208,7 +228,16 @@ public class RunHttpQuery extends CmdARQ
 			return;
 		}
 
-		final ResultSet rs = ResultSetFactory.fromJSON( response.body() );
+		final JsonObject obj = JSON.parse(response.body());
+
+		printPlans( obj );
+
+		final ResultSet rs = ResultSetFactory.fromJSON(
+			new ByteArrayInputStream(
+				obj.getString(HttpConstants.JSON_RESULT)
+				.getBytes(StandardCharsets.UTF_8)
+			)
+		);
 
 		QueryExecUtils.outputResultSet( rs, query.getPrologue(), modResults.getResultsFormat(), out );
 
@@ -304,4 +333,28 @@ public class RunHttpQuery extends CmdARQ
 		return "BASE <" + query.getPrologue().getBaseURI() + ">\n" + serialized;
 	}
 
+	/**
+	 * Prints any query planning and execution artifacts contained in the
+	 * given response object using the printers configured in the plan
+	 * printing module.
+	 *
+	 * @param obj JSON response object returned by the HeFQUIN service
+	 */
+	protected void printPlans( final JsonObject obj ) {
+		final JsonValue srcasgValue = obj.get(HttpConstants.JSON_SOURCE_ASSIGNMENT);
+		if ( srcasgValue != null && srcasgValue.isString() )
+			modPlanPrinting.printSourceAssignment( srcasgValue.getAsString().value() );
+
+		final JsonValue lplanValue = obj.get(HttpConstants.JSON_LOGICAL_PLAN);
+		if ( lplanValue != null && lplanValue.isString() )
+			modPlanPrinting.printLogicalPlan( lplanValue.getAsString().value() );
+
+		final JsonValue pplanValue = obj.get(HttpConstants.JSON_PHYSICAL_PLAN);
+		if ( pplanValue != null && pplanValue.isString() )
+			modPlanPrinting.printPhysicalPlan( pplanValue.getAsString().value() );
+
+		final JsonValue eplanValue = obj.get(HttpConstants.JSON_EXECUTABLE_PLAN);
+		if ( eplanValue != null && eplanValue.isString() )
+			modPlanPrinting.printExecutablePlan( eplanValue.getAsString().value() );
+	}
 }

--- a/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/modules/ModPlanPrinting.java
+++ b/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/modules/ModPlanPrinting.java
@@ -32,6 +32,11 @@ public class ModPlanPrinting extends ModBase
 	protected PhysicalPlanPrinter pplanPrinter = null;
 	protected ExecutablePlanPrinter eplanPrinter = null;
 
+	protected PrintStream[] srcasgOutsList;
+	protected PrintStream[] lplanOutsList;
+	protected PrintStream[] pplanOutsList;
+	protected PrintStream[] eplanOutsList;
+
 	@Override
 	public void registerWith( final CmdGeneral cmdLine ) {
 		cmdLine.getUsage().startCategory("Query Plan Printing");
@@ -46,21 +51,21 @@ public class ModPlanPrinting extends ModBase
 	}
 
 	@Override
-	public void processArgs( final CmdArgModule cmdLine ) {	
-		final PrintStream[] srcasgOutsList = processPrintFlags( cmdLine, argPrintSrcAssignment, argPrintSrcAssignmentToFile );
+	public void processArgs( final CmdArgModule cmdLine ) {
+		srcasgOutsList = processPrintFlags( cmdLine, argPrintSrcAssignment, argPrintSrcAssignmentToFile );
 		if ( srcasgOutsList != null )
 			srcasgPrinter = new TextBasedLogicalPlanPrinterImpl( srcasgOutsList );
 
-		final PrintStream[] lplanOutsList = processPrintFlags( cmdLine, argPrintLogicalPlan, argPrintLogicalPlanToFile );
-		if ( lplanOutsList != null ) 
+		lplanOutsList = processPrintFlags( cmdLine, argPrintLogicalPlan, argPrintLogicalPlanToFile );
+		if ( lplanOutsList != null )
 			lplanPrinter = new TextBasedLogicalPlanPrinterImpl( lplanOutsList );
 
-		final PrintStream[] pplanOutsList = processPrintFlags( cmdLine, argPrintPhysicalPlan, argPrintPhysicalPlanToFile );
-		if ( pplanOutsList != null ) 
+		pplanOutsList = processPrintFlags( cmdLine, argPrintPhysicalPlan, argPrintPhysicalPlanToFile );
+		if ( pplanOutsList != null )
 			pplanPrinter = new TextBasedPhysicalPlanPrinterImpl( pplanOutsList );
 
-		final PrintStream[] eplanOutsList = processPrintFlags( cmdLine, argPrintExecutablePlan, argPrintExecutablePlanToFile );
-		if ( eplanOutsList != null ) 
+		eplanOutsList = processPrintFlags( cmdLine, argPrintExecutablePlan, argPrintExecutablePlanToFile );
+		if ( eplanOutsList != null )
 			eplanPrinter = new TextBasedExecutablePlanPrinterImpl( eplanOutsList );
 	}
 
@@ -94,6 +99,27 @@ public class ModPlanPrinting extends ModBase
 		}
 
 		return outsList;
+	}
+
+	public void printSourceAssignment( final String text ) {
+		print( srcasgOutsList, text );
+	}
+
+	public void printLogicalPlan( final String text ) {
+		print( lplanOutsList, text );
+	}
+
+	public void printPhysicalPlan( final String text ) {
+		print( pplanOutsList, text );
+	}
+
+	public void printExecutablePlan( final String text ) {
+		print( eplanOutsList, text );
+	}
+
+	private void print( final PrintStream[] outs, final String text ) {
+		for ( PrintStream out : outs )
+			out.print(text);
 	}
 
 	/**

--- a/hefquin-service/src/main/java/se/liu/ida/hefquin/service/SparqlServlet.java
+++ b/hefquin-service/src/main/java/se/liu/ida/hefquin/service/SparqlServlet.java
@@ -148,14 +148,22 @@ public class SparqlServlet extends HttpServlet {
 					.setSkipExecution( Boolean.parseBoolean( request.getHeader(HttpConstants.X_HEADER_SKIP_EXECUTION) ) );
 
 		final QueryResponseBuffers queryResBuf = new QueryResponseBuffers();
-		if ( Boolean.parseBoolean( request.getHeader(HttpConstants.X_HEADER_PRINT_SOURCE_ASSIGNMENT)) )
+		if ( Boolean.parseBoolean( request.getHeader(HttpConstants.X_HEADER_PRINT_SOURCE_ASSIGNMENT)) ) {
+			queryResBuf.sourceAssignment = new ByteArrayOutputStream();
 			ctxBuilder.setSourceAssignmentPrinter( new TextBasedLogicalPlanPrinterImpl( new PrintStream( queryResBuf.sourceAssignment, true, StandardCharsets.UTF_8 ) ) );
-		if ( Boolean.parseBoolean( request.getHeader(HttpConstants.X_HEADER_PRINT_LOGICAL_PLAN)) )
+		}
+		if ( Boolean.parseBoolean( request.getHeader(HttpConstants.X_HEADER_PRINT_LOGICAL_PLAN)) ) {
+			queryResBuf.logicalPlan = new ByteArrayOutputStream();
 			ctxBuilder.setLogicalPlanPrinter( new TextBasedLogicalPlanPrinterImpl( new PrintStream( queryResBuf.logicalPlan, true, StandardCharsets.UTF_8 ) ) );
-		if ( Boolean.parseBoolean( request.getHeader(HttpConstants.X_HEADER_PRINT_PHYSICAL_PLAN)) )
+		}
+		if ( Boolean.parseBoolean( request.getHeader(HttpConstants.X_HEADER_PRINT_PHYSICAL_PLAN)) ) {
+			queryResBuf.physicalPlan = new ByteArrayOutputStream();
 			ctxBuilder.setPhysicalPlanPrinter( new TextBasedPhysicalPlanPrinterImpl( new PrintStream( queryResBuf.physicalPlan, true, StandardCharsets.UTF_8 ) ) );
-		if ( Boolean.parseBoolean( request.getHeader(HttpConstants.X_HEADER_PRINT_EXECUTABLE_PLAN)) )
+		}
+		if ( Boolean.parseBoolean( request.getHeader(HttpConstants.X_HEADER_PRINT_EXECUTABLE_PLAN)) ) {
+			queryResBuf.executablePlan = new ByteArrayOutputStream();
 			ctxBuilder.setExecutablePlanPrinter( new TextBasedExecutablePlanPrinterImpl( new PrintStream( queryResBuf.executablePlan, true, StandardCharsets.UTF_8 ) ) );
+		}
 
 		final QueryProcContext ctx = ctxBuilder.build();
 
@@ -236,7 +244,7 @@ public class SparqlServlet extends HttpServlet {
 	 * @param QueryResponseBuffers container for optional query execution artifacts
 	 * @return the query result and exceptions in JSON format
 	 */
-	private static JsonObject execute( final String queryString, final String mimeType, final QueryProcContext ctx, final QueryResponseBuffers queryResponseBuffers )
+	private static JsonObject execute( final String queryString, final String mimeType, final QueryProcContext ctx, final QueryResponseBuffers queryResBuf )
 			throws UnsupportedQueryException, IllegalQueryException
 	{
 		final Query query = QueryFactory.create( queryString, SyntaxForHeFQUIN.syntaxSPARQL_12_HeFQUIN );
@@ -250,14 +258,14 @@ public class SparqlServlet extends HttpServlet {
 
 		final JsonObject res = new JsonObject();
 		res.put( HttpConstants.JSON_RESULT, resultBaos.toString() );
-		if ( queryResponseBuffers.sourceAssignment.size() > 0 )
-			res.put(HttpConstants.JSON_SOURCE_ASSIGNMENT, queryResponseBuffers.sourceAssignment.toString());
-		if ( queryResponseBuffers.logicalPlan.size() > 0 )
-			res.put(HttpConstants.JSON_LOGICAL_PLAN, queryResponseBuffers.logicalPlan.toString());
-		if ( queryResponseBuffers.physicalPlan.size() > 0 )
-			res.put(HttpConstants.JSON_PHYSICAL_PLAN, queryResponseBuffers.physicalPlan.toString());
-		if ( queryResponseBuffers.executablePlan.size() > 0 )
-			res.put(HttpConstants.JSON_EXECUTABLE_PLAN, queryResponseBuffers.executablePlan.toString());
+		if ( queryResBuf.sourceAssignment != null && queryResBuf.sourceAssignment.size() > 0 )
+			res.put(HttpConstants.JSON_SOURCE_ASSIGNMENT, queryResBuf.sourceAssignment.toString());
+		if ( queryResBuf.logicalPlan != null && queryResBuf.logicalPlan.size() > 0 )
+			res.put(HttpConstants.JSON_LOGICAL_PLAN, queryResBuf.logicalPlan.toString());
+		if ( queryResBuf.physicalPlan != null && queryResBuf.physicalPlan.size() > 0 )
+			res.put(HttpConstants.JSON_PHYSICAL_PLAN, queryResBuf.physicalPlan.toString());
+		if ( queryResBuf.executablePlan != null && queryResBuf.executablePlan.size() > 0 )
+			res.put(HttpConstants.JSON_EXECUTABLE_PLAN, queryResBuf.executablePlan.toString());
 		res.put( HttpConstants.JSON_EXCEPTIONS, ServletUtils.getExceptions(statsAndExceptions) );
 		return res;
 	}
@@ -285,9 +293,9 @@ public class SparqlServlet extends HttpServlet {
 	 * produced during query processing.
 	 */
 	private class QueryResponseBuffers {
-		public final ByteArrayOutputStream sourceAssignment = new ByteArrayOutputStream();
-		public final ByteArrayOutputStream logicalPlan = new ByteArrayOutputStream();
-		public final ByteArrayOutputStream physicalPlan = new ByteArrayOutputStream();
-		public final ByteArrayOutputStream executablePlan = new ByteArrayOutputStream();
+		public ByteArrayOutputStream sourceAssignment;
+		public ByteArrayOutputStream logicalPlan;
+		public ByteArrayOutputStream physicalPlan;
+		public ByteArrayOutputStream executablePlan;
 	}
 }

--- a/hefquin-service/src/main/java/se/liu/ida/hefquin/service/SparqlServlet.java
+++ b/hefquin-service/src/main/java/se/liu/ida/hefquin/service/SparqlServlet.java
@@ -28,6 +28,9 @@ import se.liu.ida.hefquin.engine.HeFQUINEngine;
 import se.liu.ida.hefquin.engine.IllegalQueryException;
 import se.liu.ida.hefquin.engine.QueryProcessingStatsAndExceptions;
 import se.liu.ida.hefquin.engine.UnsupportedQueryException;
+import se.liu.ida.hefquin.engine.queryplan.utils.ExecutablePlanPrinter;
+import se.liu.ida.hefquin.engine.queryplan.utils.LogicalPlanPrinter;
+import se.liu.ida.hefquin.engine.queryplan.utils.PhysicalPlanPrinter;
 import se.liu.ida.hefquin.engine.queryplan.utils.TextBasedExecutablePlanPrinterImpl;
 import se.liu.ida.hefquin.engine.queryplan.utils.TextBasedLogicalPlanPrinterImpl;
 import se.liu.ida.hefquin.engine.queryplan.utils.TextBasedPhysicalPlanPrinterImpl;
@@ -128,6 +131,8 @@ public class SparqlServlet extends HttpServlet {
 	private void executeRequest( final String query,
 	                             final HttpServletRequest request,
 	                             final HttpServletResponse response ) throws IOException {
+		logger.debug( "Received SPARQL query: {}", query );
+
 		response.setCharacterEncoding( "utf-8" );
 
 		// Ensure query is not null or empty
@@ -144,34 +149,12 @@ public class SparqlServlet extends HttpServlet {
 		}
 
 		// Create QueryProcContext using request-specific execution settings
-		final QueryProcContextBuilder ctxBuilder = engine.getQueryProcContextBuilder()
-					.setSkipExecution( Boolean.parseBoolean( request.getHeader(HttpConstants.X_HEADER_SKIP_EXECUTION) ) );
-
 		final QueryResponseBuffers queryResBuf = new QueryResponseBuffers();
-		if ( Boolean.parseBoolean( request.getHeader(HttpConstants.X_HEADER_PRINT_SOURCE_ASSIGNMENT)) ) {
-			queryResBuf.sourceAssignment = new ByteArrayOutputStream();
-			ctxBuilder.setSourceAssignmentPrinter( new TextBasedLogicalPlanPrinterImpl( new PrintStream( queryResBuf.sourceAssignment, true, StandardCharsets.UTF_8 ) ) );
-		}
-		if ( Boolean.parseBoolean( request.getHeader(HttpConstants.X_HEADER_PRINT_LOGICAL_PLAN)) ) {
-			queryResBuf.logicalPlan = new ByteArrayOutputStream();
-			ctxBuilder.setLogicalPlanPrinter( new TextBasedLogicalPlanPrinterImpl( new PrintStream( queryResBuf.logicalPlan, true, StandardCharsets.UTF_8 ) ) );
-		}
-		if ( Boolean.parseBoolean( request.getHeader(HttpConstants.X_HEADER_PRINT_PHYSICAL_PLAN)) ) {
-			queryResBuf.physicalPlan = new ByteArrayOutputStream();
-			ctxBuilder.setPhysicalPlanPrinter( new TextBasedPhysicalPlanPrinterImpl( new PrintStream( queryResBuf.physicalPlan, true, StandardCharsets.UTF_8 ) ) );
-		}
-		if ( Boolean.parseBoolean( request.getHeader(HttpConstants.X_HEADER_PRINT_EXECUTABLE_PLAN)) ) {
-			queryResBuf.executablePlan = new ByteArrayOutputStream();
-			ctxBuilder.setExecutablePlanPrinter( new TextBasedExecutablePlanPrinterImpl( new PrintStream( queryResBuf.executablePlan, true, StandardCharsets.UTF_8 ) ) );
-		}
-
-		final QueryProcContext ctx = ctxBuilder.build();
+		final QueryProcContext ctx = createQueryProcContext(queryResBuf, request);
 
 		try {
-			logger.debug( "Received SPARQL query: {}", query );
-
-			final JsonObject result = execute( query, mimeType, ctx, queryResBuf );
-			if ( ! result.get( HttpConstants.JSON_EXCEPTIONS ).getAsArray().isEmpty() ) {
+			final JsonObject result = execute(query, mimeType, ctx, queryResBuf);
+			if ( ! result.get(HttpConstants.JSON_EXCEPTIONS).getAsArray().isEmpty() ) {
 				writeJsonError( response, 500, result.get( HttpConstants.JSON_EXCEPTIONS ) );
 				return;
 			}
@@ -288,11 +271,70 @@ public class SparqlServlet extends HttpServlet {
 		response.getWriter().write( msg.toString() );
 	}
 
+	protected QueryProcContext createQueryProcContext( final QueryResponseBuffers queryResBuf,
+	                                                   final HttpServletRequest request ) {
+		final QueryProcContextBuilder ctxBuilder = engine.getQueryProcContextBuilder();
+
+		final String skipExec = request.getHeader( HttpConstants.X_HEADER_SKIP_EXECUTION );
+		ctxBuilder.setSkipExecution( Boolean.parseBoolean(skipExec) );
+
+		final String printSA = request.getHeader( HttpConstants.X_HEADER_PRINT_SOURCE_ASSIGNMENT );
+		final String printLP = request.getHeader( HttpConstants.X_HEADER_PRINT_LOGICAL_PLAN );
+		final String printPP = request.getHeader( HttpConstants.X_HEADER_PRINT_PHYSICAL_PLAN );
+		final String printEP = request.getHeader( HttpConstants.X_HEADER_PRINT_EXECUTABLE_PLAN );
+
+		if ( Boolean.parseBoolean(printSA) ) {
+			queryResBuf.sourceAssignment = new ByteArrayOutputStream();
+
+			final PrintStream ps = new PrintStream( queryResBuf.sourceAssignment,
+			                                        true, // auto flush
+			                                        StandardCharsets.UTF_8 );
+			final LogicalPlanPrinter p = new TextBasedLogicalPlanPrinterImpl(ps);
+
+			ctxBuilder.setSourceAssignmentPrinter(p);
+		}
+
+		if ( Boolean.parseBoolean(printLP) ) {
+			queryResBuf.logicalPlan = new ByteArrayOutputStream();
+
+			final PrintStream ps = new PrintStream( queryResBuf.logicalPlan,
+			                                        true, // auto flush
+			                                        StandardCharsets.UTF_8 );
+			final LogicalPlanPrinter p = new TextBasedLogicalPlanPrinterImpl(ps);
+
+			ctxBuilder.setLogicalPlanPrinter(p);
+		}
+
+		if ( Boolean.parseBoolean(printPP) ) {
+			queryResBuf.physicalPlan = new ByteArrayOutputStream();
+
+			final PrintStream ps = new PrintStream( queryResBuf.physicalPlan,
+			                                        true, // auto flush
+			                                        StandardCharsets.UTF_8 );
+			final PhysicalPlanPrinter p = new TextBasedPhysicalPlanPrinterImpl(ps);
+
+			ctxBuilder.setPhysicalPlanPrinter(p);
+		}
+
+		if ( Boolean.parseBoolean(printEP) ) {
+			queryResBuf.executablePlan = new ByteArrayOutputStream();
+
+			final PrintStream ps = new PrintStream( queryResBuf.executablePlan,
+			                                        true, // auto flush
+			                                        StandardCharsets.UTF_8 );
+			final ExecutablePlanPrinter p = new TextBasedExecutablePlanPrinterImpl(ps);
+
+			ctxBuilder.setExecutablePlanPrinter(p);
+		}
+
+		return ctxBuilder.build();
+	}
+
 	/**
 	 * Holds optional serialized query execution artifacts (plans and source assignments)
 	 * produced during query processing.
 	 */
-	private class QueryResponseBuffers {
+	protected static class QueryResponseBuffers {
 		public ByteArrayOutputStream sourceAssignment;
 		public ByteArrayOutputStream logicalPlan;
 		public ByteArrayOutputStream physicalPlan;

--- a/hefquin-service/src/main/java/se/liu/ida/hefquin/service/SparqlServlet.java
+++ b/hefquin-service/src/main/java/se/liu/ida/hefquin/service/SparqlServlet.java
@@ -174,12 +174,15 @@ public class SparqlServlet extends HttpServlet {
 			if ( mimeType.equals( ACCEPT_CSV ) ||
 				 mimeType.equals( ACCEPT_TSV ) ||
 				 mimeType.equals( ACCEPT_SPARQL_RESULTS_XML ) ) {
-
 				response.getWriter().write( result.getString( HttpConstants.JSON_RESULT ) );
 				return;
 			}
-			else
+			else if ( mimeType.equals( ACCEPT_SPARQL_RESULTS_JSON ) )
 				response.getWriter().write( result.toString() );
+			else {
+				writeJsonError( response, 406, new JsonString( "Unsupported response format: " + mimeType ) );
+				return;
+			}
 		}
 		catch ( final IllegalQueryException e ) {
 			writeJsonError( response, 400, new JsonString( "The given query is invalid: " + e.getMessage() ) );
@@ -247,10 +250,14 @@ public class SparqlServlet extends HttpServlet {
 
 		final JsonObject res = new JsonObject();
 		res.put( HttpConstants.JSON_RESULT, resultBaos.toString() );
-		res.put( HttpConstants.JSON_SOURCE_ASSIGNMENT, queryResponseBuffers.sourceAssignment.toString() );
-		res.put( HttpConstants.JSON_LOGICAL_PLAN, queryResponseBuffers.logicalPlan.toString() );
-		res.put( HttpConstants.JSON_PHYSICAL_PLAN, queryResponseBuffers.physicalPlan.toString() );
-		res.put( HttpConstants.JSON_EXECUTABLE_PLAN, queryResponseBuffers.executablePlan.toString() );
+		if ( queryResponseBuffers.sourceAssignment.size() > 0 )
+			res.put(HttpConstants.JSON_SOURCE_ASSIGNMENT, queryResponseBuffers.sourceAssignment.toString());
+		if ( queryResponseBuffers.logicalPlan.size() > 0 )
+			res.put(HttpConstants.JSON_LOGICAL_PLAN, queryResponseBuffers.logicalPlan.toString());
+		if ( queryResponseBuffers.physicalPlan.size() > 0 )
+			res.put(HttpConstants.JSON_PHYSICAL_PLAN, queryResponseBuffers.physicalPlan.toString());
+		if ( queryResponseBuffers.executablePlan.size() > 0 )
+			res.put(HttpConstants.JSON_EXECUTABLE_PLAN, queryResponseBuffers.executablePlan.toString());
 		res.put( HttpConstants.JSON_EXCEPTIONS, ServletUtils.getExceptions(statsAndExceptions) );
 		return res;
 	}

--- a/hefquin-service/src/main/java/se/liu/ida/hefquin/service/SparqlServlet.java
+++ b/hefquin-service/src/main/java/se/liu/ida/hefquin/service/SparqlServlet.java
@@ -28,6 +28,9 @@ import se.liu.ida.hefquin.engine.HeFQUINEngine;
 import se.liu.ida.hefquin.engine.IllegalQueryException;
 import se.liu.ida.hefquin.engine.QueryProcessingStatsAndExceptions;
 import se.liu.ida.hefquin.engine.UnsupportedQueryException;
+import se.liu.ida.hefquin.engine.queryplan.utils.TextBasedExecutablePlanPrinterImpl;
+import se.liu.ida.hefquin.engine.queryplan.utils.TextBasedLogicalPlanPrinterImpl;
+import se.liu.ida.hefquin.engine.queryplan.utils.TextBasedPhysicalPlanPrinterImpl;
 import se.liu.ida.hefquin.engine.queryproc.QueryProcContext;
 import se.liu.ida.hefquin.engine.queryproc.QueryProcContextBuilder;
 import se.liu.ida.hefquin.jenaext.query.SyntaxForHeFQUIN;
@@ -143,20 +146,40 @@ public class SparqlServlet extends HttpServlet {
 		// Create QueryProcContext using request-specific execution settings
 		final QueryProcContextBuilder ctxBuilder = engine.getQueryProcContextBuilder()
 					.setSkipExecution( Boolean.parseBoolean( request.getHeader(HttpConstants.X_HEADER_SKIP_EXECUTION) ) );
+
+		final QueryResponseBuffers queryResBuf = new QueryResponseBuffers();
+		if ( Boolean.parseBoolean( request.getHeader(HttpConstants.X_HEADER_PRINT_SOURCE_ASSIGNMENT)) )
+			ctxBuilder.setSourceAssignmentPrinter( new TextBasedLogicalPlanPrinterImpl( new PrintStream( queryResBuf.sourceAssignment, true, StandardCharsets.UTF_8 ) ) );
+		if ( Boolean.parseBoolean( request.getHeader(HttpConstants.X_HEADER_PRINT_LOGICAL_PLAN)) )
+			ctxBuilder.setLogicalPlanPrinter( new TextBasedLogicalPlanPrinterImpl( new PrintStream( queryResBuf.logicalPlan, true, StandardCharsets.UTF_8 ) ) );
+		if ( Boolean.parseBoolean( request.getHeader(HttpConstants.X_HEADER_PRINT_PHYSICAL_PLAN)) )
+			ctxBuilder.setPhysicalPlanPrinter( new TextBasedPhysicalPlanPrinterImpl( new PrintStream( queryResBuf.physicalPlan, true, StandardCharsets.UTF_8 ) ) );
+		if ( Boolean.parseBoolean( request.getHeader(HttpConstants.X_HEADER_PRINT_EXECUTABLE_PLAN)) )
+			ctxBuilder.setExecutablePlanPrinter( new TextBasedExecutablePlanPrinterImpl( new PrintStream( queryResBuf.executablePlan, true, StandardCharsets.UTF_8 ) ) );
+
 		final QueryProcContext ctx = ctxBuilder.build();
 
 		try {
 			logger.debug( "Received SPARQL query: {}", query );
 
-			final JsonObject result = execute( query, mimeType, ctx );
-			if ( ! result.get( "exceptions" ).getAsArray().isEmpty() ) {
-				writeJsonError( response, 500, result.get( "exceptions" ) );
+			final JsonObject result = execute( query, mimeType, ctx, queryResBuf );
+			if ( ! result.get( HttpConstants.JSON_EXCEPTIONS ).getAsArray().isEmpty() ) {
+				writeJsonError( response, 500, result.get( HttpConstants.JSON_EXCEPTIONS ) );
 				return;
 			}
 
 			response.setStatus( 200 );
 			response.setContentType( mimeType );
-			response.getWriter().write( result.getString( "result" ) );
+
+			if ( mimeType.equals( ACCEPT_CSV ) ||
+				 mimeType.equals( ACCEPT_TSV ) ||
+				 mimeType.equals( ACCEPT_SPARQL_RESULTS_XML ) ) {
+
+				response.getWriter().write( result.getString( HttpConstants.JSON_RESULT ) );
+				return;
+			}
+			else
+				response.getWriter().write( result.toString() );
 		}
 		catch ( final IllegalQueryException e ) {
 			writeJsonError( response, 400, new JsonString( "The given query is invalid: " + e.getMessage() ) );
@@ -204,26 +227,31 @@ public class SparqlServlet extends HttpServlet {
 	/**
 	 * Executes the given SPARQL query using the HeFQUIN engine and returns the serialized result.
 	 *
-	 * @param queryString the SPARQL query string
-	 * @param mimeType    the MIME type for the response format
-	 * @param ctx         the processing context
+	 * @param queryString          the SPARQL query string
+	 * @param mimeType             the MIME type for the response format
+	 * @param ctx                  the processing context
+	 * @param QueryResponseBuffers container for optional query execution artifacts
 	 * @return the query result and exceptions in JSON format
 	 */
-	private static JsonObject execute( final String queryString, final String mimeType, final QueryProcContext ctx )
+	private static JsonObject execute( final String queryString, final String mimeType, final QueryProcContext ctx, final QueryResponseBuffers queryResponseBuffers )
 			throws UnsupportedQueryException, IllegalQueryException
 	{
 		final Query query = QueryFactory.create( queryString, SyntaxForHeFQUIN.syntaxSPARQL_12_HeFQUIN );
 		final ResultsFormat resultsFormat = ServletUtils.convert( mimeType );
-		final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+		final ByteArrayOutputStream resultBaos = new ByteArrayOutputStream();
 
 		final QueryProcessingStatsAndExceptions statsAndExceptions;
-		try ( PrintStream ps = new PrintStream( baos, true, StandardCharsets.UTF_8 ) ) {
-			statsAndExceptions = engine.executeQueryAndPrintResult(query, resultsFormat, ps, ctx);
+		try ( PrintStream ps = new PrintStream( resultBaos, true, StandardCharsets.UTF_8 ) ) {
+			statsAndExceptions = engine.executeQueryAndPrintResult( query, resultsFormat, ps, ctx );
 		}
 
 		final JsonObject res = new JsonObject();
-		res.put( "result", baos.toString() );
-		res.put( "exceptions", ServletUtils.getExceptions(statsAndExceptions) );
+		res.put( HttpConstants.JSON_RESULT, resultBaos.toString() );
+		res.put( HttpConstants.JSON_SOURCE_ASSIGNMENT, queryResponseBuffers.sourceAssignment.toString() );
+		res.put( HttpConstants.JSON_LOGICAL_PLAN, queryResponseBuffers.logicalPlan.toString() );
+		res.put( HttpConstants.JSON_PHYSICAL_PLAN, queryResponseBuffers.physicalPlan.toString() );
+		res.put( HttpConstants.JSON_EXECUTABLE_PLAN, queryResponseBuffers.executablePlan.toString() );
+		res.put( HttpConstants.JSON_EXCEPTIONS, ServletUtils.getExceptions(statsAndExceptions) );
 		return res;
 	}
 
@@ -243,5 +271,16 @@ public class SparqlServlet extends HttpServlet {
 		final JsonObject msg = new JsonObject();
 		msg.put( "error", message );
 		response.getWriter().write( msg.toString() );
+	}
+
+	/**
+	 * Holds optional serialized query execution artifacts (plans and source assignments)
+	 * produced during query processing.
+	 */
+	private class QueryResponseBuffers {
+		public final ByteArrayOutputStream sourceAssignment = new ByteArrayOutputStream();
+		public final ByteArrayOutputStream logicalPlan = new ByteArrayOutputStream();
+		public final ByteArrayOutputStream physicalPlan = new ByteArrayOutputStream();
+		public final ByteArrayOutputStream executablePlan = new ByteArrayOutputStream();
 	}
 }

--- a/hefquin-service/src/test/java/se/liu/ida/hefquin/service/SparqlServletTest.java
+++ b/hefquin-service/src/test/java/se/liu/ida/hefquin/service/SparqlServletTest.java
@@ -9,6 +9,8 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
+import org.apache.jena.atlas.json.JSON;
+import org.apache.jena.atlas.json.JsonObject;
 import org.apache.jena.query.ARQ;
 import org.apache.jena.query.QuerySolution;
 import org.apache.jena.query.ResultSet;
@@ -23,10 +25,13 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import se.liu.ida.hefquin.base.net.http.HttpConstants;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -137,6 +142,19 @@ public class SparqlServletTest {
 		}
 	}
 
+	private static ResultSet extractResultSetJSON( final CloseableHttpResponse response ) throws IOException {
+		final String json = new String(
+			response.getEntity().getContent().readAllBytes(),
+			StandardCharsets.UTF_8
+		);
+
+		final JsonObject obj = JSON.parse(json);
+
+		final String resultJson = obj.getString(HttpConstants.JSON_RESULT);
+
+		return ResultSetFactory.fromJSON( new ByteArrayInputStream( resultJson.getBytes(StandardCharsets.UTF_8) ) );
+	}
+
 	@Test
 	public void testPostUrlEncodedRequestReturnsXmlResults() throws Exception {
 		final HttpPost request = createPostRequest( CONTENT_TYPE_FORM_URLENCODED, ACCEPT_SPARQL_RESULTS_XML,
@@ -154,7 +172,7 @@ public class SparqlServletTest {
 				DEFAULT_QUERY );
 		try ( final CloseableHttpResponse response = httpClient.execute( request ) ) {
 			assertEquals( 200, response.getStatusLine().getStatusCode() );
-			final ResultSet resultSet = ResultSetFactory.fromJSON( response.getEntity().getContent() );
+			final ResultSet resultSet = extractResultSetJSON( response );
 			validateResultSet( resultSet );
 		}
 	}
@@ -218,7 +236,7 @@ public class SparqlServletTest {
 			assertEquals( 200, response.getStatusLine().getStatusCode() );
 			final String contentType = response.getHeaders( "Content-Type" )[0].getValue().split( ";" )[0];
 			assertEquals( contentType, ACCEPT_SPARQL_RESULTS_JSON );
-			final ResultSet resultSet = ResultSetFactory.fromJSON( response.getEntity().getContent() );
+			final ResultSet resultSet = extractResultSetJSON( response );
 			validateResultSet( resultSet );
 		}
 	}
@@ -240,7 +258,7 @@ public class SparqlServletTest {
 				DEFAULT_QUERY );
 		try ( final CloseableHttpResponse response = httpClient.execute( request ) ) {
 			assertEquals( 200, response.getStatusLine().getStatusCode() );
-			final ResultSet resultSet = ResultSetFactory.fromJSON( response.getEntity().getContent() );
+			final ResultSet resultSet = extractResultSetJSON( response );
 			validateResultSet( resultSet );
 		}
 	}
@@ -304,7 +322,7 @@ public class SparqlServletTest {
 			assertEquals( 200, response.getStatusLine().getStatusCode() );
 			final String contentType = response.getHeaders( "Content-Type" )[0].getValue().split( ";" )[0];
 			assertEquals( contentType, ACCEPT_SPARQL_RESULTS_JSON );
-			final ResultSet resultSet = ResultSetFactory.fromJSON( response.getEntity().getContent() );
+			final ResultSet resultSet = extractResultSetJSON( response );
 			validateResultSet( resultSet );
 		}
 	}
@@ -324,7 +342,7 @@ public class SparqlServletTest {
 		final HttpGet request = createGetRequest( ACCEPT_SPARQL_RESULTS_JSON, DEFAULT_QUERY );
 		try ( final CloseableHttpResponse response = httpClient.execute( request ) ) {
 			assertEquals( 200, response.getStatusLine().getStatusCode() );
-			final ResultSet resultSet = ResultSetFactory.fromJSON( response.getEntity().getContent() );
+			final ResultSet resultSet = extractResultSetJSON( response );
 			validateResultSet( resultSet );
 		}
 	}


### PR DESCRIPTION
Addresses the third group of extension in #641 (also including `--printExecutablePlan` & `--printExecutablePlanToFile`)
