### PR TITLE
Move maxParallelRequests to AsyncFederationAccessManagerImpl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Support for ChronicleMap-based persistent cache for federation requests (including cardinality requests), with support for cache replacement and invalidation policies ([546](https://github.com/LiUSemWeb/HeFQUIN/pull/546)).
 - CLI program to issue queries to the HeFQUIN service ([#616](https://github.com/LiUSemWeb/HeFQUIN/issues/616), [#643](https://github.com/LiUSemWeb/HeFQUIN/issues/643)).
 ### Changed
+- Refactoring maxParallelRequests handling to eliminate redundant constructors in federation access managers ([#650](https://github.com/LiUSemWeb/HeFQUIN/pull/650)).
 - Pushing projection variables and distinct into requests to SPARQL endpoints ([#600](https://github.com/LiUSemWeb/HeFQUIN/issues/600), [#629](https://github.com/LiUSemWeb/HeFQUIN/issues/629), [#638](https://github.com/LiUSemWeb/HeFQUIN/issues/638), [#639](https://github.com/LiUSemWeb/HeFQUIN/issues/639), [#642](https://github.com/LiUSemWeb/HeFQUIN/issues/642)).
 - Logging for query planner ([#636](https://github.com/LiUSemWeb/HeFQUIN/pull/636), [#637](https://github.com/LiUSemWeb/HeFQUIN/pull/637)).
 - Refactoring of  the context objects that are passed around during query processing ([#645](https://github.com/LiUSemWeb/HeFQUIN/issues/645)).

--- a/config/DefaultConfDescr.ttl
+++ b/config/DefaultConfDescr.ttl
@@ -22,9 +22,12 @@ _:bFederationAccessManager rdf:type ec:FederationAccessManager ;
     ec:constructorArguments (
         [ ec:argumentTypeName "se.liu.ida.hefquin.federation.access.FederationAccessManager" ;
           ec:javaClassName "se.liu.ida.hefquin.federation.access.impl.AsyncFederationAccessManagerImpl" ;
-          ec:constructorArguments ( ec:value:ExecServiceForFedAccess ) ]
+          ec:constructorArguments (
+            ec:value:ExecServiceForFedAccess
+            10  # defaultMaxParallelRequests
+          )
+        ]
         100  # cacheCapacity
-        10   # defaultMaxParallelRequests
     ) .
 
 _:bSourcePlanner rdf:type ec:SourcePlanner ;

--- a/config/DefaultConfDescrExtended.ttl
+++ b/config/DefaultConfDescrExtended.ttl
@@ -10,10 +10,12 @@ PREFIX ex:     <http://example.org/>
         ec:constructorArguments (
             [ ec:argumentTypeName "se.liu.ida.hefquin.federation.access.FederationAccessManager" ;
               ec:javaClassName "se.liu.ida.hefquin.federation.access.impl.AsyncFederationAccessManagerImpl" ;
-              ec:constructorArguments ( ec:value:ExecServiceForFedAccess )
+              ec:constructorArguments (
+                ec:value:ExecServiceForFedAccess
+                10  # defaultMaxParallelRequests
+              )
             ]
             100  # cacheCapacity
-            10   # defaultMaxParallelRequests
         )
    ] ;
    ec:queryProcessor _:b1 .

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/AsyncFederationAccessManagerImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/AsyncFederationAccessManagerImpl.java
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
+import se.liu.ida.hefquin.base.net.http.HttpClientProvider;
 import se.liu.ida.hefquin.federation.FederationMember;
 import se.liu.ida.hefquin.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.federation.access.DataRetrievalResponse;
@@ -58,6 +59,22 @@ public class AsyncFederationAccessManagerImpl extends FederationAccessManagerBas
 		      new BRTPFRequestProcessorImpl(),
 		      new Neo4jRequestProcessorImpl(),
 		      new RESTRequestProcessorImpl() );
+	}
+
+	/**
+	 * Creates an {@link AsyncFederationAccessManagerImpl} using the given executor
+	 * service and sets the default maximum number of parallel requests to a given
+	 * endpoint address.
+	 *
+	 * @param execService         the executor service used for asynchronous request
+	 *                            execution
+	 * @param maxParallelRequests the default maximum number of parallel requests to
+	 *                            any given endpoint address
+	 */
+	public AsyncFederationAccessManagerImpl( final ExecutorService execService, final int maxParallelRequests ) {
+		this(execService);
+		// Set default number of parallel request to any given endpoint address
+		HttpClientProvider.setDefaultMaxParallelRequests(maxParallelRequests);
 	}
 
 	@Override

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerWithCache.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerWithCache.java
@@ -69,15 +69,6 @@ public class FederationAccessManagerWithCache implements FederationAccessManager
 		this( fedAccMan, cacheCapacity, new MyDefaultCachePolicies() );
 	}
 
-	public FederationAccessManagerWithCache( final FederationAccessManager fedAccMan,
-	                                         final int cacheCapacity,
-	                                         final int maxParallelRequests )
-	{
-		this(fedAccMan, cacheCapacity);
-		// Set default number of parallel request to a given endpoint address
-		HttpClientProvider.setDefaultMaxParallelRequests(maxParallelRequests);
-	}
-
 	/**
 	 * Creates a {@link FederationAccessManagerWithCache} with a default configuration.
 	 */

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerWithChronicleMapCache.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerWithChronicleMapCache.java
@@ -63,28 +63,6 @@ public class FederationAccessManagerWithChronicleMapCache extends FederationAcce
 	 *
 	 * @param fedAccMan                 the wrapped federation access manager
 	 * @param cacheCapacity             the maximum cache capacity
-	 * @param maxParallelRequests       the maximum default number of parallel
-	 *                                  requests to a given endpoint address
-	 * @param chronicleMapCachePolicies the cache policies used by the
-	 *                                  ChronicleMap-backed cache
-	 * @throws IOException if the persistent cache cannot be created or opened
-	 */
-	public FederationAccessManagerWithChronicleMapCache( final FederationAccessManager fedAccMan,
-	                                                     final int cacheCapacity,
-	                                                     final int maxParallelRequests,
-	                                                     final CachePolicies<ChronicleMapCacheKey, CompletableFuture<? extends DataRetrievalResponse<?>>, ChronicleMapCacheEntry> chronicleMapCachePolicies )
-			throws IOException
-	{
-		super(fedAccMan, cacheCapacity, maxParallelRequests);
-		chronicleMapCache = new ChronicleMapCache(cacheCapacity, chronicleMapCachePolicies);
-	}
-
-	/**
-	 * Creates a federation access manager with a ChronicleMap-backed persistent
-	 * cache using the given capacity and cache policies.
-	 *
-	 * @param fedAccMan                 the wrapped federation access manager
-	 * @param cacheCapacity             the maximum cache capacity
 	 * @param chronicleMapCachePolicies the cache policies used by the
 	 *                                  ChronicleMap-backed cache
 	 * @throws IOException if the persistent cache cannot be created or opened
@@ -118,31 +96,6 @@ public class FederationAccessManagerWithChronicleMapCache extends FederationAcce
 			throws IOException
 	{
 		this(fedAccMan, cacheCapacity, new DefaultChronicleMapCachePolicies(timeToLive) );
-	}
-
-	/**
-	 * Creates a federation access manager with a ChronicleMap-backed persistent
-	 * cache using the given capacity and the default cache policies.
-	 *
-	 * <p>
-	 * The cache uses a least-recently-used (LRU) replacement policy and the
-	 * specified time-to-live for cache entry invalidation.
-	 * </p>
-	 *
-	 * @param fedAccMan           the wrapped federation access manager
-	 * @param cacheCapacity       the maximum cache capacity
-	 * @param timeToLive          the cache entry time-to-live in milliseconds
-	 * @param maxParallelRequests the maximum default number of parallel requests to
-	 *                            a given endpoint address
-	 * @throws IOException if the persistent cache cannot be created or opened
-	 */
-	public FederationAccessManagerWithChronicleMapCache( final FederationAccessManager fedAccMan,
-	                                                     final int cacheCapacity,
-	                                                     final int timeToLive,
-	                                                     final int maxParallelRequests )
-			throws IOException 
-	{
-		this( fedAccMan, cacheCapacity, maxParallelRequests, new DefaultChronicleMapCachePolicies(timeToLive) );
 	}
 
 	/**


### PR DESCRIPTION
This PR moves the `maxParallelRequests` argument to `AsyncFederationAccessManagerImpl`. This reduces duplication of code and reduces the number of constructors required in other federations access managers, such as `FederationAccessManagerWithCache` and `FederationAccessManagerWithChronicleMapCache`.