### PR TITLE
Add documentation for hefquin-rmlmat and for hefquin-client

### DIFF
--- a/docs/doc/cli.html
+++ b/docs/doc/cli.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>HeFQUIN - Querying a Federation via the Command-Line Program</title>
+    <title>HeFQUIN - Querying a Federation via the Command-Line Programs</title>
 
     <!-- Prism -->
     <link href="../css/prism-coy-without-shadows.css" rel="stylesheet" />
@@ -29,24 +29,29 @@
     <div id="header"></div>
 
     <main>
-        <h1>Querying a Federation via the HeFQUIN Command-Line Program</h1>
+        <h1>Querying a Federation via the HeFQUIN Command-Line Programs</h1>
         <p>
-            HeFQUIN comes with <a href="programs.html">several command-line programs</a>, including one to run queries over a federation directly from the command line. This page focuses on that program.
+            HeFQUIN comes with <a href="programs.html">several command-line programs</a>, including <em>two programs</em> to run queries over a federation. One of them, called <code>hefquin-client</code>, provides this functionality through interacting with a <a href="index.html#service">HeFQUIN service</a>. The other one, simply called <code>hefquin</code>, uses an instance of the HeFQUIN engine created directly within this program and, thus, can be used without starting up a HeFQUIN service in a separate process. The latter may be your first choice if you simply want to try HeFQUIN, or for experimentation and testing purposes, whereas the HeFQUIN client-server combination should be the preferred choice if you want to run multiple queries, because it avoids initializing the engine for every single query.
         </p>
         <p>
-            You can use the program as follows, assuming the file <code>MyFedConf.ttl</code> contains the <a href="federation_description.html">description of your federation</a> and the file <code>ExampleQuery.rq</code> contains the <a href="queries.html">query that you want to run</a> over this federation, and assuming that you have <a href="programs.html">added the HeFQUIN programs to your <code>PATH</code></a> (otherwise, enter the directory in which you have unpacked the HeFQUIN release and replace <code>hefquin</code> by <code>bin/hefquin</code>).
+            You can use the <code>hefquin</code> program as follows, assuming the file <code>MyFedConf.ttl</code> contains the <a href="federation_description.html">description of your federation</a> and the file <code>ExampleQuery.rq</code> contains the <a href="queries.html">query that you want to run</a> over this federation, and assuming that you have <a href="programs.html">added the HeFQUIN programs to your <code>PATH</code></a> (otherwise, enter the directory in which you have unpacked the HeFQUIN release and replace <code>hefquin</code> by <code>bin/hefquin</code>).
         </p>
         <pre><code class="language-bash">hefquin --fd MyFedConf.ttl --query ExampleQuery.rq</code></pre>
         <p>
-            Further arguments can be passed to the program, which are described in detail below. You can also have the list of supported arguments printed by executing the program with the argument <code>--help</code>.
+            Similarly, the <code>hefquin-client</code> program can be used by issuing the following command, assuming that the HeFQUIN service you want interact with is available at the address <a href="http://localhost:8080/">http://localhost:8080/</a>, and assuming again that you have <a href="programs.html">added the HeFQUIN programs to your <code>PATH</code></a> (otherwise, enter the directory in which you have unpacked the HeFQUIN release and replace <code>hefquin-client</code> by <code>bin/hefquin-client</code>). In this case, the given query (in <code>ExampleQuery.rq</code>) will be executed over the federation for which the service is set up.
+        </p>
+        <pre><code class="language-bash">hefquin-client --server http://localhost:8080/ --query ExampleQuery.rq</code></pre>
+        <p>
+            Further arguments can be passed to both programs, which are described in detail below. You can also have the list of supported arguments printed by executing the programs with the argument <code>--help</code>.
         </p>
         <pre><code class="language-bash">hefquin --help</code></pre>
+        <pre><code class="language-bash">hefquin-client --help</code></pre>
 
-        <section id="arguments">
-            <h2>Query-Related Arguments of the Program</h2>
+        <section>
+            <h2>Arguments of Only One of the Programs</h2>
             <p id="--fd" style="font-weight:bold">
                 --fd=&lt;<em>file</em>>
