### PR TITLE
Extend bin/hefquin-client to print queryproc- & fedaccess stats

### DIFF
--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/net/http/HttpConstants.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/net/http/HttpConstants.java
@@ -8,6 +8,8 @@ public class HttpConstants
 	public static final String X_HEADER_PRINT_LOGICAL_PLAN = "X-HeFQUIN-Print-Logical-Plan";
 	public static final String X_HEADER_PRINT_PHYSICAL_PLAN = "X-HeFQUIN-Print-Physical-Plan";
 	public static final String X_HEADER_PRINT_EXECUTABLE_PLAN = "X-HeFQUIN-Print-Executable-Plan";
+	public static final String X_HEADER_RETURN_QUERY_PROC_STATS = "X-HeFQUIN-Return-Query-Proc-Stats";
+	public static final String X_HEADER_RETURN_FED_ACCESS_STATS = "X-HeFQUIN-Return-Fed-Access-Stats";
 
 	// response JSON fields
 	public static final String JSON_RESULT = "result";
@@ -16,4 +18,6 @@ public class HttpConstants
 	public static final String JSON_PHYSICAL_PLAN = "physicalPlan";
 	public static final String JSON_EXECUTABLE_PLAN = "executablePlan";
 	public static final String JSON_EXCEPTIONS = "exceptions";
+	public static final String JSON_QUERY_PROC_STATS = "queryProcStats";
+	public static final String JSON_FED_ACCESS_STATS = "fedAccessStats";
 }

--- a/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunHttpQuery.java
+++ b/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunHttpQuery.java
@@ -70,6 +70,12 @@ public class RunHttpQuery extends CmdARQ
 	protected final ArgDecl argSkipExecution = new ArgDecl( ArgDecl.NoValue, "skipExecution" );
 	protected final ArgDecl argServerAddress = new ArgDecl( ArgDecl.HasValue, "server" );
 	protected final ArgDecl argOutputToFile =  new ArgDecl( ArgDecl.HasValue, "outputToFile" );
+	protected final ArgDecl argQueryProcStats = new ArgDecl( ArgDecl.NoValue, "printQueryProcStats" );
+	protected final ArgDecl argOnelineTimeStats = new ArgDecl( ArgDecl.NoValue, "printQueryProcMeasurements" );
+	protected final ArgDecl argFedAccessStats = new ArgDecl( ArgDecl.NoValue, "printFedAccessStats" );
+	protected final ArgDecl argQueryProcStatsToFile = new ArgDecl( ArgDecl.HasValue, "printQueryProcStatsToFile" );
+	protected final ArgDecl argOnelineTimeStatsToFile = new ArgDecl( ArgDecl.HasValue, "printQueryProcMeasurementsToFile" );
+	protected final ArgDecl argFedAccessStatsToFile = new ArgDecl( ArgDecl.HasValue, "printFedAccessStatsToFile" );
 
 	protected static final Pattern BASE_PATTERN = Pattern.compile( "\\bBASE\\b\\s*<[^>]+>", Pattern.CASE_INSENSITIVE );
 
@@ -90,6 +96,13 @@ public class RunHttpQuery extends CmdARQ
 		add( argSkipExecution, "--skipExecution", "Do not execute the query (but create the execution plan)" );
 		add( argServerAddress, "--server", "Address of HeFQUIN service" );
 		add( argOutputToFile, "--outputToFile", "Output file (optional, printing to stdout if omitted)" );
+		add( argQueryProcStats, "--printQueryProcStats", "Print out statistics about the query execution process" );
+		add( argQueryProcStatsToFile, "--printQueryProcStatsToFile", "Print out statistics about the query execution process to a file" );
+		add( argOnelineTimeStats, "--printQueryProcMeasurements",
+				"Print out measurements about the query processing time in one line that can be used for a CSV file" );
+		add( argOnelineTimeStatsToFile, "--printQueryProcMeasurementsToFile", "Print out measurements about the query processing time to a file" );
+		add( argFedAccessStats, "--printFedAccessStats", "Print out statistics of the federation access manager" );
+		add( argFedAccessStatsToFile, "--printFedAccessStatsToFile", "Print out statistics of the federation access manager to a file" );
 
 		addModule( modQuery );
 	}
@@ -193,7 +206,7 @@ public class RunHttpQuery extends CmdARQ
 			.timeout( Duration.ofSeconds(60) )
 			.POST( HttpRequest.BodyPublishers.ofString(prepareQuery( query )) );
 
