### PR TITLE
Support --outputToFile argument in RunQueryWithoutSrcSel and improves --help output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,12 @@ this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ## [unreleased]
 
 ### Added
-- Support configurable logging when using the HeFQUIN CLI ([#659](https://github.com/LiUSemWeb/HeFQUIN/pull/659)).
 - Support for MapDB-based persistent cache for federation requests (including cardinality requests), with support for cache replacement and invalidation policies ([#648](https://github.com/LiUSemWeb/HeFQUIN/pull/648)).
 - Support for ChronicleMap-based persistent cache for federation requests (including cardinality requests), with support for cache replacement and invalidation policies ([#546](https://github.com/LiUSemWeb/HeFQUIN/pull/546), [#666](https://github.com/LiUSemWeb/HeFQUIN/pull/666)).
-- CLI program to issue queries to the HeFQUIN service ([#616](https://github.com/LiUSemWeb/HeFQUIN/issues/616), [#643](https://github.com/LiUSemWeb/HeFQUIN/issues/643), [#646](https://github.com/LiUSemWeb/HeFQUIN/issues/646), [#647](https://github.com/LiUSemWeb/HeFQUIN/issues/647), [#653](https://github.com/LiUSemWeb/HeFQUIN/issues/653), [#655](https://github.com/LiUSemWeb/HeFQUIN/issues/655)).
-- CLI program to use the RML component of HeFQUIN explicitly ([#601](https://github.com/LiUSemWeb/HeFQUIN/pull/601), [#644](https://github.com/LiUSemWeb/HeFQUIN/issues/644), [#670](https://github.com/LiUSemWeb/HeFQUIN/issues/670)).
+- Option to print the query result to a file when using the HeFQUIN CLI ([#671](https://github.com/LiUSemWeb/HeFQUIN/issues/671)).
+- Support configurable logging when using the HeFQUIN CLI ([#659](https://github.com/LiUSemWeb/HeFQUIN/pull/659)).
+- New CLI program to issue queries to the HeFQUIN service ([#616](https://github.com/LiUSemWeb/HeFQUIN/issues/616), [#643](https://github.com/LiUSemWeb/HeFQUIN/issues/643), [#646](https://github.com/LiUSemWeb/HeFQUIN/issues/646), [#647](https://github.com/LiUSemWeb/HeFQUIN/issues/647), [#653](https://github.com/LiUSemWeb/HeFQUIN/issues/653), [#655](https://github.com/LiUSemWeb/HeFQUIN/issues/655), [#671](https://github.com/LiUSemWeb/HeFQUIN/issues/671)).
+- New CLI program to use the RML component of HeFQUIN explicitly ([#601](https://github.com/LiUSemWeb/HeFQUIN/pull/601), [#644](https://github.com/LiUSemWeb/HeFQUIN/issues/644), [#670](https://github.com/LiUSemWeb/HeFQUIN/issues/670)).
 ### Changed
 - Refactoring issueCardinalityRequest to make it generic ([#630](https://github.com/LiUSemWeb/HeFQUIN/pull/630)).
 - Refactoring maxParallelRequests handling to eliminate redundant constructors in federation access managers ([#650](https://github.com/LiUSemWeb/HeFQUIN/pull/650)).

--- a/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunHttpQuery.java
+++ b/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunHttpQuery.java
@@ -20,6 +20,7 @@ import org.apache.jena.atlas.json.JSON;
 import org.apache.jena.atlas.json.JsonObject;
 import org.apache.jena.atlas.json.JsonValue;
 import org.apache.jena.cmd.ArgDecl;
+import org.apache.jena.cmd.CmdGeneral;
 import org.apache.jena.cmd.TerminationException;
 import org.apache.jena.query.ARQ;
 import org.apache.jena.query.Query;
@@ -36,8 +37,8 @@ import org.apache.jena.sparql.serializer.QuerySerializerFactory;
 import org.apache.jena.sparql.serializer.SerializationContext;
 import org.apache.jena.sparql.serializer.SerializerRegistry;
 import org.apache.jena.sparql.util.QueryExecUtils;
+import org.apache.jena.sys.JenaSystem;
 
-import arq.cmdline.CmdARQ;
 import arq.cmdline.ModTime;
 import se.liu.ida.hefquin.base.net.http.HttpConstants;
 import se.liu.ida.hefquin.cli.modules.ModPlanPrinting;
@@ -59,15 +60,18 @@ import se.liu.ida.hefquin.jenaext.sparql.lang.sparql_12_hefquin.ParserSPARQL12He
  * The resulting solution mappings are printed to standard output or written
  * to a file in a user-selected results format.
  */
-public class RunHttpQuery extends CmdARQ
+public class RunHttpQuery extends CmdGeneral
 {
+	static {
+		JenaSystem.init();
+	}
+
 	protected final ModTime          modTime =          new ModTime();
 	protected final ModPlanPrinting  modPlanPrinting =  new ModPlanPrinting();
 	protected final ModQuery         modQuery =         new ModQuery();
 	protected final ModResultsOutExt modResultsExt =    new ModResultsOutExt();
 
 	protected final ArgDecl argServerAddress = new ArgDecl( ArgDecl.HasValue, "server" );
-	protected final ArgDecl argOutputToFile =  new ArgDecl( ArgDecl.HasValue, "outputToFile" );
 
 	protected static final Pattern BASE_PATTERN = Pattern.compile( "\\bBASE\\b\\s*<[^>]+>", Pattern.CASE_INSENSITIVE );
 
@@ -83,11 +87,10 @@ public class RunHttpQuery extends CmdARQ
 		addModule( modTime );
 		addModule( modPlanPrinting );
 		addModule( modResultsExt );
-
-		add( argServerAddress, "--server", "Address of HeFQUIN service" );
-		add( argOutputToFile, "--outputToFile", "Output file (optional, printing to stdout if omitted)" );
-
 		addModule( modQuery );
+
+		getUsage().startCategory("Server");
+		add( argServerAddress, "--server", "Address of HeFQUIN service" );
 	}
 
 	/**
@@ -134,15 +137,16 @@ public class RunHttpQuery extends CmdARQ
 			out = NullPrintStream.INSTANCE;
 			ownedStream = null;
 		}
-		else if ( contains(argOutputToFile) ) {
+		else if ( modResultsExt.getOutputFile() != null ) {
+			final String filename = modResultsExt.getOutputFile();
 			try {
-				// Appends to file rather than overwriting
 				ownedStream = new PrintStream(
-					new FileOutputStream( getValue( argOutputToFile ), true ),
-					true );
+						new FileOutputStream(filename, true), // append to file
+						true ); // auto-flush
 				out = ownedStream;
-			} catch ( final FileNotFoundException e ) {
-				cmdError( "Failed to create print stream for output destination: " + getValue( argOutputToFile ), false );
+			}
+			catch ( final FileNotFoundException e ) {
+				cmdError( "Failed to create print stream for output destination: " + filename, false );
 				return;
 			}
 		}

--- a/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunQueryWithoutSrcSel.java
+++ b/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunQueryWithoutSrcSel.java
@@ -1,5 +1,7 @@
 package se.liu.ida.hefquin.cli;
 
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
 import java.io.PrintStream;
 import java.util.List;
 import org.apache.commons.io.output.NullPrintStream;
@@ -51,7 +53,7 @@ public class RunQueryWithoutSrcSel extends CmdARQ
 
 	/**
 	 * Constructor that initializes the command-line tool with necessary argument
-	 * modules for speciffying, e.g., federation configuration, engine configuration, and output format.
+	 * modules for specifying, e.g., federation configuration, engine configuration, and output format.
 	 *
 	 * @param argv Command-line arguments.
 	 */
@@ -59,11 +61,11 @@ public class RunQueryWithoutSrcSel extends CmdARQ
 		super( argv );
 
 		addModule( modTime );
+		addModule( modEngineConfig );
 		addModule( modPlanPrinting );
 		addModule( modResultsExt );
 
 		addModule( modQuery );
-		addModule( modEngineConfig );
 		addModule( modFederation );
 	}
 
@@ -74,7 +76,7 @@ public class RunQueryWithoutSrcSel extends CmdARQ
 	 */
 	@Override
 	protected String getSummary() {
-		return getCommandName() + " --query=<query> --federationDescription=<federation description>";
+		return getCommandName() + " --query <query> --fd <federation description>";
 	}
 
 	/**
@@ -105,13 +107,29 @@ public class RunQueryWithoutSrcSel extends CmdARQ
 		final Query query = getQuery();
 		final ResultsFormat resFmt = modResultsExt.getResultsFormat();
 
-		modTime.startTimer();
-
 		final PrintStream out;
+		final PrintStream ownedStream;
+		// Result printout suppression has highest precedence
 		if ( modResultsExt.isSuppressResultPrintout() ) {
 			out = NullPrintStream.INSTANCE;
-		} else {
+			ownedStream = null;
+		}
+		else if ( modResultsExt.getOutputFile() != null ) {
+			final String filename = modResultsExt.getOutputFile();
+			try {
+				ownedStream = new PrintStream(
+						new FileOutputStream(filename, true), // append to file
+						true ); // auto-flush
+				out = ownedStream;
+			}
+			catch ( final FileNotFoundException ex ) {
+				cmdError( "Failed to create print stream for output destination: " + filename, false );
+				return;
+			}
+		}
+		else {
 			out = System.out;
+			ownedStream = null;
 		}
 
 		final QueryProcContextBuilder ctxBuilder = e.getQueryProcContextBuilder()
@@ -121,6 +139,8 @@ public class RunQueryWithoutSrcSel extends CmdARQ
 					.setExecutablePlanPrinter( modPlanPrinting.getExecutablePlanPrinter() )
 					.setSkipExecution( modResultsExt.isSkipExecution() );
 		final QueryProcContext ctx = ctxBuilder.build();
+
+		modTime.startTimer();
 
 		QueryProcessingStatsAndExceptions statsAndExceptions = null;
 		try {
@@ -141,6 +161,9 @@ public class RunQueryWithoutSrcSel extends CmdARQ
 			System.err.println( ex.getMessage() );
 			ex.printStackTrace( System.err );
 		}
+
+		if ( ownedStream != null )
+			ownedStream.close();
 
 		if ( statsAndExceptions != null && statsAndExceptions.containsExceptions() ) {
 			final List<Exception> exceptions = statsAndExceptions.getExceptions();

--- a/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/modules/ModEngineConfig.java
+++ b/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/modules/ModEngineConfig.java
@@ -13,7 +13,7 @@ public class ModEngineConfig extends ModBase
 
 	@Override
 	public void registerWith( final CmdGeneral cmdLine ) {
-		cmdLine.getUsage().startCategory("Configuration options for HeFQUIN engine") ;
+		cmdLine.getUsage().startCategory("Configuration of HeFQUIN") ;
 
 		cmdLine.add(confDescrDecl, "--confDescr", "file with an RDF description of the configuration");
 	}

--- a/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/modules/ModFederation.java
+++ b/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/modules/ModFederation.java
@@ -20,7 +20,7 @@ public class ModFederation extends ModBase
 	@Override
 	public void registerWith( final CmdGeneral cmdLine ) {
 		cmdLine.getUsage().startCategory("Federation");
-		cmdLine.add(fedDescrDecl,  "--federationDescription",  "file with an RDF description of the federation (can be given multiple times if your description is distributed across multiple files)");
+		cmdLine.add(fedDescrDecl,  "--fd, --federationDescription",  "RDF file describing the federation (can be given multiple times)");
 	}
 
 	@Override

--- a/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/modules/ModResultsOutExt.java
+++ b/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/modules/ModResultsOutExt.java
@@ -43,6 +43,15 @@ public class ModResultsOutExt extends ModResultsOut
 
 	@Override
 	public void registerWith( final CmdGeneral cmdLine ) {
+		cmdLine.getUsage().startCategory("Statistics Printing");
+		cmdLine.add( argQueryProcStats, "--printQueryProcStats", "Print out statistics about the query execution process" );
+		cmdLine.add( argQueryProcStatsToFile, "--printQueryProcStatsToFile", "Print out statistics about the query execution process to a file" );
+		cmdLine.add( argOnelineTimeStats, "--printQueryProcMeasurements",
+			"Print out measurements about the query processing time in one line that can be used for a CSV file" );
+		cmdLine.add( argOnelineTimeStatsToFile, "--printQueryProcMeasurementsToFile", "Print out measurements about the query processing time to a file" );
+		cmdLine.add( argFedAccessStats, "--printFedAccessStats", "Print out statistics of the federation access manager" );
+		cmdLine.add( argFedAccessStatsToFile, "--printFedAccessStatsToFile", "Print out statistics of the federation access manager to a file" );
+
 		// -------------
 		// Instead of using the super-class functionality ...
 		//super.registerWith(cmdLine);
@@ -56,13 +65,6 @@ public class ModResultsOutExt extends ModResultsOut
 		cmdLine.add( argOutputToFile, "--outputToFile", "Output file (optional, printing to stdout if omitted)" );
 		cmdLine.add( argSuppressResultPrintout, "--suppressResultPrintout", "Do not print out the query result" );
 		cmdLine.add( argSkipExecution, "--skipExecution", "Do not execute the query (but create the execution plan)" );
-		cmdLine.add( argQueryProcStats, "--printQueryProcStats", "Print out statistics about the query execution process" );
-		cmdLine.add( argQueryProcStatsToFile, "--printQueryProcStatsToFile", "Print out statistics about the query execution process to a file" );
-		cmdLine.add( argOnelineTimeStats, "--printQueryProcMeasurements",
-			"Print out measurements about the query processing time in one line that can be used for a CSV file" );
-		cmdLine.add( argOnelineTimeStatsToFile, "--printQueryProcMeasurementsToFile", "Print out measurements about the query processing time to a file" );
-		cmdLine.add( argFedAccessStats, "--printFedAccessStats", "Print out statistics of the federation access manager" );
-		cmdLine.add( argFedAccessStatsToFile, "--printFedAccessStatsToFile", "Print out statistics of the federation access manager to a file" );
 	}
 
 	@Override

--- a/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/modules/ModResultsOutExt.java
+++ b/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/modules/ModResultsOutExt.java
@@ -21,6 +21,7 @@ import se.liu.ida.hefquin.engine.QueryProcessingStatsAndExceptions;
  */
 public class ModResultsOutExt extends ModResultsOut
 {
+	protected final ArgDecl argOutputToFile           = new ArgDecl( ArgDecl.HasValue, "outputToFile" );
 	protected final ArgDecl argSuppressResultPrintout = new ArgDecl( ArgDecl.NoValue, "suppressResultPrintout" );
 	protected final ArgDecl argSkipExecution          = new ArgDecl( ArgDecl.NoValue, "skipExecution" );
 	protected final ArgDecl argQueryProcStats         = new ArgDecl( ArgDecl.NoValue, "printQueryProcStats" );
@@ -35,13 +36,24 @@ public class ModResultsOutExt extends ModResultsOut
 	protected boolean printQueryProcStats;
 	protected boolean printFedAccessStats;
 	protected boolean printOnelineTimeStats;
+	protected String outputFile;
 	protected String queryProcStatsFile;
 	protected String fedAccessStatsFile;
 	protected String onelineTimeStatsFile;
 
 	@Override
 	public void registerWith( final CmdGeneral cmdLine ) {
-		super.registerWith(cmdLine);
+		// -------------
+		// Instead of using the super-class functionality ...
+		//super.registerWith(cmdLine);
+		// ... we do that part also ourselves:
+		cmdLine.getUsage().startCategory("Results");
+		cmdLine.add( resultsFmtDecl,
+		             "--rfmt",
+		             "Result format (Result set: text, XML, JSON, CSV, TSV; Graph: TTL, NTRIPLES, JSONLD, RDF/XML)") ;
+		// -------------
+
+		cmdLine.add( argOutputToFile, "--outputToFile", "Output file (optional, printing to stdout if omitted)" );
 		cmdLine.add( argSuppressResultPrintout, "--suppressResultPrintout", "Do not print out the query result" );
 		cmdLine.add( argSkipExecution, "--skipExecution", "Do not execute the query (but create the execution plan)" );
 		cmdLine.add( argQueryProcStats, "--printQueryProcStats", "Print out statistics about the query execution process" );
@@ -67,6 +79,9 @@ public class ModResultsOutExt extends ModResultsOut
 
 		printFedAccessStats = cmdLine.contains(argFedAccessStats);
 
+		if ( cmdLine.contains(argOutputToFile) )
+			outputFile = cmdLine.getValue(argOutputToFile);
+
 		if ( cmdLine.contains(argQueryProcStatsToFile) )
 			queryProcStatsFile = cmdLine.getValue(argQueryProcStatsToFile);
 
@@ -75,6 +90,10 @@ public class ModResultsOutExt extends ModResultsOut
 
 		if ( cmdLine.contains(argFedAccessStatsToFile) )
 			fedAccessStatsFile = cmdLine.getValue(argFedAccessStatsToFile);
+	}
+
+	public String getOutputFile() {
+		return outputFile;
 	}
 
 	public boolean isSuppressResultPrintout() {


### PR DESCRIPTION
While `RunHttpQuery` (`bin/hefquin-client`) already had the `--outputToFile` argument, `RunQueryWithoutSrcSel` (`bin/hefquin`) didn't have it. This PR adds it.

Additionally, the PR improves the organization of the `--help` output of these two CLI programs.