-                <em style="padding-left:1em">(mandatory argument)</em>
+                <em style="padding-left:1em">(mandatory argument of the <code>hefquin</code> program)</em>
             </p>
             <p style="padding-left:2em">
                 Refers to a file that contains an RDF-based description of the federation to be queried. The file can be in any RDF serialization format (e.g., Turtle, N-Triples, JSON-LD) and it must use the <a href="federation_description.html">HeFQUIN Federation Vocabulary</a>. Every instance of type <code>fd:FederationMember</code> described by this document will be considered as a member of the federation to be queried.
@@ -54,6 +59,17 @@
             <p style="padding-left:2em">
                 This argument may be provided multiple times, which is useful if the federation description is distributed across multiple files (e.g., one file per federation member).
             </p>
+            <p id="--server" style="font-weight:bold">
+                --server=&lt;<em>URI</em>>
+                <em style="padding-left:1em">(mandatory argument of the <code>hefquin-client</code> program)</em>
+            </p>
+            <p style="padding-left:2em">
+                The address of the HeFQUIN service to be used. This service should be set up using the same version of HeFQUIN as the client program that you are using.
+            </p>
+        </section>
+
+        <section>
+            <h2>Query-Related Arguments of both Programs</h2>
             <p id="--query" style="font-weight:bold">
                 --query=&lt;<em>file</em>>
                 <em style="padding-left:1em">(mandatory argument)</em>
@@ -76,7 +92,7 @@
         </section>
 
         <section>
-            <h2>Result-Related Arguments of the Program</h2>
+            <h2>Result-Related Arguments of both Programs</h2>
             <p id="--rfmt" style="font-weight:bold">
                 --rfmt=&lt;<em>format</em>>
             </p>
@@ -119,7 +135,7 @@
         </section>
 
         <section>
-            <h2>Planning-Related Arguments of the Program</h2>
+            <h2>Planning-Related Arguments of both Programs</h2>
 
             <p id="--printSourceAssignment" style="font-weight:bold">
                 --printSourceAssignment
@@ -174,7 +190,7 @@
         </section>
 
         <section>
-            <h2>Experiments-Related Arguments of the Program</h2>
+            <h2>Experiments-Related Arguments of both Programs</h2>
             <p id="--printQueryProcMeasurements" style="font-weight:bold">
                 --printQueryProcMeasurements
             </p>
@@ -250,7 +266,7 @@
         </section>
 
         <section>
-            <h2>Other Arguments of the Program</h2>
+            <h2>Other Arguments of both Programs</h2>
             <p id="--confDescr" style="font-weight:bold">
                 --confDescr=&lt;<em>file</em>>
             </p>

--- a/docs/doc/cli.html
+++ b/docs/doc/cli.html
@@ -36,7 +36,7 @@
         <p>
             You can use the program as follows, assuming the file <code>MyFedConf.ttl</code> contains the <a href="federation_description.html">description of your federation</a> and the file <code>ExampleQuery.rq</code> contains the <a href="queries.html">query that you want to run</a> over this federation, and assuming that you have <a href="programs.html">added the HeFQUIN programs to your <code>PATH</code></a> (otherwise, enter the directory in which you have unpacked the HeFQUIN release and replace <code>hefquin</code> by <code>bin/hefquin</code>).
         </p>
-        <pre><code class="language-bash">hefquin --fd=MyFedConf.ttl --query=ExampleQuery.rq</code></pre>
+        <pre><code class="language-bash">hefquin --fd MyFedConf.ttl --query ExampleQuery.rq</code></pre>
         <p>
             Further arguments can be passed to the program, which are described in detail below. You can also have the list of supported arguments printed by executing the program with the argument <code>--help</code>.
         </p>
@@ -77,8 +77,8 @@
 
         <section>
             <h2>Result-Related Arguments of the Program</h2>
-            <p id="--results" style="font-weight:bold">
-                --results=&lt;<em>format</em>>
+            <p id="--rfmt" style="font-weight:bold">
+                --rfmt=&lt;<em>format</em>>
             </p>
             <p style="padding-left:2em">
                 Use this argument to specify the format in which you would like the query result to be printed. The possible values for this argument depend on the type of query.
@@ -103,6 +103,12 @@
                     <li>JSONLD - <a href="https://www.w3.org/TR/json-ld/">JSON-LD</a> format.</li>
                     <li>RDF/XML - <a href="https://www.w3.org/TR/rdf-syntax-grammar/">RDF/XML</a> format.</li>
                 </ul>