-		if ( contains(argSkipExecution) )
+		if ( contains( argSkipExecution ) )
 			builder.header( HttpConstants.X_HEADER_SKIP_EXECUTION, "true" );
 
 		if ( modPlanPrinting.getSourceAssignmentPrinter() != null )
@@ -207,6 +220,12 @@ public class RunHttpQuery extends CmdARQ
 
 		if ( modPlanPrinting.getExecutablePlanPrinter() != null )
 			builder.header( HttpConstants.X_HEADER_PRINT_EXECUTABLE_PLAN, "true" );
+
+		if ( contains( argQueryProcStats ) || contains( argQueryProcStatsToFile ) || contains( argOnelineTimeStats ) || contains( argOnelineTimeStatsToFile ) )
+			builder.header( HttpConstants.X_HEADER_RETURN_QUERY_PROC_STATS, "true" );
+
+		if ( contains( argFedAccessStats ) || contains( argFedAccessStatsToFile ) )
+			builder.header( HttpConstants.X_HEADER_RETURN_FED_ACCESS_STATS, "true" );
 
 		final HttpRequest request = builder.build();
 
@@ -244,6 +263,57 @@ public class RunHttpQuery extends CmdARQ
 		if ( modTime.timingEnabled() ) {
 			final long time = modTime.endTimer();
 			System.err.println( "Time: " + modTime.timeStr( time ) + " sec" );
+		}
+
+		final JsonValue queryProcStatsValue = obj.get(HttpConstants.JSON_QUERY_PROC_STATS);
+		if ( queryProcStatsValue != null ) {
+			if ( contains( argQueryProcStats ) ) {
+				System.err.println( queryProcStatsValue.toString() );
+				System.err.println();
+			}
+			if ( contains( argQueryProcStatsToFile ) ) {
+				final String outputDest = getValue( argQueryProcStatsToFile );
+				if ( outputDestIsValid( outputDest ) ) {
+					try ( final PrintStream printStream = new PrintStream( new FileOutputStream( outputDest, true ) ) ) {
+						printStream.print( queryProcStatsValue.toString() );
+					} catch ( final FileNotFoundException ex ) {
+						cmdError( "Failed to create print stream for output destination: " + outputDest, false );
+					}
+				}
+			}
+			if ( contains( argOnelineTimeStats ) ) {
+				final String queryProcStats = getQueryProcStats( queryProcStatsValue );
+				System.out.println( queryProcStats );
+			}
+			if ( contains( argOnelineTimeStatsToFile ) ) {
+				final String outputDest = getValue( argOnelineTimeStatsToFile );
+				if ( outputDestIsValid( outputDest ) ) {
+					try ( final PrintStream printStream = new PrintStream( new FileOutputStream( outputDest, true ) ) ) {
+						final String queryProcStats = getQueryProcStats( queryProcStatsValue );
+						printStream.println( queryProcStats );
+					} catch ( final FileNotFoundException ex ) {
+						cmdError( "Failed to create print stream for output destination: " + outputDest, false );
+					}
+				}
+			}
+		}
+
+		final JsonValue fedAccessStatsValue = obj.get(HttpConstants.JSON_FED_ACCESS_STATS);
+		if ( fedAccessStatsValue != null ) {
+			if ( contains(argFedAccessStats) ) {
+				System.err.println( fedAccessStatsValue.toString() );
+				System.err.println();
+			}
+			if ( contains(argFedAccessStatsToFile) ) {
+				final String outputDest = getValue( argFedAccessStatsToFile );
+				if ( outputDestIsValid( outputDest ) ) {
+					try ( final PrintStream printStream = new PrintStream( new FileOutputStream( outputDest, true ) ) ) {
+						printStream.print( fedAccessStatsValue.toString() );
+					} catch ( final FileNotFoundException ex ) {
+						cmdError( "Failed to create print stream for output destination: " + outputDest, false );
+					}
+				}
+			}
 		}
 	}
 
@@ -356,5 +426,44 @@ public class RunHttpQuery extends CmdARQ
 		final JsonValue eplanValue = obj.get(HttpConstants.JSON_EXECUTABLE_PLAN);
 		if ( eplanValue != null && eplanValue.isString() )
 			modPlanPrinting.printExecutablePlan( eplanValue.getAsString().value() );
