### PR TITLE
657 add support for controlling class specific logging levels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [unreleased]
 
 ### Added
-- Support configurable logging when using the HeFQUIN CLI (#659)[https://github.com/LiUSemWeb/HeFQUIN/pull/659].
+- Support configurable logging when using the HeFQUIN CLI ([#659](https://github.com/LiUSemWeb/HeFQUIN/pull/659)).
 - Support for MapDB-based persistent cache for federation requests (including cardinality requests), with support for cache replacement and invalidation policies ([#648](https://github.com/LiUSemWeb/HeFQUIN/pull/648)).
 - Support for ChronicleMap-based persistent cache for federation requests (including cardinality requests), with support for cache replacement and invalidation policies ([#546](https://github.com/LiUSemWeb/HeFQUIN/pull/546)).
 - CLI program to issue queries to the HeFQUIN service ([#616](https://github.com/LiUSemWeb/HeFQUIN/issues/616), [#643](https://github.com/LiUSemWeb/HeFQUIN/issues/643), [#646](https://github.com/LiUSemWeb/HeFQUIN/issues/646), [#647](https://github.com/LiUSemWeb/HeFQUIN/issues/647), [#653](https://github.com/LiUSemWeb/HeFQUIN/issues/653), [#655](https://github.com/LiUSemWeb/HeFQUIN/issues/655)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [unreleased]
 
 ### Added
+- Support configurable logging when using the HeFQUIN CLI (#659)[https://github.com/LiUSemWeb/HeFQUIN/pull/659].
 - Support for MapDB-based persistent cache for federation requests (including cardinality requests), with support for cache replacement and invalidation policies ([#648](https://github.com/LiUSemWeb/HeFQUIN/pull/648)).
 - Support for ChronicleMap-based persistent cache for federation requests (including cardinality requests), with support for cache replacement and invalidation policies ([#546](https://github.com/LiUSemWeb/HeFQUIN/pull/546)).
 - CLI program to issue queries to the HeFQUIN service ([#616](https://github.com/LiUSemWeb/HeFQUIN/issues/616), [#643](https://github.com/LiUSemWeb/HeFQUIN/issues/643), [#646](https://github.com/LiUSemWeb/HeFQUIN/issues/646), [#647](https://github.com/LiUSemWeb/HeFQUIN/issues/647), [#653](https://github.com/LiUSemWeb/HeFQUIN/issues/653), [#655](https://github.com/LiUSemWeb/HeFQUIN/issues/655)).

--- a/bin/common.sh
+++ b/bin/common.sh
@@ -79,4 +79,5 @@ JVM_ARGS="$JVM_ARGS \
   --add-opens=java.base/java.lang=ALL-UNNAMED \
   --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
   --add-opens=java.base/java.io=ALL-UNNAMED \
-  --add-opens=java.base/java.util=ALL-UNNAMED"
+  --add-opens=java.base/java.util=ALL-UNNAMED \
+  --sun-misc-unsafe-memory-access=allow"

--- a/bin/hefquin
+++ b/bin/hefquin
@@ -3,4 +3,4 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source ${SCRIPT_DIR}/common.sh
 
 # Run the Java command
-"$JAVA" $JVM_ARGS -cp $HEFQUIN_CP se.liu.ida.hefquin.cli.RunQueryWithoutSrcSel $@
+"$JAVA" $JVM_ARGS -cp "${SCRIPT_DIR}:${HEFQUIN_CP}" se.liu.ida.hefquin.cli.RunQueryWithoutSrcSel $@

--- a/bin/simplelogger.properties
+++ b/bin/simplelogger.properties
@@ -1,0 +1,72 @@
+###############################################################################
+# SLF4J Simple Logger Configuration
+#
+# This file controls logging for the HeFQUIN command-line tools.
+#
+# Logging levels (least to most verbose):
+#
+#   error  - Only serious failures.
+#   warn   - Warnings and errors (recommended default).
+#   info   - General progress and status information.
+#   debug  - Detailed information useful for debugging.
+#   trace  - Extremely detailed diagnostic output.
+#
+# The effective log level for a logger is determined by the most specific
+# matching setting. If no class-specific setting exists, the default level
+# below is used.
+###############################################################################
+
+# Default log level for all loggers.
+# Ignored for any logger with a class-specific setting below.
+org.slf4j.simpleLogger.defaultLogLevel=warn
+
+
+###############################################################################
+# Class-specific log levels
+#
+# These override the default level for individual classes.
+#
+# Format:
+# org.slf4j.simpleLogger.log.<fully-qualified-class-name>=<level>
+#
+# Examples:
+#
+# Enable DEBUG logging for the parallel bind join operator:
+#
+# org.slf4j.simpleLogger.log.se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.BaseForExecOpParallelBindJoin=debug
+#
+# Silence INFO messages from the same class:
+#
+# org.slf4j.simpleLogger.log.se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.BaseForExecOpParallelBindJoin=warn
+#
+###############################################################################
+
+
+###############################################################################
+# Output formatting
+###############################################################################
+
+# Prefix each log message with the current time.
+org.slf4j.simpleLogger.showDateTime=true
+
+# Time format.
+org.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss.SSS
+
+# Include the thread name.
+# Example: [ForkJoinPool.commonPool-worker-3]
+org.slf4j.simpleLogger.showThreadName=false
+
+# Include the thread ID.
+org.slf4j.simpleLogger.showThreadId=false
+
+# Include the full logger (class) name.
+org.slf4j.simpleLogger.showLogName=false
+
+# Include only the simple class name.
+# If both showLogName and showShortLogName are false, no logger name is shown.
+org.slf4j.simpleLogger.showShortLogName=true
+
+# Show the log level in brackets.
+# Example:
+#   [INFO], [WARN], [ERROR], [DEBUG], [TRACE]
+org.slf4j.simpleLogger.levelInBrackets=true

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerWithMapDBCache.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerWithMapDBCache.java
@@ -214,11 +214,14 @@ public class FederationAccessManagerWithMapDBCache extends FederationAccessManag
 	 * @throws IllegalStateException     if the request/member combination is
 	 *                                   unsupported
 	 */
+	@Override
 	public < ReqType extends DataRetrievalRequest,
+	         RespType extends DataRetrievalResponse<?>,
 	         MemberType extends FederationMember >
-	CompletableFuture<CardinalityResponse> issueCardReq( final ReqType req,
-	                                                     final MemberType fm )
-			throws FederationAccessException
+	CompletableFuture<CardinalityResponse> issueCardinalityRequest(
+			final ReqType req,
+			final MemberType fm )
+					throws FederationAccessException
 	{
 		final PersistentCacheKey key;
 		try {
@@ -273,30 +276,6 @@ public class FederationAccessManagerWithMapDBCache extends FederationAccessManag
 		@SuppressWarnings("unchecked")
 		final CompletableFuture<CardinalityResponse> cachedResponse2 = (CompletableFuture<CardinalityResponse>) cachedResponse;
 		return cachedResponse2;
-	}
-
-	@Override
-	public CompletableFuture<CardinalityResponse> issueCardinalityRequest( final SPARQLRequest req,
-	                                                                       final SPARQLEndpoint fm )
-			throws FederationAccessException
-	{
-		return issueCardReq(req, fm);
-	}
-
-	@Override
-	public CompletableFuture<CardinalityResponse> issueCardinalityRequest( final TPFRequest req,
-	                                                                       final TPFServer fm )
-			throws FederationAccessException
-	{
-		return issueCardReq(req, fm);
-	}
-
-	@Override
-	public CompletableFuture<CardinalityResponse> issueCardinalityRequest( final TPFRequest req,
-	                                                                       final BRTPFServer fm )
-			throws FederationAccessException
-	{
-		return issueCardReq(req, fm);
 	}
 
 	@Override


### PR DESCRIPTION
This PR adds support for configuring class-specific logging levels when using the HeFQUIN CLI.