+            </p>
+            <p style="font-weight:bold">
+                --outputToFile=&lt;<em>file</em>>
+            </p>
+            <p style="padding-left:2em">
+                Use this argument if you want the query result to be written into a file. If this argument is omitted, the result is written to stdout. If the given file already exists, the output is appended to that file (instead of overwriting the file).
             </p>
             <p style="font-weight:bold">
                 --suppressResultPrintout

--- a/docs/doc/hefquin_service.html
+++ b/docs/doc/hefquin_service.html
@@ -36,14 +36,20 @@
                 href="separate_servlet_container.html">using your own, separate servlet container</a>), you can first
             test it by opening <code><a href="http://localhost:8080/">http://localhost:8080/</a></code> in a Web browser
             (assuming that you have started the service at port 8080). If this works (i.e., you see a page that
-            describes the service), you can start interacting with the service via HTTP. In particular,
+            describes the service), you can start interacting with the service.
+        </p>
+        <p>
+            As one option, this can be done <a href="cli.html">by using the HeFQUIN client program</a>.
+        </p>
+        <p>
+            Alternatively, you can interact with the service directly via HTTP, in which case you can ...
         </p>
         <ul>
-            <li>you can <a href="#issuing-queries">issue queries</a> and</li>
-            <li>you can <a href="inspecting-queries">issue a request for query processing details</a>.</li>
+            <li><a href="#issuing-queries">issue queries</a> and</li>
+            <li><a href="inspecting-queries">issue a request for query processing details</a>.</li>
         </ul>
         <p>
-            While the following sections describe these options in detail, we also provide an <a href="hefquin_api.html">OpenAPI documentation of the API of the HeFQUIN service</a>. This documentation is also available at the root endpoint of the service:
+            While the following sections describe the latter two of these options in detail, we also provide an <a href="hefquin_api.html">OpenAPI documentation of the API of the HeFQUIN service</a>. This documentation is also available at the root endpoint of the service:
             <code><a href="http://localhost:8080/">http://localhost:8080/</a></code> (assuming that you have started the service at port 8080).
         </p>
 

--- a/docs/doc/index.html
+++ b/docs/doc/index.html
@@ -67,6 +67,9 @@
                 <h2>Other Command-Line Programs</h2>
                 <ul>
                     <li>
+                        <a href="rmlmat.html">RML materialization</a>
+                    </li>
+                    <li>
                         <a href="pg_connector.html">Property Graph Connector</a>
                     </li>
                 </ul>

--- a/docs/doc/index.html
+++ b/docs/doc/index.html
@@ -30,7 +30,7 @@
                 </li>
             </ul>
 
-            <section class="section">
+            <section class="section" id="service">
                 <h2>Using HeFQUIN as a Service</h2>
                 <ul>
                     <li>
@@ -58,7 +58,7 @@
                         <a href="programs.html">Setting up the command-line programs</a>
                     </li>
                     <li>
-                        <a href="cli.html">Querying a federation via the HeFQUIN command-line program</a>
+                        <a href="cli.html">Querying a federation via the HeFQUIN command-line programs</a>
                     </li>
                 </ul>
             </section>

--- a/docs/doc/programs.html
+++ b/docs/doc/programs.html
@@ -38,6 +38,7 @@
             <li><code>hefquin-server</code> - <a href="embedded_servlet_container.html">start HeFQUIN as a Web service</a>,</li>
             <li><code>hefquin-pg</code> - <a href="pg_connector.html">execute SPARQL queries over a virtual RDF view of a Property Graph</a>, and</li>
             <li><code>hefquin-pgmat</code> - <a href="pg_connector.html">create an RDF representation of a Property Graph</a>.</li>
+            <li><code>hefquin-rmlmat</code> - <a href="rmlmat.html">materialize an RDF dataset from an RML mapping</a>.</li>
         </ul>
         <p>
         This page describes how to set up and run these programs ...

--- a/docs/doc/programs.html
+++ b/docs/doc/programs.html
@@ -34,11 +34,11 @@
             HeFQUIN comes with several command-line programs, including:
         </p>
         <ul>