+	}
+
+	/**
+	 * Extracts and formats query processing statistics from the given
+	 * {@code QueryProcessingStatsAndExceptions} object into a comma-separated string.
+	 *
+	 * The returned string contains the overall query processing time, planning time,
+	 * compilation time, and execution time, in that order.
+	 *
+	 * @param statsAndExceptions the object containing query processing statistics
+	 * @return a comma-separated string of query processing statistics
+	 */
+	private static String getQueryProcStats( final JsonValue statsAndExceptions ) {
+		final JsonObject obj = statsAndExceptions.getAsObject();
+
+		final long overallQueryProcessingTime = obj.get("overallQueryProcessingTime").getAsNumber().value().longValue();
+		final long planningTime = obj.get("planningTime").getAsNumber().value().longValue();
+		final long compilationTime = obj.get("compilationTime").getAsNumber().value().longValue();
+		final long executionTime = obj.get("executionTime").getAsNumber().value().longValue();
+
+		final String queryProcStats = overallQueryProcessingTime + ", " + planningTime + ", " + compilationTime
+				+ ", " + executionTime;
+		return queryProcStats;
+	}
+
+	/**
+	 * Validates the output destination for statistics by checking if it starts with a hyphen.
+	 * If the output destination is invalid, an error message is printed and the method returns false. Otherwise, it returns true.
+	 *
+	 * @param outputDest the output destination to validate
+	 * @return true if the output destination is valid, false otherwise
+	 */
+	private boolean outputDestIsValid( final String outputDest ) {
+		if ( outputDest.startsWith( "-" ) ) {
+			cmdError( "Invalid output destination: " + outputDest, false );
+			cmdError( "Output destination should be a file path, not an argument.", false );
+			return false;
+		}
+		return true;
 	}
 }

