### PR TITLE
Extend so filters can be pushed under l2g and g2l operators

### DIFF
--- a/hefquin-base/pom.xml
+++ b/hefquin-base/pom.xml
@@ -60,5 +60,18 @@
         </includes>
       </resource>
     </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
   </build>
 </project>

--- a/hefquin-base/pom.xml
+++ b/hefquin-base/pom.xml
@@ -61,6 +61,7 @@
       </resource>
     </resources>
     <plugins>
+      <!-- Package test classes in a separate JAR for use by tests in other modules -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/VocabularyMapping.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/VocabularyMapping.java
@@ -24,7 +24,7 @@ public interface VocabularyMapping
 
 	/**
 	 * Applies this vocabulary mapping to the given filter expression, which is
-	 * assumed to use the global vocabulary, and returns the translated expression.
+	 * assumed to use the local vocabulary, and returns the translated expression.
 	 * If this mapping is not relevant for the given expression (i.e., applying
 	 * the mapping does not change the expression), then the result of this
 	 * function is simply the given expression itself.
@@ -34,6 +34,19 @@ public interface VocabularyMapping
 	 * throws an {@link UnsupportedOperationException}.
 	 */
 	Expr translateExpression( Expr e );
+
+	/**
+	 * Applies this vocabulary mapping to the given filter expression, which is
+	 * assumed to use the global vocabulary, and returns the translated expression.
+	 * If this mapping is not relevant for the given expression (i.e., applying
+	 * the mapping does not change the expression), then the result of this
+	 * function is simply the given expression itself.
+	 * <p>
+	 * It may not be possible to translate every expression; if the
+	 * given expression cannot be translated, then this method
+	 * throws an {@link UnsupportedOperationException}.
+	 */
+	Expr translateExpressionFromGlobal( Expr e );
 
 	/**
 	 * Applies this vocabulary mapping to the given solution mapping expressed

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/VocabularyMapping.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/VocabularyMapping.java
@@ -33,7 +33,7 @@ public interface VocabularyMapping
 	 * given expression cannot be translated, then this method
 	 * throws an {@link UnsupportedOperationException}.
 	 */
-	Expr translateExpression( Expr e );
+	Expr translateExpressionFromLocal( Expr e );
 
 	/**
 	 * Applies this vocabulary mapping to the given filter expression, which is

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/mappings/EntityMapping.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/mappings/EntityMapping.java
@@ -39,6 +39,20 @@ public interface EntityMapping
 	Expr applyToExpression( Expr e );
 
 	/**
+	 * Applies this entity mapping to the given filter expression, which is
+	 * assumed to use the local representation of the entities mentioned in
+	 * it, and returns the translated expression.
+	 * If this entity mapping is not relevant for the given expression (i.e.,
+	 * applying this entity mapping does not change the expression), then the
+	 * result of this function is simply the given expression itself.
+	 * <p>
+	 * It may not be possible to translate every expression; if the
+	 * given expression cannot be translated, then this method
+	 * throws an {@link UnsupportedOperationException}.
+	 */
+	Expr applyInverseToExpression( Expr e );
+
+	/**
 	 * Applies this entity mapping to the given solution mapping, which
 	 * is assumed to use the global representation of the entities that
 	 * it binds to its query variables. If this entity mapping is not

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/mappings/SchemaMapping.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/mappings/SchemaMapping.java
@@ -38,6 +38,20 @@ public interface SchemaMapping
 	Expr applyToExpression( Expr n );
 
 	/**
+	 * Applies this schema mapping to the given filter expression, which is
+	 * assumed to use the local schema for the vocabulary terms mentioned
+	 * in it, and returns the translated expression.
+	 * If this schema mapping is not relevant for the given expression (i.e.,
+	 * applying this schema mapping does not change the expression), then the
+	 * result of this function is simply the given expression itself.
+	 * <p>
+	 * It may not be possible to translate every expression; if the
+	 * given expression cannot be translated, then this method
+	 * throws an {@link UnsupportedOperationException}.
+	 */
+	Expr applyInverseToExpression( Expr n );
+
+	/**
 	 * Applies this schema mapping to the given solution mapping, which
 	 * is assumed to use the global schema for the vocabulary terms that
 	 * it binds to its query variables. If this schema mapping is not

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/mappings/VocabularyMappingUtils.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/mappings/VocabularyMappingUtils.java
@@ -205,7 +205,7 @@ public class VocabularyMappingUtils
 		final ExprList rewrittenExpressions = new ExprList();
 
 		for ( final Expr e : exprs ) {
-			final Expr rewritten = vm.translateExpression(e);
+			final Expr rewritten = vm.translateExpressionFromLocal(e);
 
 			rewrittenExpressions.add(rewritten);
 		}

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/mappings/VocabularyMappingUtils.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/mappings/VocabularyMappingUtils.java
@@ -211,4 +211,16 @@ public class VocabularyMappingUtils
 		}
 		return rewrittenExpressions;
 	}
+
+	public static ExprList translateExpressionsFromGlobal( final ExprList exprs,
+	                                                       final VocabularyMapping vm ) {
+		final ExprList rewrittenExpressions = new ExprList();
+
+		for ( final Expr e : exprs ) {
+			final Expr rewritten = vm.translateExpressionFromGlobal(e);
+
+			rewrittenExpressions.add(rewritten);
+		}
+		return rewrittenExpressions;
+	}
 }

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/mappings/VocabularyMappingUtils.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/mappings/VocabularyMappingUtils.java
@@ -196,7 +196,7 @@ public class VocabularyMappingUtils
 	                                                        final VocabularyMapping vm ) {
 		final Op subOp = op.getSubOp();
 		final SPARQLGraphPattern translatedSubPlan = translateGraphPattern(subOp, vm);
-		final ExprList translatedExprs = translateExpressions( op.getExprs(), vm );
+		final ExprList translatedExprs = translateExpressionsFromGlobal( op.getExprs(), vm );
 		return translatedSubPlan.mergeWith(translatedExprs);
 	}
 

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/mappings/impl/EntityMappingImpl.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/mappings/impl/EntityMappingImpl.java
@@ -129,9 +129,19 @@ public class EntityMappingImpl implements EntityMapping
 
 	@Override
 	public Expr applyToExpression( final Expr expr ) {
+		return applyToExpression(expr, false);
+	}
+
+	@Override
+	public Expr applyInverseToExpression( final Expr expr ) {
+		return applyToExpression(expr, true);
+	}
+
+	protected Expr applyToExpression( final Expr expr,
+	                                  final boolean useInverse ) {
 		if ( expr instanceof E_LogicalAnd and ) {
-			final Expr l = applyToExpression( and.getArg1() );
-			final Expr r = applyToExpression( and.getArg2() );
+			final Expr l = applyToExpression( and.getArg1(), useInverse ) ;
+			final Expr r = applyToExpression( and.getArg2(), useInverse ) ;
 
 			if ( and.getArg1().equals(l) && and.getArg2().equals(r) )
 				return expr;
@@ -140,8 +150,8 @@ public class EntityMappingImpl implements EntityMapping
 		}
 
 		if ( expr instanceof E_LogicalOr or ) {
-			final Expr l = applyToExpression( or.getArg1()) ;
-			final Expr r = applyToExpression( or.getArg2()) ;
+			final Expr l = applyToExpression( or.getArg1(), useInverse );
+			final Expr r = applyToExpression( or.getArg2(), useInverse );
 
 			if ( or.getArg1().equals(l) && or.getArg2().equals(r) )
 				return expr;
@@ -150,7 +160,7 @@ public class EntityMappingImpl implements EntityMapping
 		}
 
 		if ( expr instanceof E_Equals || expr instanceof E_NotEquals ) {
-			return rewriteComparison( expr );
+			return rewriteComparison( expr, useInverse );
 		}
 
 		// other rexpression types aren't considered rewritable at the moment
@@ -232,7 +242,8 @@ public class EntityMappingImpl implements EntityMapping
 		return result;
 	}
 
-	protected Expr rewriteComparison( final Expr expr ) {
+	protected Expr rewriteComparison( final Expr expr,
+	                                  final boolean useInverse ) {
 		final Expr left;
 		final Expr right;
 		final boolean equals;
@@ -250,8 +261,8 @@ public class EntityMappingImpl implements EntityMapping
 		else
 			throw new UnsupportedOperationException( "Filter expression " + expr + " cannot be rewritten" );
 
-		final List<Expr> leftExprs = expandExpression(left);
-		final List<Expr> rightExprs = expandExpression(right);
+		final List<Expr> leftExprs = expandExpression(left, useInverse);
+		final List<Expr> rightExprs = expandExpression(right, useInverse);
 
 		final List<Expr> rewritten = new ArrayList<>();
 
@@ -280,7 +291,8 @@ public class EntityMappingImpl implements EntityMapping
 	 * @param e the expression to expand
 	 * @return the translated expressions
 	 */