-            <li><code>hefquin</code> - <a href="cli.html">execute queries over a federation</a>,</li>
-            <li><code>hefquin-server</code> - <a href="embedded_servlet_container.html">start HeFQUIN as a Web service</a>,</li>
-            <li><code>hefquin-pg</code> - <a href="pg_connector.html">execute SPARQL queries over a virtual RDF view of a Property Graph</a>, and</li>
-            <li><code>hefquin-pgmat</code> - <a href="pg_connector.html">create an RDF representation of a Property Graph</a>.</li>
-            <li><code>hefquin-rmlmat</code> - <a href="rmlmat.html">materialize an RDF dataset from an RML mapping</a>.</li>
+            <li><code style="font-weight:bold">hefquin</code> - <a href="cli.html">execute queries over a federation</a></li>
+            <li><code style="font-weight:bold">hefquin-server</code> - <a href="embedded_servlet_container.html">start HeFQUIN as a Web service</a></li>
+            <li><code style="font-weight:bold">hefquin-pg</code> - <a href="pg_connector.html">execute SPARQL queries over a virtual RDF view of a Property Graph</a></li>
+            <li><code style="font-weight:bold">hefquin-pgmat</code> - <a href="pg_connector.html">create an RDF representation of a Property Graph</a></li>
+            <li><code style="font-weight:bold">hefquin-rmlmat</code> - <a href="rmlmat.html">execute an RML mapping and materialize the resulting RDF dataset</a></li>
         </ul>
         <p>
         This page describes how to set up and run these programs ...

--- a/docs/doc/programs.html
+++ b/docs/doc/programs.html
@@ -34,7 +34,8 @@
             HeFQUIN comes with several command-line programs, including:
         </p>
         <ul>
-            <li><code style="font-weight:bold">hefquin</code> - <a href="cli.html">execute queries over a federation</a></li>
+            <li><code style="font-weight:bold">hefquin</code> - <a href="cli.html">execute queries directly over a federation</a></li>
+            <li><code style="font-weight:bold">hefquin-client</code> - <a href="cli.html">execute queries via a HeFQUIN service</a></li>
             <li><code style="font-weight:bold">hefquin-server</code> - <a href="embedded_servlet_container.html">start HeFQUIN as a Web service</a></li>
             <li><code style="font-weight:bold">hefquin-pg</code> - <a href="pg_connector.html">execute SPARQL queries over a virtual RDF view of a Property Graph</a></li>
             <li><code style="font-weight:bold">hefquin-pgmat</code> - <a href="pg_connector.html">create an RDF representation of a Property Graph</a></li>

--- a/docs/doc/rml.html
+++ b/docs/doc/rml.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>HeFQUIN - RML Support</title>
+
+    <script src="../js/mustache.min.js"></script>
+    <script src="../js/script.js"></script>
+    <link rel="stylesheet" href="../css/style.css">
+</head>
+
+<body>
+    <div id="header"></div>
+
+    <main>
+        <h1>RML Support in HeFQUIN</h1>
+        <p>
+            Sorry, this page of the user documentation is still to be written (and the support for <a href="https://w3id.org/rml/core/spec">RML-Core</a> in HeFQUIN is still to be completed).
+        </p>
+
+    </main>
+
+    <div id="footer"></div>
+</body>
+
+</html>