--- a/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunHttpQuery.java
+++ b/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunHttpQuery.java
@@ -282,14 +282,14 @@ public class RunHttpQuery extends CmdARQ
 				}
 			}
 			if ( contains( argOnelineTimeStats ) ) {
-				final String queryProcStats = getQueryProcStats( queryProcStatsValue );
+				final String queryProcStats = extractOnelineTimeStats( queryProcStatsValue );
 				System.out.println( queryProcStats );
 			}
 			if ( contains( argOnelineTimeStatsToFile ) ) {
 				final String outputDest = getValue( argOnelineTimeStatsToFile );
 				if ( outputDestIsValid( outputDest ) ) {
 					try ( final PrintStream printStream = new PrintStream( new FileOutputStream( outputDest, true ) ) ) {
-						final String queryProcStats = getQueryProcStats( queryProcStatsValue );
+						final String queryProcStats = extractOnelineTimeStats( queryProcStatsValue );
 						printStream.println( queryProcStats );
 					} catch ( final FileNotFoundException ex ) {
 						cmdError( "Failed to create print stream for output destination: " + outputDest, false );
@@ -438,7 +438,7 @@ public class RunHttpQuery extends CmdARQ
 	 * @param statsAndExceptions the object containing query processing statistics
 	 * @return a comma-separated string of query processing statistics
 	 */
-	private static String getQueryProcStats( final JsonValue statsAndExceptions ) {
+	private static String extractOnelineTimeStats( final JsonValue statsAndExceptions ) {
 		final JsonObject obj = statsAndExceptions.getAsObject();
 
 		final long overallQueryProcessingTime = obj.get("overallQueryProcessingTime").getAsNumber().value().longValue();

--- a/hefquin-service/src/main/java/se/liu/ida/hefquin/service/SparqlServlet.java
+++ b/hefquin-service/src/main/java/se/liu/ida/hefquin/service/SparqlServlet.java
@@ -24,6 +24,7 @@ import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import se.liu.ida.hefquin.base.net.http.HttpConstants;
+import se.liu.ida.hefquin.base.utils.StatsPrinter;
 import se.liu.ida.hefquin.engine.HeFQUINEngine;
 import se.liu.ida.hefquin.engine.IllegalQueryException;
 import se.liu.ida.hefquin.engine.QueryProcessingStatsAndExceptions;
@@ -152,8 +153,13 @@ public class SparqlServlet extends HttpServlet {
 		final QueryResponseBuffers queryResBuf = new QueryResponseBuffers();
 		final QueryProcContext ctx = createQueryProcContext(queryResBuf, request);
 
+		final boolean returnQueryProcStats = Boolean.parseBoolean( request.getHeader(HttpConstants.X_HEADER_RETURN_QUERY_PROC_STATS));
+		final boolean returnFedAccessStats = Boolean.parseBoolean( request.getHeader(HttpConstants.X_HEADER_RETURN_FED_ACCESS_STATS));
+
 		try {
-			final JsonObject result = execute(query, mimeType, ctx, queryResBuf);
+			logger.debug( "Received SPARQL query: {}", query );
+
+			final JsonObject result = execute( query, mimeType, ctx, queryResBuf, returnQueryProcStats, returnFedAccessStats );
 			if ( ! result.get(HttpConstants.JSON_EXCEPTIONS).getAsArray().isEmpty() ) {
 				writeJsonError( response, 500, result.get( HttpConstants.JSON_EXCEPTIONS ) );
 				return;
@@ -225,11 +231,16 @@ public class SparqlServlet extends HttpServlet {
 	 * @param mimeType             the MIME type for the response format
 	 * @param ctx                  the processing context
 	 * @param QueryResponseBuffers container for optional query execution artifacts
-	 * @return the query result and exceptions in JSON format
+	 * @param returnQueryProcStats whether query proccessing stats should be returned
+	 * @param returnFedAccessStats whether federation access stats should be returned
+	 * @return a JSON object containing the query result, any exceptions, optional plans and statistics
 	 */
-	private static JsonObject execute( final String queryString, final String mimeType, final QueryProcContext ctx, final QueryResponseBuffers queryResBuf )
-			throws UnsupportedQueryException, IllegalQueryException
-	{
+	private static JsonObject execute( final String queryString,
+	                                   final String mimeType,
+	                                   final QueryProcContext ctx,
+	                                   final QueryResponseBuffers queryResBuf,
+	                                   final boolean returnQueryProcStats,
+	                                   final boolean returnFedAccessStats ) throws UnsupportedQueryException, IllegalQueryException {
 		final Query query = QueryFactory.create( queryString, SyntaxForHeFQUIN.syntaxSPARQL_12_HeFQUIN );
 		final ResultsFormat resultsFormat = ServletUtils.convert( mimeType );
 		final ByteArrayOutputStream resultBaos = new ByteArrayOutputStream();
@@ -250,6 +261,16 @@ public class SparqlServlet extends HttpServlet {
 		if ( queryResBuf.executablePlan != null && queryResBuf.executablePlan.size() > 0 )
 			res.put(HttpConstants.JSON_EXECUTABLE_PLAN, queryResBuf.executablePlan.toString());
 		res.put( HttpConstants.JSON_EXCEPTIONS, ServletUtils.getExceptions(statsAndExceptions) );
+
+		final JsonObject queryProcStatsAsJson;
+		if ( statsAndExceptions != null && returnQueryProcStats ) {
+			queryProcStatsAsJson = StatsPrinter.statsAsJson(statsAndExceptions, true);
+			res.put( HttpConstants.JSON_QUERY_PROC_STATS, queryProcStatsAsJson );
+		}
+		if ( returnFedAccessStats ) {
+			final JsonObject fedAccessStatsAsJson = StatsPrinter.statsAsJson(engine.getFederationAccessStats(), true);
+			res.put( HttpConstants.JSON_FED_ACCESS_STATS, fedAccessStatsAsJson );
+		}
 		return res;
 	}
 

--- a/hefquin-service/src/main/java/se/liu/ida/hefquin/service/SparqlServlet.java
+++ b/hefquin-service/src/main/java/se/liu/ida/hefquin/service/SparqlServlet.java
@@ -157,8 +157,6 @@ public class SparqlServlet extends HttpServlet {
 		final boolean returnFedAccessStats = Boolean.parseBoolean( request.getHeader(HttpConstants.X_HEADER_RETURN_FED_ACCESS_STATS));
 
 		try {
-			logger.debug( "Received SPARQL query: {}", query );
-
 			final JsonObject result = execute( query, mimeType, ctx, queryResBuf, returnQueryProcStats, returnFedAccessStats );
 			if ( ! result.get(HttpConstants.JSON_EXCEPTIONS).getAsArray().isEmpty() ) {
 				writeJsonError( response, 500, result.get( HttpConstants.JSON_EXCEPTIONS ) );


### PR DESCRIPTION
Closes #641 by adding flags:

- `--printQueryProcMeasurements`
- `--printQueryProcMeasurementsToFile`
- `--printQueryProcStats`
- `--printQueryProcStatsToFile`
- `--printFedAccessStats`
- `--printFedAccessStatsToFile`

I thought the remaining groups were too similar and too small by themselves so I combined them into one PR.