-	protected List<Expr> expandExpression( final Expr e ) {
+	protected List<Expr> expandExpression( final Expr e,
+	                                       final boolean useInverse ) {
 		if ( e.isConstant() ) {
 			final Node n = e.getConstant().asNode();
 
@@ -288,7 +300,7 @@ public class EntityMappingImpl implements EntityMapping
 				return List.of(e);
 
 			final List<Expr> exprs = new ArrayList<>();
-			final Set<Node> mappings = g2lMap.get(n);
+			final Set<Node> mappings = useInverse ? l2gMap.get(n) : g2lMap.get(n);
 
 			if ( mappings == null || mappings.isEmpty() )
 				exprs.add(e);
@@ -300,7 +312,8 @@ public class EntityMappingImpl implements EntityMapping
 		}
 
 		for ( final Node uri : ExprUtils.collectURIs(e) ) {
-			if ( g2lMap.containsKey(uri) ) {
+			final boolean isMapped = useInverse ? l2gMap.containsKey(uri) : g2lMap.containsKey(uri);
+			if ( isMapped ) {
 				throw new UnsupportedOperationException(
 					"Filter expression " + e + " cannot be rewritten"
 				);

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/mappings/impl/SchemaMappingImpl.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/mappings/impl/SchemaMappingImpl.java
@@ -165,9 +165,19 @@ public class SchemaMappingImpl implements SchemaMapping
 
 	@Override
 	public Expr applyToExpression( final Expr expr ) {
+		return applyToExpression(expr, false);
+	}
+
+	@Override
+	public Expr applyInverseToExpression( final Expr expr ) {
+		return applyToExpression(expr, true);
+	}
+
+	protected Expr applyToExpression( final Expr expr,
+	                                  final boolean useInverse ) {
 		if ( expr instanceof E_LogicalAnd and ) {
-			final Expr l = applyToExpression( and.getArg1() );
-			final Expr r = applyToExpression( and.getArg2() );
+			final Expr l = applyToExpression( and.getArg1(), useInverse );
+			final Expr r = applyToExpression( and.getArg2(), useInverse );
 
 			if ( and.getArg1().equals(l) && and.getArg2().equals(r) )
 				return expr;
@@ -176,8 +186,8 @@ public class SchemaMappingImpl implements SchemaMapping
 		}
 
 		if ( expr instanceof E_LogicalOr or ) {
-			final Expr l = applyToExpression( or.getArg1()) ;
-			final Expr r = applyToExpression( or.getArg2()) ;
+			final Expr l = applyToExpression( or.getArg1(), useInverse );
+			final Expr r = applyToExpression( or.getArg2(), useInverse );
 
 			if ( or.getArg1().equals(l) && or.getArg2().equals(r) )
 				return expr;
@@ -186,7 +196,7 @@ public class SchemaMappingImpl implements SchemaMapping
 		}
 
 		if ( expr instanceof E_Equals || expr instanceof E_NotEquals ) {
-			return rewriteComparison( expr );
+			return rewriteComparison( expr, useInverse );
 		}
 
 		// other rexpression types aren't considered rewritable at the moment
@@ -273,7 +283,8 @@ public class SchemaMappingImpl implements SchemaMapping
 		return result;
 	}
 
-	protected Expr rewriteComparison( final Expr expr ) {
+	protected Expr rewriteComparison( final Expr expr,
+	                                  final boolean useInverse ) {
 		final Expr left;
 		final Expr right;
 		final boolean equals;
@@ -291,8 +302,8 @@ public class SchemaMappingImpl implements SchemaMapping
 		else
 			throw new UnsupportedOperationException( "Filter expression " + expr + " cannot be rewritten" );
 
-		final List<Expr> leftExprs = expandExpression(left);
-		final List<Expr> rightExprs = expandExpression(right);
+		final List<Expr> leftExprs = expandExpression(left, useInverse);
+		final List<Expr> rightExprs = expandExpression(right, useInverse);
 
 		final List<Expr> rewritten = new ArrayList<>();
 
@@ -321,23 +332,28 @@ public class SchemaMappingImpl implements SchemaMapping
 	 * @param e the expression to expand
 	 * @return the translated expressions
 	 */
-	public List<Expr> expandExpression( final Expr e ) {
+	public List<Expr> expandExpression( final Expr e,
+	                                    final boolean useInverse ) {
 		if ( e.isConstant() ) {
 			final Node n = e.getConstant().asNode();
 
 			if ( ! n.isURI() )
 				return List.of(e);
 
+			final Set<TermMapping> mappings = useInverse ? l2gMap.get(n) : g2lMap.get(n);
+
+			final Set<Node> translatedTerms = new HashSet<>();
+			if ( mappings != null && ! mappings.isEmpty() ) {
+				translatedTerms.addAll(useInverse ? extractGlobalTermsForLocalTerm(mappings) : extractLocalTermsForGlobalTerm(mappings));
+			}
+
+			if ( translatedTerms.isEmpty() )
+				return List.of(e);
+
 			final List<Expr> exprs = new ArrayList<>();
-			final Set<TermMapping> mappings = g2lMap.get(n);
 
-			if ( mappings != null && ! mappings.isEmpty() )
-				for ( final TermMapping tm : mappings )
-					for ( final Node localTerm :  tm.getLocalTerms() )
-						exprs.add(NodeValue.makeNode(localTerm));
-
-			if ( exprs.isEmpty() )
-				exprs.add(e);
+			for ( final Node term : translatedTerms )
+				exprs.add(NodeValue.makeNode(term));
 
 			return exprs;
 		}

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/mappings/impl/VocabularyMappingWrappingImpl.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/mappings/impl/VocabularyMappingWrappingImpl.java
@@ -100,7 +100,7 @@ public class VocabularyMappingWrappingImpl implements VocabularyMapping
 	}
 
 	@Override
-	public Expr translateExpression( final Expr e ) {
+	public Expr translateExpressionFromLocal( final Expr e ) {
 		final Expr translatedExpr = em.applyInverseToExpression(e);
 
 		return sm.applyInverseToExpression(translatedExpr);

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/mappings/impl/VocabularyMappingWrappingImpl.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/data/mappings/impl/VocabularyMappingWrappingImpl.java
@@ -101,6 +101,13 @@ public class VocabularyMappingWrappingImpl implements VocabularyMapping
 
 	@Override
 	public Expr translateExpression( final Expr e ) {
+		final Expr translatedExpr = em.applyInverseToExpression(e);
+
+		return sm.applyInverseToExpression(translatedExpr);
+	}
+
+	@Override
+	public Expr translateExpressionFromGlobal( final Expr e ) {
 		final Expr translatedExpr = em.applyToExpression(e);
 
 		return sm.applyToExpression(translatedExpr);

--- a/hefquin-base/src/test/java/se/liu/ida/hefquin/base/data/mappings/VocabularyMappingUtilsTest.java
+++ b/hefquin-base/src/test/java/se/liu/ida/hefquin/base/data/mappings/VocabularyMappingUtilsTest.java
@@ -507,7 +507,7 @@ public class VocabularyMappingUtilsTest
 			);
 
 		// Test & check
-		assertThrows( UnsupportedOperationException.class, () -> vm.translateExpression(expr) );
+		assertThrows( UnsupportedOperationException.class, () -> vm.translateExpressionFromLocal(expr) );
 	}
 
 	@Test

--- a/hefquin-base/src/test/java/se/liu/ida/hefquin/base/data/mappings/VocabularyMappingUtilsTest.java
+++ b/hefquin-base/src/test/java/se/liu/ida/hefquin/base/data/mappings/VocabularyMappingUtilsTest.java
@@ -6,13 +6,9 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.*;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.graph.Triple;
-import org.apache.jena.riot.Lang;
-import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.sparql.algebra.op.OpBGP;
 import org.apache.jena.sparql.core.BasicPattern;
 import org.apache.jena.sparql.expr.E_Equals;
@@ -25,17 +21,11 @@ import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.ExprList;
 import org.apache.jena.sparql.expr.ExprVar;
 import org.apache.jena.sparql.expr.NodeValue;
-import org.apache.jena.sparql.graph.GraphFactory;
 import org.apache.jena.sparql.syntax.ElementTriplesBlock;
 import org.junit.Before;
 import org.junit.Test;
 
 import se.liu.ida.hefquin.base.data.VocabularyMapping;
-import se.liu.ida.hefquin.base.data.mappings.impl.EntityMappingImpl;
-import se.liu.ida.hefquin.base.data.mappings.impl.EntityMappingReader;
-import se.liu.ida.hefquin.base.data.mappings.impl.SchemaMappingImpl;
-import se.liu.ida.hefquin.base.data.mappings.impl.SchemaMappingReader;
-import se.liu.ida.hefquin.base.data.mappings.impl.VocabularyMappingWrappingImpl;
 import se.liu.ida.hefquin.base.query.BGP;
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
 import se.liu.ida.hefquin.base.query.SPARQLGroupPattern;
@@ -47,6 +37,7 @@ import se.liu.ida.hefquin.base.query.impl.GenericSPARQLGraphPatternImpl2;
 import se.liu.ida.hefquin.base.query.impl.SPARQLGroupPatternImpl;
 import se.liu.ida.hefquin.base.query.impl.SPARQLUnionPatternImpl;
 import se.liu.ida.hefquin.base.query.impl.TriplePatternImpl;
+import se.liu.ida.hefquin.testutils.TestUtils;
 
 public class VocabularyMappingUtilsTest
 {
@@ -76,28 +67,7 @@ public class VocabularyMappingUtilsTest
 
 	@Before
 	public void setup() {
-		final String entityMapping = """
-			@prefix owl:  <http://www.w3.org/2002/07/owl#> .
-			@prefix l:    <http://example.org/local/> .
-			@prefix g:    <http://example.org/global/> .
-			l:e1 owl:sameAs g:e .
-			l:e2 owl:sameAs g:e .
-			""";
-
-		final String schemaMapping = """
-			@prefix owl:  <http://www.w3.org/2002/07/owl#> .
-			@prefix l:    <http://example.org/local/> .
-			@prefix g:    <http://example.org/global/> .
-			l:s1 owl:equivalentClass g:s .
-			l:s2 owl:equivalentClass g:s .
-			l:p1 owl:equivalentProperty g:p .
-			l:p2 owl:equivalentProperty g:p .
-			l:o1 owl:equivalentClass g:o .
-			l:o2 owl:equivalentClass g:o .
-			""";
-		final SchemaMapping sm = createSchemaMapping(schemaMapping);
-		final EntityMapping em = createEntityMapping(entityMapping);
-		vm = new VocabularyMappingWrappingImpl(em, sm);
+		vm = TestUtils.createVocabularyMapping();
 	}
 
 	// TriplePattern
@@ -515,7 +485,7 @@ public class VocabularyMappingUtilsTest
 		final ExprList result = VocabularyMappingUtils.translateExpressionsFromGlobal(exprList, vm);
 
 		// Check
-		final Set<String> actual = extractEqualsPairs(result.get(0));
+		final Set<String> actual = TestUtils.extractEqualsPairs(result.get(0));
 
 		// Order doesn't matter here
 		assertEquals( Set.of(
@@ -605,34 +575,5 @@ public class VocabularyMappingUtilsTest
 	                                         final Set<TriplePattern> expected ) {
 		final Set<TriplePattern> results = translateAndCollect(input);
 		assertEquals(expected, results);
-	}
-
-	protected SchemaMapping createSchemaMapping( final String mappingAsTurtle ) {
-		final Graph mapping = GraphFactory.createDefaultGraph();
-		RDFDataMgr.read( mapping, IOUtils.toInputStream(mappingAsTurtle, "UTF-8"), Lang.TURTLE );
-
-		final Map<Node, Set<TermMapping>> g2lMap = SchemaMappingReader.read(mapping);
-		return new SchemaMappingImpl(g2lMap);
-	}
-
-	protected EntityMapping createEntityMapping( final String mappingAsTurtle ) {
-		final Graph mapping = GraphFactory.createDefaultGraph();
-		RDFDataMgr.read( mapping, IOUtils.toInputStream(mappingAsTurtle, "UTF-8"), Lang.TURTLE );
-		final Map<Node, Set<Node>> g2lMap = EntityMappingReader.read(mapping);
-		return new EntityMappingImpl(g2lMap);
-	}
-
-	protected Set<String> extractEqualsPairs( final Expr e ) {
-		final Set<String> result = new HashSet<>();
-
-		if ( e instanceof E_Equals eq ) {
-			result.add( eq.getArg1().toString() + "=" + eq.getArg2().toString() );
-		}
-		else if ( e instanceof E_LogicalOr or ) {
-			result.addAll( extractEqualsPairs(or.getArg1()) );
-			result.addAll( extractEqualsPairs(or.getArg2()) );
-		}
-
-		return result;
 	}
 }

--- a/hefquin-base/src/test/java/se/liu/ida/hefquin/base/data/mappings/VocabularyMappingUtilsTest.java
+++ b/hefquin-base/src/test/java/se/liu/ida/hefquin/base/data/mappings/VocabularyMappingUtilsTest.java
@@ -377,7 +377,7 @@ public class VocabularyMappingUtilsTest
 		final ExprList exprList = new ExprList(expr);
 
 		// Test
-		final ExprList result = VocabularyMappingUtils.translateExpressions(exprList, vm);
+		final ExprList result = VocabularyMappingUtils.translateExpressionsFromGlobal(exprList, vm);
 
 		// Check
 		assertTrue( result.get(0) instanceof E_LogicalOr );
@@ -418,7 +418,7 @@ public class VocabularyMappingUtilsTest
 		final ExprList exprList = new ExprList( new E_LogicalOr(expr, expr1) );
 
 		// Test
-		final ExprList result = VocabularyMappingUtils.translateExpressions(exprList, vm);
+		final ExprList result = VocabularyMappingUtils.translateExpressionsFromGlobal(exprList, vm);
 
 		// Check
 		assertTrue( result.get(0) instanceof E_LogicalOr );
@@ -470,7 +470,7 @@ public class VocabularyMappingUtilsTest
 		final ExprList exprList = new ExprList(notAllowedExpr);
 
 		// Test & Check
-		assertThrows( UnsupportedOperationException.class, () -> VocabularyMappingUtils.translateExpressions(exprList, vm) );
+		assertThrows( UnsupportedOperationException.class, () -> VocabularyMappingUtils.translateExpressionsFromGlobal(exprList, vm) );
 	}
 
 	@Test
@@ -494,7 +494,7 @@ public class VocabularyMappingUtilsTest
 		final ExprList exprList = new ExprList( new E_LogicalOr(expr, notAllowedExpr) );
 
 		// Test & check
-		assertThrows( UnsupportedOperationException.class, () -> VocabularyMappingUtils.translateExpressions(exprList, vm) );
+		assertThrows( UnsupportedOperationException.class, () -> VocabularyMappingUtils.translateExpressionsFromGlobal(exprList, vm) );
 	}
 
 	@Test
@@ -512,7 +512,7 @@ public class VocabularyMappingUtilsTest
 		final ExprList exprList = new ExprList(expr);
 
 		// Test
-		final ExprList result = VocabularyMappingUtils.translateExpressions(exprList, vm);
+		final ExprList result = VocabularyMappingUtils.translateExpressionsFromGlobal(exprList, vm);
 
 		// Check
 		final Set<String> actual = extractEqualsPairs(result.get(0));
@@ -538,6 +538,37 @@ public class VocabularyMappingUtilsTest
 
 		// Test & check
 		assertThrows( UnsupportedOperationException.class, () -> vm.translateExpression(expr) );
+	}
+
+	@Test
+	public void translate_filter_expression_l2g() {
+		// A filter expression containing a local term is rewritten to use the
+		// corresponding global term.
+
+		// Set up
+		final Node x = NodeFactory.createVariable("x");
+
+		final Expr expr =
+			new E_Equals(
+				new ExprVar(x),
+				NodeValue.makeNode(e_l1)
+			);
+
+		final ExprList exprList = new ExprList(expr);
+
+		// Test
+		final ExprList result = VocabularyMappingUtils.translateExpressions(exprList, vm);
+
+		// Check
+		assertTrue( result.get(0) instanceof E_Equals );
+
+		final E_Equals equals = (E_Equals) result.get(0);
+
+		final Node node =
+			( (NodeValue) equals.getArg2() ).asNode();
+
+		assertEquals( Set.of(e_g),
+					  Set.of(node) );
 	}
 
 	// -------------- helpers --------------

--- a/hefquin-base/src/test/java/se/liu/ida/hefquin/testutils/TestUtils.java
+++ b/hefquin-base/src/test/java/se/liu/ida/hefquin/testutils/TestUtils.java
@@ -1,0 +1,82 @@
+package se.liu.ida.hefquin.testutils;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.jena.graph.Graph;
+import org.apache.jena.graph.Node;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.apache.jena.sparql.expr.E_Equals;
+import org.apache.jena.sparql.expr.E_LogicalOr;
+import org.apache.jena.sparql.expr.Expr;
+import org.apache.jena.sparql.graph.GraphFactory;
+
+import se.liu.ida.hefquin.base.data.mappings.EntityMapping;
+import se.liu.ida.hefquin.base.data.mappings.SchemaMapping;
+import se.liu.ida.hefquin.base.data.mappings.TermMapping;
+import se.liu.ida.hefquin.base.data.mappings.impl.EntityMappingImpl;
+import se.liu.ida.hefquin.base.data.mappings.impl.EntityMappingReader;
+import se.liu.ida.hefquin.base.data.mappings.impl.SchemaMappingImpl;
+import se.liu.ida.hefquin.base.data.mappings.impl.SchemaMappingReader;
+import se.liu.ida.hefquin.base.data.mappings.impl.VocabularyMappingWrappingImpl;
+
+public class TestUtils
+{
+	public static VocabularyMappingWrappingImpl createVocabularyMapping() {
+		final String entityMapping = """
+			@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+			@prefix l:    <http://example.org/local/> .
+			@prefix g:    <http://example.org/global/> .
+			l:e1 owl:sameAs g:e .
+			l:e2 owl:sameAs g:e .
+			""";
+
+		final String schemaMapping = """
+			@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+			@prefix l:    <http://example.org/local/> .
+			@prefix g:    <http://example.org/global/> .
+			l:s1 owl:equivalentClass g:s .
+			l:s2 owl:equivalentClass g:s .
+			l:p1 owl:equivalentProperty g:p .
+			l:p2 owl:equivalentProperty g:p .
+			l:o1 owl:equivalentClass g:o .
+			l:o2 owl:equivalentClass g:o .
+			""";
+
+		final SchemaMapping sm = createSchemaMapping(schemaMapping);
+		final EntityMapping em = createEntityMapping(entityMapping);
+		return new VocabularyMappingWrappingImpl(em, sm);
+	}
+
+	protected static SchemaMapping createSchemaMapping( final String mappingAsTurtle ) {
+		final Graph mapping = GraphFactory.createDefaultGraph();
+		RDFDataMgr.read( mapping, IOUtils.toInputStream(mappingAsTurtle, "UTF-8"), Lang.TURTLE );
+
+		final Map<Node, Set<TermMapping>> g2lMap = SchemaMappingReader.read(mapping);
+		return new SchemaMappingImpl(g2lMap);
+	}
+
+	protected static EntityMapping createEntityMapping( final String mappingAsTurtle ) {
+		final Graph mapping = GraphFactory.createDefaultGraph();
+		RDFDataMgr.read( mapping, IOUtils.toInputStream(mappingAsTurtle, "UTF-8"), Lang.TURTLE );
+		final Map<Node, Set<Node>> g2lMap = EntityMappingReader.read(mapping);
+		return new EntityMappingImpl(g2lMap);
+	}
+
+	public static Set<String> extractEqualsPairs( final Expr e ) {
+		final Set<String> result = new HashSet<>();
+
+		if ( e instanceof E_Equals eq ) {
+			result.add( eq.getArg1().toString() + "=" + eq.getArg2().toString() );
+		}
+		else if ( e instanceof E_LogicalOr or ) {
+			result.addAll( extractEqualsPairs(or.getArg1()) );
+			result.addAll( extractEqualsPairs(or.getArg2()) );
+		}
+
+		return result;
+	}
+}

--- a/hefquin-engine/pom.xml
+++ b/hefquin-engine/pom.xml
@@ -47,7 +47,7 @@
       <artifactId>hefquin-base</artifactId>
       <version>0.0.12-SNAPSHOT</version>
     </dependency>
-    <!-- hefquin-base-test-jar -->
+    <!-- hefquin-base (test-jar) -->
     <dependency>
       <groupId>se.liu.research.hefquin</groupId>
       <artifactId>hefquin-base</artifactId>

--- a/hefquin-engine/pom.xml
+++ b/hefquin-engine/pom.xml
@@ -47,6 +47,14 @@
       <artifactId>hefquin-base</artifactId>
       <version>0.0.12-SNAPSHOT</version>
     </dependency>
+    <!-- hefquin-base-test-jar -->
+    <dependency>
+      <groupId>se.liu.research.hefquin</groupId>
+      <artifactId>hefquin-base</artifactId>
+      <version>0.0.12-SNAPSHOT</version>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
     <!-- hefquin-vocabs -->
     <dependency>
       <groupId>se.liu.research.hefquin</groupId>

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDown.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDown.java
@@ -11,6 +11,8 @@ import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.ExprList;
 import org.apache.jena.sparql.expr.ExprVars;
 
+import se.liu.ida.hefquin.base.data.VocabularyMapping;
+import se.liu.ida.hefquin.base.data.mappings.VocabularyMappingUtils;
 import se.liu.ida.hefquin.base.data.utils.SolutionMappingUtils;
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
@@ -209,7 +211,8 @@ public class FilterPushDown implements HeuristicForLogicalOptimization
 			createdPlan = createPlanForL2GOrG2LUnderFilter( filterOp,
 			                                                op,
 			                                                subPlanUnderFilter.getSubPlan(0),
-			                                                inputPlan );
+			                                                inputPlan,
+			                                                op.getVocabularyMapping() );
 		}
 
 		@Override
@@ -217,7 +220,8 @@ public class FilterPushDown implements HeuristicForLogicalOptimization
 			createdPlan = createPlanForL2GOrG2LUnderFilter( filterOp,
 			                                                op,
 			                                                subPlanUnderFilter.getSubPlan(0),
-			                                                inputPlan );
+			                                                inputPlan,
+			                                                op.getVocabularyMapping() );
 		}
 
 		@Override
@@ -364,21 +368,23 @@ public class FilterPushDown implements HeuristicForLogicalOptimization
 	 * or a {@link LogicalOpGlobalToLocal}.
 	 */
 	protected LogicalPlan createPlanForL2GOrG2LUnderFilter( final LogicalOpFilter parentFilterOp,
-	                                                        final UnaryLogicalOp childOp,
+	                                                        final UnaryLogicalOp mappingOp,
 	                                                        final LogicalPlan subPlanUnderChildOp,
-	                                                        final LogicalPlan inputPlan ) {
-		// The current implementation does not try to push filter
-		// conditions under the vocabulary rewriting operators,
-		// LogicalOpLocalToGlobal and LogicalOpGlobalToLocal.
-		// Extending the implementation to try to push filter
-		// conditions in these cases is captured as issue #271.
-		//
-		// https://github.com/LiUSemWeb/HeFQUIN/issues/271
-		//
-		// However, for the time being, we only apply the filter
-		// push-down heuristic to the subplan that is under the
-		// given vocabulary rewriting operator.
-		return createPlanAfterPushingInSubPlan(parentFilterOp, childOp, subPlanUnderChildOp, inputPlan);
+	                                                        final LogicalPlan inputPlan,
+	                                                        final VocabularyMapping vm ) {
+		final ExprList exprs;
+		try {
+			if ( mappingOp instanceof LogicalOpLocalToGlobal )
+				exprs = VocabularyMappingUtils.translateExpressions(parentFilterOp.getFilterExpressions(), vm);
+			else
+				exprs = VocabularyMappingUtils.translateExpressionsFromGlobal(parentFilterOp.getFilterExpressions(), vm);
+		}
+		catch ( final UnsupportedOperationException e ) {
+			return createPlanAfterPushingInSubPlan(parentFilterOp, mappingOp, subPlanUnderChildOp, inputPlan);
+		}
+		final LogicalOpFilter translatedFilter = new LogicalOpFilter(exprs, parentFilterOp.mayReduce());
+		final LogicalPlan rewrittenPlan = new LogicalPlanWithUnaryRootImpl(translatedFilter, null, subPlanUnderChildOp);
+		return new LogicalPlanWithUnaryRootImpl(mappingOp, null, apply(rewrittenPlan));
 	}
 
 	/**

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/physical/TestUtils.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/physical/TestUtils.java
@@ -42,8 +42,13 @@ public class TestUtils
 			}
 
 			@Override
-			public Expr translateExpression(Expr e) {
+			public Expr translateExpression( Expr e ) {
 				throw new UnsupportedOperationException("Unimplemented method 'translateExpression'");
+			}
+
+			@Override
+			public Expr translateExpressionFromGlobal( Expr e ) {
+				throw new UnsupportedOperationException("Unimplemented method 'translateExpressionFromGlobal'");
 			}
 
 			@Override

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/physical/TestUtils.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/physical/TestUtils.java
@@ -42,7 +42,7 @@ public class TestUtils
 			}
 
 			@Override
-			public Expr translateExpression( Expr e ) {
+			public Expr translateExpressionFromLocal( Expr e ) {
 				throw new UnsupportedOperationException("Unimplemented method 'translateExpression'");
 			}
 

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDownTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDownTest.java
@@ -5,10 +5,17 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
+import org.apache.commons.io.IOUtils;
+import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.core.VarExprList;
 import org.apache.jena.sparql.expr.E_Bound;
@@ -16,6 +23,7 @@ import org.apache.jena.sparql.expr.E_Equals;
 import org.apache.jena.sparql.expr.E_IsBlank;
 import org.apache.jena.sparql.expr.E_IsIRI;
 import org.apache.jena.sparql.expr.E_LogicalNot;
+import org.apache.jena.sparql.expr.E_LogicalOr;
 import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.ExprList;
 import org.apache.jena.sparql.expr.ExprVar;
@@ -28,6 +36,14 @@ import org.apache.jena.sparql.syntax.ElementTriplesBlock;
 import org.junit.Test;
 
 import se.liu.ida.hefquin.base.data.SolutionMapping;
+import se.liu.ida.hefquin.base.data.mappings.EntityMapping;
+import se.liu.ida.hefquin.base.data.mappings.SchemaMapping;
+import se.liu.ida.hefquin.base.data.mappings.TermMapping;
+import se.liu.ida.hefquin.base.data.mappings.impl.EntityMappingImpl;
+import se.liu.ida.hefquin.base.data.mappings.impl.EntityMappingReader;
+import se.liu.ida.hefquin.base.data.mappings.impl.SchemaMappingImpl;
+import se.liu.ida.hefquin.base.data.mappings.impl.SchemaMappingReader;
+import se.liu.ida.hefquin.base.data.mappings.impl.VocabularyMappingWrappingImpl;
 import se.liu.ida.hefquin.base.data.utils.SolutionMappingUtils;
 import se.liu.ida.hefquin.base.query.TriplePattern;
 import se.liu.ida.hefquin.base.query.impl.TriplePatternImpl;
@@ -42,7 +58,9 @@ import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFilter;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPAdd;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFixedSolMap;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGPOptAdd;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpGlobalToLocal;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpLocalToGlobal;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMinus;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayUnion;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
@@ -505,6 +523,113 @@ public class FilterPushDownTest extends EngineTestBase
 	}
 
 	@Test
+	public void pushFilterUnderL2G() {
+		// a filter on top of a minus of two triple pattern requests,
+		// where the filter is expected to push into the first request
+		// but not the second
+
+		// set up
+		final Var v1 = Var.alloc("x");
+		final FederationMember fmA = new SPARQLEndpointForTest("http://exA.org");
+
+		final TriplePattern tp1 = new TriplePatternImpl(v1, v1, v1);
+		final LogicalOpRequest<?,?> reqOp = new LogicalOpRequest<>( fmA, false, new SPARQLRequestImpl(tp1) );
+
+		final Node e_l1 = NodeFactory.createURI("http://example.org/local/e1");
+		final Node x = NodeFactory.createVariable("x");
+
+		final VocabularyMappingWrappingImpl vm = createVocabularyMapping();
+		final LogicalOpLocalToGlobal l2gOp = new LogicalOpLocalToGlobal(vm, false);
+
+		final LogicalPlan l2gSubPlan = new LogicalPlanWithUnaryRootImpl(l2gOp, null, new LogicalPlanWithNullaryRootImpl(reqOp, null));
+
+		final Expr e =
+			new E_Equals(
+				new ExprVar(x),
+				NodeValue.makeNode(e_l1)
+			);
+		final UnaryLogicalOp rootOp = new LogicalOpFilter(e, false);
+		final LogicalPlan filterPlan = new LogicalPlanWithUnaryRootImpl(rootOp, null, l2gSubPlan);
+
+		// test
+		final LogicalPlan result = new FilterPushDown().apply(filterPlan);
+
+		// check
+		assertTrue( result.getRootOperator() instanceof LogicalOpLocalToGlobal );
+
+		final LogicalPlan subResult = result.getSubPlan(0);
+		assertTrue( subResult.getRootOperator() instanceof LogicalOpRequest<?,?> );
+
+		final LogicalOpRequest<?,?> resultReqOp = (LogicalOpRequest<?,?>) subResult.getRootOperator();
+		assertTrue( resultReqOp.getFederationMember() == fmA );
+
+		final SPARQLRequest resultReq = (SPARQLRequest) resultReqOp.getRequest();
+		final Element resultElmt1 = QueryPatternUtils.convertToJenaElement( resultReq.getQueryPattern() );
+		assertTrue(                                        resultElmt1 instanceof ElementGroup );
+		assertTrue(                        ((ElementGroup) resultElmt1).get(0) instanceof ElementTriplesBlock );
+		assertTrue( ((ElementTriplesBlock) ((ElementGroup) resultElmt1).get(0)).getPattern().get(0).equals(tp1.asJenaTriple()) );
+		assertTrue(                        ((ElementGroup) resultElmt1).get(1) instanceof ElementFilter );
+
+		final Set<String> actual = extractEqualsPairs( ((ElementFilter) ((ElementGroup) resultElmt1).get(1)).getExpr() );
+		assertEquals( Set.of(x + "=<http://example.org/global/e>"), actual );
+	}
+
+	@Test
+	public void pushFilterUnderG2L() {
+		// a filter on top of a minus of two triple pattern requests,
+		// where the filter is expected to push into the first request
+		// but not the second
+
+		// set up
+		final Var v1 = Var.alloc("x");
+		final FederationMember fmA = new SPARQLEndpointForTest("http://exA.org");
+
+		final TriplePattern tp1 = new TriplePatternImpl(v1, v1, v1);
+		final LogicalOpRequest<?,?> reqOp = new LogicalOpRequest<>( fmA, false, new SPARQLRequestImpl(tp1) );
+
+		final Node e_g  = NodeFactory.createURI("http://example.org/global/e");
+		final Node x = NodeFactory.createVariable("x");
+
+		final VocabularyMappingWrappingImpl vm = createVocabularyMapping();
+		final LogicalOpGlobalToLocal g2lOp = new LogicalOpGlobalToLocal(vm, false);
+
+		final LogicalPlan g2lSubPlan = new LogicalPlanWithUnaryRootImpl(g2lOp, null, new LogicalPlanWithNullaryRootImpl(reqOp, null));
+
+		final Expr e =
+			new E_Equals(
+				new ExprVar(x),
+				NodeValue.makeNode(e_g)
+			);
+		final UnaryLogicalOp rootOp = new LogicalOpFilter(e, false);
+		final LogicalPlan filterPlan = new LogicalPlanWithUnaryRootImpl(rootOp, null, g2lSubPlan);
+
+		// test
+		final LogicalPlan result = new FilterPushDown().apply(filterPlan);
+
+		// check
+		assertTrue( result.getRootOperator() instanceof LogicalOpGlobalToLocal );
+
+		final LogicalPlan subResult = result.getSubPlan(0);
+		assertTrue( subResult.getRootOperator() instanceof LogicalOpRequest<?,?> );
+
+		final LogicalOpRequest<?,?> resultReqOp = (LogicalOpRequest<?,?>) subResult.getRootOperator();
+		assertTrue( resultReqOp.getFederationMember() == fmA );
+
+		final SPARQLRequest resultReq = (SPARQLRequest) resultReqOp.getRequest();
+		final Element resultElmt1 = QueryPatternUtils.convertToJenaElement( resultReq.getQueryPattern() );
+		assertTrue(                                        resultElmt1 instanceof ElementGroup );
+		assertTrue(                        ((ElementGroup) resultElmt1).get(0) instanceof ElementTriplesBlock );
+		assertTrue( ((ElementTriplesBlock) ((ElementGroup) resultElmt1).get(0)).getPattern().get(0).equals(tp1.asJenaTriple()) );
+		assertTrue(                        ((ElementGroup) resultElmt1).get(1) instanceof ElementFilter );
+
+		final Set<String> actual = extractEqualsPairs( ((ElementFilter) ((ElementGroup) resultElmt1).get(1)).getExpr() );
+		assertEquals( Set.of(
+			x + "=<http://example.org/local/e1>",
+			x + "=<http://example.org/local/e2>"
+		), actual );
+	}
+
+	@Test
 	public void pushFilterUnderMinus() {
 		// a filter on top of a minus of two triple pattern requests,
 		// where the filter is expected to push into the first request
@@ -820,5 +945,62 @@ public class FilterPushDownTest extends EngineTestBase
 		assertTrue( ((ElementTriplesBlock) ((ElementGroup) resultElmt1).get(0)).getPattern().get(0).equals(tp1.asJenaTriple()) );
 		assertTrue(                        ((ElementGroup) resultElmt1).get(1) instanceof ElementFilter );
 		assertTrue(       ((ElementFilter) ((ElementGroup) resultElmt1).get(1)).getExpr().equals(e1) );
+	}
+
+	// -------------- helpers --------------
+
+	protected VocabularyMappingWrappingImpl createVocabularyMapping() {
+		final String entityMapping = """
+			@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+			@prefix l:    <http://example.org/local/> .
+			@prefix g:    <http://example.org/global/> .
+			l:e1 owl:sameAs g:e .
+			l:e2 owl:sameAs g:e .
+			""";
+
+		final String schemaMapping = """
+			@prefix owl:  <http://www.w3.org/2002/07/owl#> .
+			@prefix l:    <http://example.org/local/> .
+			@prefix g:    <http://example.org/global/> .
+			l:s1 owl:equivalentClass g:s .
+			l:s2 owl:equivalentClass g:s .
+			l:p1 owl:equivalentProperty g:p .
+			l:p2 owl:equivalentProperty g:p .
+			l:o1 owl:equivalentClass g:o .
+			l:o2 owl:equivalentClass g:o .
+			""";
+
+		final SchemaMapping sm = createSchemaMapping(schemaMapping);
+		final EntityMapping em = createEntityMapping(entityMapping);
+		return new VocabularyMappingWrappingImpl(em, sm);
+	}
+
+	protected SchemaMapping createSchemaMapping( final String mappingAsTurtle ) {
+		final Graph mapping = GraphFactory.createDefaultGraph();
+		RDFDataMgr.read( mapping, IOUtils.toInputStream(mappingAsTurtle, "UTF-8"), Lang.TURTLE );
+
+		final Map<Node, Set<TermMapping>> g2lMap = SchemaMappingReader.read(mapping);
+		return new SchemaMappingImpl(g2lMap);
+	}
+
+	protected EntityMapping createEntityMapping( final String mappingAsTurtle ) {
+		final Graph mapping = GraphFactory.createDefaultGraph();
+		RDFDataMgr.read( mapping, IOUtils.toInputStream(mappingAsTurtle, "UTF-8"), Lang.TURTLE );
+		final Map<Node, Set<Node>> g2lMap = EntityMappingReader.read(mapping);
+		return new EntityMappingImpl(g2lMap);
+	}
+
+	protected Set<String> extractEqualsPairs( final Expr e ) {
+		final Set<String> result = new HashSet<>();
+
+		if ( e instanceof E_Equals eq ) {
+			result.add( eq.getArg1().toString() + "=" + eq.getArg2().toString() );
+		}
+		else if ( e instanceof E_LogicalOr or ) {
+			result.addAll( extractEqualsPairs(or.getArg1()) );
+			result.addAll( extractEqualsPairs(or.getArg2()) );
+		}
+
+		return result;
 	}
 }

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDownTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDownTest.java
@@ -5,17 +5,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
-import org.apache.jena.riot.Lang;
-import org.apache.jena.riot.RDFDataMgr;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.core.VarExprList;
 import org.apache.jena.sparql.expr.E_Bound;
@@ -23,7 +17,6 @@ import org.apache.jena.sparql.expr.E_Equals;
 import org.apache.jena.sparql.expr.E_IsBlank;
 import org.apache.jena.sparql.expr.E_IsIRI;
 import org.apache.jena.sparql.expr.E_LogicalNot;
-import org.apache.jena.sparql.expr.E_LogicalOr;
 import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.ExprList;
 import org.apache.jena.sparql.expr.ExprVar;
@@ -36,13 +29,6 @@ import org.apache.jena.sparql.syntax.ElementTriplesBlock;
 import org.junit.Test;
 
 import se.liu.ida.hefquin.base.data.SolutionMapping;
-import se.liu.ida.hefquin.base.data.mappings.EntityMapping;
-import se.liu.ida.hefquin.base.data.mappings.SchemaMapping;
-import se.liu.ida.hefquin.base.data.mappings.TermMapping;
-import se.liu.ida.hefquin.base.data.mappings.impl.EntityMappingImpl;
-import se.liu.ida.hefquin.base.data.mappings.impl.EntityMappingReader;
-import se.liu.ida.hefquin.base.data.mappings.impl.SchemaMappingImpl;
-import se.liu.ida.hefquin.base.data.mappings.impl.SchemaMappingReader;
 import se.liu.ida.hefquin.base.data.mappings.impl.VocabularyMappingWrappingImpl;
 import se.liu.ida.hefquin.base.data.utils.SolutionMappingUtils;
 import se.liu.ida.hefquin.base.query.TriplePattern;
@@ -72,6 +58,7 @@ import se.liu.ida.hefquin.federation.access.SPARQLRequest;
 import se.liu.ida.hefquin.federation.access.TriplePatternRequest;
 import se.liu.ida.hefquin.federation.access.impl.req.SPARQLRequestImpl;
 import se.liu.ida.hefquin.federation.access.impl.req.TriplePatternRequestImpl;
+import se.liu.ida.hefquin.testutils.TestUtils;
 
 public class FilterPushDownTest extends EngineTestBase
 {
@@ -538,7 +525,7 @@ public class FilterPushDownTest extends EngineTestBase
 		final Node e_l1 = NodeFactory.createURI("http://example.org/local/e1");
 		final Node x = NodeFactory.createVariable("x");
 
-		final VocabularyMappingWrappingImpl vm = createVocabularyMapping();
+		final VocabularyMappingWrappingImpl vm = TestUtils.createVocabularyMapping();
 		final LogicalOpLocalToGlobal l2gOp = new LogicalOpLocalToGlobal(vm, false);
 
 		final LogicalPlan l2gSubPlan = new LogicalPlanWithUnaryRootImpl(l2gOp, null, new LogicalPlanWithNullaryRootImpl(reqOp, null));
@@ -570,7 +557,7 @@ public class FilterPushDownTest extends EngineTestBase
 		assertTrue( ((ElementTriplesBlock) ((ElementGroup) resultElmt1).get(0)).getPattern().get(0).equals(tp1.asJenaTriple()) );
 		assertTrue(                        ((ElementGroup) resultElmt1).get(1) instanceof ElementFilter );
 
-		final Set<String> actual = extractEqualsPairs( ((ElementFilter) ((ElementGroup) resultElmt1).get(1)).getExpr() );
+		final Set<String> actual = TestUtils.extractEqualsPairs( ((ElementFilter) ((ElementGroup) resultElmt1).get(1)).getExpr() );
 		assertEquals( Set.of(x + "=<http://example.org/global/e>"), actual );
 	}
 
@@ -587,7 +574,7 @@ public class FilterPushDownTest extends EngineTestBase
 		final LogicalOpRequest<?,?> reqOp = new LogicalOpRequest<>( fmA, false, new SPARQLRequestImpl(tp1) );
 
 
-		final VocabularyMappingWrappingImpl vm = createVocabularyMapping();
+		final VocabularyMappingWrappingImpl vm = TestUtils.createVocabularyMapping();
 		final LogicalOpLocalToGlobal l2gOp = new LogicalOpLocalToGlobal(vm, false);
 
 		final LogicalPlan l2gSubPlan = new LogicalPlanWithUnaryRootImpl(l2gOp, null, new LogicalPlanWithNullaryRootImpl(reqOp, null));
@@ -634,7 +621,7 @@ public class FilterPushDownTest extends EngineTestBase
 		final Node e_g  = NodeFactory.createURI("http://example.org/global/e");
 		final Node x = NodeFactory.createVariable("x");
 
-		final VocabularyMappingWrappingImpl vm = createVocabularyMapping();
+		final VocabularyMappingWrappingImpl vm = TestUtils.createVocabularyMapping();
 		final LogicalOpGlobalToLocal g2lOp = new LogicalOpGlobalToLocal(vm, false);
 
 		final LogicalPlan g2lSubPlan = new LogicalPlanWithUnaryRootImpl(g2lOp, null, new LogicalPlanWithNullaryRootImpl(reqOp, null));
@@ -666,7 +653,7 @@ public class FilterPushDownTest extends EngineTestBase
 		assertTrue( ((ElementTriplesBlock) ((ElementGroup) resultElmt1).get(0)).getPattern().get(0).equals(tp1.asJenaTriple()) );
 		assertTrue(                        ((ElementGroup) resultElmt1).get(1) instanceof ElementFilter );
 
-		final Set<String> actual = extractEqualsPairs( ((ElementFilter) ((ElementGroup) resultElmt1).get(1)).getExpr() );
+		final Set<String> actual = TestUtils.extractEqualsPairs( ((ElementFilter) ((ElementGroup) resultElmt1).get(1)).getExpr() );
 		assertEquals( Set.of(
 			x + "=<http://example.org/local/e1>",
 			x + "=<http://example.org/local/e2>"
@@ -989,62 +976,5 @@ public class FilterPushDownTest extends EngineTestBase
 		assertTrue( ((ElementTriplesBlock) ((ElementGroup) resultElmt1).get(0)).getPattern().get(0).equals(tp1.asJenaTriple()) );
 		assertTrue(                        ((ElementGroup) resultElmt1).get(1) instanceof ElementFilter );
 		assertTrue(       ((ElementFilter) ((ElementGroup) resultElmt1).get(1)).getExpr().equals(e1) );
-	}
-
-	// -------------- helpers --------------
-
-	protected VocabularyMappingWrappingImpl createVocabularyMapping() {
-		final String entityMapping = """
-			@prefix owl:  <http://www.w3.org/2002/07/owl#> .
-			@prefix l:    <http://example.org/local/> .
-			@prefix g:    <http://example.org/global/> .
-			l:e1 owl:sameAs g:e .
-			l:e2 owl:sameAs g:e .
-			""";
-
-		final String schemaMapping = """
-			@prefix owl:  <http://www.w3.org/2002/07/owl#> .
-			@prefix l:    <http://example.org/local/> .
-			@prefix g:    <http://example.org/global/> .
-			l:s1 owl:equivalentClass g:s .
-			l:s2 owl:equivalentClass g:s .
-			l:p1 owl:equivalentProperty g:p .
-			l:p2 owl:equivalentProperty g:p .
-			l:o1 owl:equivalentClass g:o .
-			l:o2 owl:equivalentClass g:o .
-			""";
-
-		final SchemaMapping sm = createSchemaMapping(schemaMapping);
-		final EntityMapping em = createEntityMapping(entityMapping);
-		return new VocabularyMappingWrappingImpl(em, sm);
-	}
-
-	protected SchemaMapping createSchemaMapping( final String mappingAsTurtle ) {
-		final Graph mapping = GraphFactory.createDefaultGraph();
-		RDFDataMgr.read( mapping, IOUtils.toInputStream(mappingAsTurtle, "UTF-8"), Lang.TURTLE );
-
-		final Map<Node, Set<TermMapping>> g2lMap = SchemaMappingReader.read(mapping);
-		return new SchemaMappingImpl(g2lMap);
-	}
-
-	protected EntityMapping createEntityMapping( final String mappingAsTurtle ) {
-		final Graph mapping = GraphFactory.createDefaultGraph();
-		RDFDataMgr.read( mapping, IOUtils.toInputStream(mappingAsTurtle, "UTF-8"), Lang.TURTLE );
-		final Map<Node, Set<Node>> g2lMap = EntityMappingReader.read(mapping);
-		return new EntityMappingImpl(g2lMap);
-	}
-
-	protected Set<String> extractEqualsPairs( final Expr e ) {
-		final Set<String> result = new HashSet<>();
-
-		if ( e instanceof E_Equals eq ) {
-			result.add( eq.getArg1().toString() + "=" + eq.getArg2().toString() );
-		}
-		else if ( e instanceof E_LogicalOr or ) {
-			result.addAll( extractEqualsPairs(or.getArg1()) );
-			result.addAll( extractEqualsPairs(or.getArg2()) );
-		}
-
-		return result;
 	}
 }

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDownTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDownTest.java
@@ -524,9 +524,9 @@ public class FilterPushDownTest extends EngineTestBase
 
 	@Test
 	public void pushFilterUnderL2G() {
-		// a filter on top of a minus of two triple pattern requests,
-		// where the filter is expected to push into the first request
-		// but not the second
+		// a filter above a LocalToGlobal operator is pushed below the operator,
+		// the filter expression is rewritten from the global vocabulary to the local
+		// vocabulary before being pushed into the request
 
 		// set up
 		final Var v1 = Var.alloc("x");
@@ -575,10 +575,54 @@ public class FilterPushDownTest extends EngineTestBase
 	}
 
 	@Test
+	public void pushNonRewritableFilterUnderL2G() {
+		// a non-rewritable filter above a GlobalToLocal operator is not
+		// pushed below the operator
+
+		// set up
+		final Var v1 = Var.alloc("x");
+		final FederationMember fmA = new SPARQLEndpointForTest("http://exA.org");
+
+		final TriplePattern tp1 = new TriplePatternImpl(v1, v1, v1);
+		final LogicalOpRequest<?,?> reqOp = new LogicalOpRequest<>( fmA, false, new SPARQLRequestImpl(tp1) );
+
+
+		final VocabularyMappingWrappingImpl vm = createVocabularyMapping();
+		final LogicalOpLocalToGlobal l2gOp = new LogicalOpLocalToGlobal(vm, false);
+
+		final LogicalPlan l2gSubPlan = new LogicalPlanWithUnaryRootImpl(l2gOp, null, new LogicalPlanWithNullaryRootImpl(reqOp, null));
+
+		final Expr e = new E_IsIRI( new ExprVar(v1) );
+		final UnaryLogicalOp rootOp = new LogicalOpFilter(e, false);
+		final LogicalPlan filterPlan = new LogicalPlanWithUnaryRootImpl(rootOp, null, l2gSubPlan);
+
+		// test
+		final LogicalPlan result = new FilterPushDown().apply(filterPlan);
+
+		// check
+		assertTrue( result.getRootOperator() instanceof LogicalOpFilter );
+
+		final LogicalPlan subResult = result.getSubPlan(0);
+		assertTrue( subResult.getRootOperator() instanceof LogicalOpLocalToGlobal );
+
+		final LogicalPlan subSubResult = subResult.getSubPlan(0);
+		assertTrue( subSubResult.getRootOperator() instanceof LogicalOpRequest );
+
+		final LogicalOpRequest<?,?> resultReqOp = (LogicalOpRequest<?,?>) subSubResult.getRootOperator();
+		assertTrue( resultReqOp.getFederationMember() == fmA );
+
+		// check that the request is unchanged
+		final SPARQLRequest resultReq = (SPARQLRequest) resultReqOp.getRequest();
+		final Element resultElmt1 = QueryPatternUtils.convertToJenaElement( resultReq.getQueryPattern() );
+		assertTrue( resultElmt1 instanceof ElementTriplesBlock );
+		assertEquals( tp1.asJenaTriple(), ((ElementTriplesBlock) resultElmt1).getPattern().get(0) );
+	}
+
+	@Test
 	public void pushFilterUnderG2L() {
-		// a filter on top of a minus of two triple pattern requests,
-		// where the filter is expected to push into the first request
-		// but not the second
+		// a filter above a GlobalToLocal operator is pushed below the operator,
+		// the filter expression is rewritten from the global vocabulary to the local
+		// vocabulary before being pushed into the request.
 
 		// set up
 		final Var v1 = Var.alloc("x");


### PR DESCRIPTION
This PR closes #271 by:
- expanding upon the work of #660 by adding `translateExpressions` and `translateExpressionsFromGlobal` (expressions can now be rewritten from local to global too).
- implementing `createPlanForL2GOrG2LUnderFilter` in `FilterPushDown`.

`createPlanForL2GOrG2LUnderFilter` now attempts to rewrite the filter expression to the vocabulary expected below the mapping operator. If rewrite succeeds, the translated filter is pushed below the l2g / g2l operator. If rewriting throws `UnsupportedOperationException`, the filter is left in its original position while the heuristic gets applied to its subplans.
 
I made this into a draft because there are a couple points I'd like some feedback on before making it a PR:
1. `FilterPushDownTest` and `VocabularyMappingUtilsTest` has some duplicate code at the moment, helper functions `createSchemaMapping`, `createEntityMapping` and `extractEqualsPairs` appear in both. Can they be moved into something like `TestUtils`?
2. In `VocabularyMappingUtils`, I added `translateExpressionsFromGlobal` but now  `translateGraphPattern( OpFilter, ... )` always calls `translateExpressions` (l2g). I assume it is desired that `translateGraphPattern` supports both directions depending on the vocabulary of the input graph pattern. Is there a preferred way to determine which translation direction should be used?