--- a/docs/doc/rmlmat.html
+++ b/docs/doc/rmlmat.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>HeFQUIN - Materializing an RDF view from an RML mapping</title>
+
+    <!-- Prism -->
+    <link href="../css/prism-coy-without-shadows.css" rel="stylesheet" />
+    <script src="../js/prism_1.29.0/prism.min.js"></script>
+    <script src="../js/prism_1.29.0/prism-bash.min.js"></script>
+    <script src="../js/prism_1.29.0/prism-toolbar.min.js"></script>
+    <script src="../js/prism_1.29.0/prism-copy-to-clipboard.min.js"></script>
+    <link href="../css/prism-toolbar.min.css" rel="stylesheet" />
+
+    <script src="../js/mustache.min.js"></script>
+    <script src="../js/script.js"></script>
+    <link rel="stylesheet" href="../css/style.css">
+
+    <script>
+        // trim any preceeding or trailing whitespaces from code snippets
+        window.addEventListener('load', trimCode);
+    </script>
+</head>
+
+<body>
+    <div id="header"></div>
+
+    <main>
+        <h1>Materializing an RDF view from an RML mapping</h1>
+        <p>
+            This command-line tool materializes an RDF dataset from an <a href="https://rml.io/specs/rml/">RML mapping</a>. It reads an RML description (Triples Maps), evaluates the mapping against its referenced JSON sources and outputs the resulting RDF dataset.
+        </p>
+        <p>
+            You can use the program as follows, assuming the file <code>MyMapping.ttl</code> contains your <a href="https://rml.io/specs/rml/">RML mapping</a>. The tool reads this mapping, materializes all <code>rml:TriplesMap</code> definitions and writes the resulting RDF dataset to standard output or a file.
+            It also assumes that you have <a href="programs.html">added the HeFQUIN programs to your <code>PATH</code></a> (otherwise, enter the directory in which you have unpacked the HeFQUIN release and replace <code>hefquin-rmlmat</code> by <code>bin/hefquin-rmlmat</code>).
+        </p>
+        <pre><code class="language-bash">hefquin-rmlmat --mapping=MyMapping.ttl</code></pre>
+        <p>
+            Further arguments can be passed to the program, which are described in detail below. You can also have the list of supported arguments printed by executing the program with the argument <code>--help</code>.
+        </p>
+        <pre><code class="language-bash">hefquin-rmlmat --help</code></pre>
+
+        <section id="arguments">
+            <h2>Arguments</h2>
+            <p id="--mapping" style="font-weight:bold">
+                --mapping=&lt;<em>rdf-file</em>>
+                <em style="padding-left:1em">(mandatory argument)</em>
+            </p>
+            <p style="padding-left:2em">
+                Path to an RDF file containing the RML mapping. The file must include <code>rml:TriplesMap</code> definitions. All Triples Maps found in the file will be processed during materialization. Supported RDF serializations include Turtle, RDF/XML, JSON-LD and N-Triples.
+            </p>
+            <p id="--outputToFile" style="font-weight:bold">
+                --outputToFile=&lt;<em>file-name</em>>
+            </p>
+            <p style="padding-left:2em">
+                Optional output destination file. If omitted, results are written to standard output. If the file already exists, output is appended rather than overwritten.
+            </p>
+            <p id="--base" style="font-weight:bold">
+                --baseIRI=&lt;<em>iri</em>>
+            </p>
+            <p style="padding-left:2em">
+                Optional base IRI used during mapping expansion and IRI resolution. If not provided, an internal default base IRI is used.
+            </p>
+            <p id="--time" style="font-weight:bold">
+                --time
+            </p>
+            <p style="padding-left:2em">
+                Enables execution timing. When active, the tool prints the total time spent in the core materialization phase (mapping evaluation + RDF generation).
+            </p>
+            <p id="--help" style="font-weight:bold">
+                --help
+            </p>
+            <p style="padding-left:2em">
+                If this argument is given, the program prints a list of all supported arguments and terminates (i.e., all other given arguments are ignored).
+            </p>
+        </section>
+
+    </main>
+
+    <div id="footer"></div>
+</body>
+
+</html>

--- a/docs/doc/rmlmat.html
+++ b/docs/doc/rmlmat.html
@@ -46,7 +46,7 @@
         <pre><code class="language-bash">hefquin-rmlmat --help</code></pre>
 
         <section id="arguments">
-            <h2>Arguments</h2>
+            <h2>RML Mapping Arguments</h2>
             <p id="--mapping" style="font-weight:bold">
                 --mapping &lt;<em>file</em>>
                 <em style="padding-left:1em">(mandatory argument)</em>
@@ -54,24 +54,63 @@
             <p style="padding-left:2em">
                 Refers to an RDF file that describes the RML mapping; hence, the file must contain <code>rml:TriplesMap</code> definitions. Every <code>rml:TriplesMap</code> found in the file will be used for the materialization. Supported serialization formats for the given RDF file include Turtle, RDF/XML, JSON-LD and N-Triples.
             </p>
-            <p id="--outputToFile" style="font-weight:bold">
-                --outputToFile &lt;<em>file</em>>
-            </p>
-            <p style="padding-left:2em">
-                Use this argument if you want the produced RDF data to be written into a file. If this argument is omitted, the result is written to stdout. If the given file already exists, it will be overwritten.
-            </p>
             <p id="--base" style="font-weight:bold">
                 --baseIRI &lt;<em>iri</em>>
             </p>
             <p style="padding-left:2em">
                 Use this argument to provide the base IRI to be used for the mapping process. If not provided, an internal default base IRI is used.
             </p>
+        </section>
+
+        <section>
+            <h2>Output Control Arguments</h2>
+            <p id="--output" style="font-weight:bold">
+                --output=&lt;<em>format</em>>
+            </p>
+            <p style="padding-left:2em">
+                Use this argument to specify the format in which the RDF output should be serialized. If the specified format supports streaming, the output is streamed. Otherwise, the output is produced using a non-streaming writer.
+            </p>
+            <p style="padding-left:2em">
+                The <a href="#--output">--output</a>, <a href="#--formatted">--formatted</a> and <a href="#--stream">--stream</a> arguments are mutually exclusive.
+            </p>
+            <p id="--formatted" style="font-weight:bold">
+                --formatted=&lt;<em>format</em>>
+            </p>
+            <p style="padding-left:2em">
+                Use this argument to specify the format in which the RDF output should be serialized using pretty printing. This option uses a non-streaming writer and therefore consumes memory while producing the output.
+            </p>
+            <p id="--stream" style="font-weight:bold">
+                --stream=&lt;<em>format</em>>
+            </p>
+            <p style="padding-left:2em">
+                Use this argument to specify the format in which the RDF output should be serialized using a streaming writer. This option is useful for producing output without keeping the entire RDF dataset in memory.
+            </p>
+            <p id="--compress" style="font-weight:bold">
+                --compress
+            </p>
+            <p style="padding-left:2em">
+                Use this argument to compress the RDF output using gzip.
+            </p>
+            <p id="--outputToFile" style="font-weight:bold">
+                --outputToFile &lt;<em>file</em>>
+            </p>
+            <p style="padding-left:2em">
+                Use this argument if you want the produced RDF data to be written into a file. If this argument is omitted, the result is written to stdout. If the given file already exists, it will be overwritten.
+            </p>
+        </section>
+
+        <section>
+            <h2>Experiments-Related Arguments</h2>
             <p id="--time" style="font-weight:bold">
                 --time
             </p>
             <p style="padding-left:2em">
                 Use this argument to print the total time spent in the core materialization phase (mapping execution + RDF generation).
             </p>
+        </section>
+
+        <section>
+            <h2>Other Arguments of the Program</h2>
             <p id="--help" style="font-weight:bold">
                 --help
             </p>

--- a/docs/doc/rmlmat.html
+++ b/docs/doc/rmlmat.html
@@ -58,7 +58,7 @@
                 --outputToFile &lt;<em>file</em>>
             </p>
             <p style="padding-left:2em">
-                Use this argument if you want the produced RDF data to be written into a file. If this argument is omitted, the result is written to stdout. If the given file already exists, output is appended rather than overwritten.
+                Use this argument if you want the produced RDF data to be written into a file. If this argument is omitted, the result is written to stdout. If the given file already exists, it will be overwritten.
             </p>
             <p id="--base" style="font-weight:bold">
                 --baseIRI &lt;<em>iri</em>>

--- a/docs/doc/rmlmat.html
+++ b/docs/doc/rmlmat.html
@@ -5,7 +5,7 @@
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>HeFQUIN - Materializing an RDF view from an RML mapping</title>
+    <title>HeFQUIN - Executing RML Mappings</title>
 
     <!-- Prism -->
     <link href="../css/prism-coy-without-shadows.css" rel="stylesheet" />
@@ -29,15 +29,17 @@
     <div id="header"></div>
 
     <main>
-        <h1>Materializing an RDF view from an RML mapping</h1>
+        <h1>Command-Line Program to Execute RML Mappings</h1>
         <p>
-            This command-line tool materializes an RDF dataset from an <a href="https://rml.io/specs/rml/">RML mapping</a>. It reads an RML description (Triples Maps), evaluates the mapping against its referenced JSON sources and outputs the resulting RDF dataset.
+            HeFQUIN comes with its own RML processor. The primary use of this RML processor is to create ephemeral RDF representations of non-RDF data obtained from some types of federation members at query runtime (e.g., from JSON-based Web APIs). However, for debugging purposes we also provide a command-line program called <code>hefquin-rmlmat</code> via which the RML processor of HeFQUIN can be used to execute an RML mapping and save the resulting RDF data into a file. This page describes how to use this program. There are related pages that describe the <a href="rml.html">specifics of RML support in HeFQUIN</a> and <a href="programs.html">how to set up the command-line programs</a>.
         </p>
         <p>
-            You can use the program as follows, assuming the file <code>MyMapping.ttl</code> contains your <a href="https://rml.io/specs/rml/">RML mapping</a>. The tool reads this mapping, materializes all <code>rml:TriplesMap</code> definitions and writes the resulting RDF dataset to standard output or a file.
-            It also assumes that you have <a href="programs.html">added the HeFQUIN programs to your <code>PATH</code></a> (otherwise, enter the directory in which you have unpacked the HeFQUIN release and replace <code>hefquin-rmlmat</code> by <code>bin/hefquin-rmlmat</code>).
+            The core functionality of the <code>hefquin-rmlmat</code> program is to read an RDF file that describes an RML mapping, to apply this mapping to the source data files mentioned in the mapping, and to print out the RDF data produced by the previous step. For the moment, only JSON files are supported as source data files.
         </p>
-        <pre><code class="language-bash">hefquin-rmlmat --mapping=MyMapping.ttl</code></pre>
+        <p>
+            You can use the program as follows, assuming the file that contains your RML mapping is called <code>MyMapping.ttl</code>, and assuming that you have <a href="programs.html">added the HeFQUIN programs to your <code>PATH</code></a> (otherwise, enter the directory in which you have unpacked the HeFQUIN release and replace <code>hefquin-rmlmat</code> by <code>bin/hefquin-rmlmat</code>). When using the program in this way, the resulting RDF data will be written to stdout.
+        </p>
+        <pre><code class="language-bash">hefquin-rmlmat --mapping MyMapping.ttl</code></pre>
         <p>
             Further arguments can be passed to the program, which are described in detail below. You can also have the list of supported arguments printed by executing the program with the argument <code>--help</code>.
         </p>
@@ -46,29 +48,29 @@
         <section id="arguments">
             <h2>Arguments</h2>
             <p id="--mapping" style="font-weight:bold">
-                --mapping=&lt;<em>rdf-file</em>>
+                --mapping &lt;<em>file</em>>
                 <em style="padding-left:1em">(mandatory argument)</em>
             </p>
             <p style="padding-left:2em">
-                Path to an RDF file containing the RML mapping. The file must include <code>rml:TriplesMap</code> definitions. All Triples Maps found in the file will be processed during materialization. Supported RDF serializations include Turtle, RDF/XML, JSON-LD and N-Triples.
+                Refers to an RDF file that describes the RML mapping; hence, the file must contain <code>rml:TriplesMap</code> definitions. Every <code>rml:TriplesMap</code> found in the file will be used for the materialization. Supported serialization formats for the given RDF file include Turtle, RDF/XML, JSON-LD and N-Triples.
             </p>
             <p id="--outputToFile" style="font-weight:bold">
-                --outputToFile=&lt;<em>file-name</em>>
+                --outputToFile &lt;<em>file</em>>
             </p>
             <p style="padding-left:2em">
-                Optional output destination file. If omitted, results are written to standard output. If the file already exists, output is appended rather than overwritten.
+                Use this argument if you want the produced RDF data to be written into a file. If this argument is omitted, the result is written to stdout. If the given file already exists, output is appended rather than overwritten.
             </p>
             <p id="--base" style="font-weight:bold">
-                --baseIRI=&lt;<em>iri</em>>
+                --baseIRI &lt;<em>iri</em>>
             </p>
             <p style="padding-left:2em">
-                Optional base IRI used during mapping expansion and IRI resolution. If not provided, an internal default base IRI is used.
+                Use this argument to provide the base IRI to be used for the mapping process. If not provided, an internal default base IRI is used.
             </p>
             <p id="--time" style="font-weight:bold">
                 --time
             </p>
             <p style="padding-left:2em">
-                Enables execution timing. When active, the tool prints the total time spent in the core materialization phase (mapping evaluation + RDF generation).
+                Use this argument to print the total time spent in the core materialization phase (mapping execution + RDF generation).
             </p>
             <p id="--help" style="font-weight:bold">
                 --help

--- a/docs/doc/rmlmat.html
+++ b/docs/doc/rmlmat.html
@@ -46,7 +46,7 @@
         <pre><code class="language-bash">hefquin-rmlmat --help</code></pre>
 
         <section id="arguments">
-            <h2>RML Mapping Arguments</h2>
+            <h2>RML-Specific Arguments of the Program</h2>
             <p id="--mapping" style="font-weight:bold">
                 --mapping &lt;<em>file</em>>
                 <em style="padding-left:1em">(mandatory argument)</em>
@@ -63,9 +63,9 @@
         </section>
 
         <section>
-            <h2>Output Control Arguments</h2>
+            <h2>Output-Related Arguments of the Program</h2>
             <p id="--output" style="font-weight:bold">
-                --output=&lt;<em>format</em>>
+                --output &lt;<em>format</em>>
             </p>
             <p style="padding-left:2em">
                 Use this argument to specify the format in which the RDF output should be serialized. If the specified format supports streaming, the output is streamed. Otherwise, the output is produced using a non-streaming writer.
@@ -74,13 +74,13 @@
                 The <a href="#--output">--output</a>, <a href="#--formatted">--formatted</a> and <a href="#--stream">--stream</a> arguments are mutually exclusive.
             </p>
             <p id="--formatted" style="font-weight:bold">
-                --formatted=&lt;<em>format</em>>
+                --formatted &lt;<em>format</em>>
             </p>
             <p style="padding-left:2em">
                 Use this argument to specify the format in which the RDF output should be serialized using pretty printing. This option uses a non-streaming writer and therefore consumes memory while producing the output.
             </p>
             <p id="--stream" style="font-weight:bold">
-                --stream=&lt;<em>format</em>>
+                --stream &lt;<em>format</em>>
             </p>
             <p style="padding-left:2em">
                 Use this argument to specify the format in which the RDF output should be serialized using a streaming writer. This option is useful for producing output without keeping the entire RDF dataset in memory.
@@ -100,7 +100,7 @@
         </section>
 
         <section>
-            <h2>Experiments-Related Arguments</h2>
+            <h2>Experiments-Related Arguments of the Program</h2>
             <p id="--time" style="font-weight:bold">
                 --time
             </p>

--- a/docs/doc/rmlmat.html
+++ b/docs/doc/rmlmat.html
@@ -85,11 +85,38 @@
             <p style="padding-left:2em">
                 Use this argument to specify the format in which the RDF output should be serialized using a streaming writer. This option is useful for producing output without keeping the entire RDF dataset in memory.
             </p>
+
+            <h4>Supported Output Formats</h4>
+            <p style="padding-left:2em">
+                The following formats are supported:
+            </p>
+
+            <ul style="margin-left:4em">
+                <li>NQUADS - <a href="https://www.w3.org/TR/n-quads/">N-Quads</a> format (<b>default</b>).</li>
+                <li>TTL - <a href="https://www.w3.org/TR/turtle/">RDF Turtle</a> format.</li>
+                <li>NTRIPLES - <a href="https://www.w3.org/TR/n-triples/">N-Triples</a> format.</li>
+                <li>TRIG - <a href="https://www.w3.org/TR/trig/">TriG</a> format.</li>
+                <li>TRIX - <a href="https://www.w3.org/2004/03/trix/">TriX</a> format.</li>
+                <li>RDF-THRIFT - RDF Thrift format.</li>
+                <li>RDF-PROTO - RDF Protocol Buffers format.</li>
+                <li>RDF/XML - <a href="https://www.w3.org/TR/rdf-syntax-grammar/">RDF/XML</a> format.</li>
+                <li>JSONLD - <a href="https://www.w3.org/TR/json-ld/">JSON-LD</a> format.</li>
+                <li>RDF/JSON - <a href="https://www.w3.org/TR/rdf-json/">RDF/JSON</a> format.</li>
+            </ul>
+
+            <p style="padding-left:2em">
+                The <a href="#--output">--output</a> and
+                <a href="#--formatted">--formatted</a> arguments support all of the
+                formats listed above. The <a href="#--stream">--stream</a> argument
+                supports Turtle, N-Triples, N-Quads, TriG, TriX, RDF-THRIFT and
+                RDF-PROTO.
+            </p>
+
             <p id="--compress" style="font-weight:bold">
                 --compress
             </p>
             <p style="padding-left:2em">
-                Use this argument to compress the RDF output using gzip.
+                Use this argument to compress the RDF output using GZIP.
             </p>
             <p id="--outputToFile" style="font-weight:bold">
                 --outputToFile &lt;<em>file</em>>


### PR DESCRIPTION
Closes #654.

The page feels a little small right now and follows the same structure as `cli.html`. Should I perhaps add a brief description of how it works or is it sufficient as is?