### PR TITLE
Multi-Request Operator

### DIFF
--- a/config/DefaultConfDescr.ttl
+++ b/config/DefaultConfDescr.ttl
@@ -41,7 +41,7 @@ _:bLogicalOptimizer rdf:type ec:LogicalOptimizer ;
 _:bListOfHeuristics
     ec:elementsTypeName "se.liu.ida.hefquin.engine.queryproc.impl.loptimizer.HeuristicForLogicalOptimization" ;
     ec:elements (
-        [ ec:javaClassName "se.liu.ida.hefquin.engine.queryproc.impl.loptimizer.ApplyVocabularyMappings" ]
+#        [ ec:javaClassName "se.liu.ida.hefquin.engine.queryproc.impl.loptimizer.ApplyVocabularyMappings" ]
         [ ec:javaClassName "se.liu.ida.hefquin.engine.queryproc.impl.loptimizer.heuristics.RemoveSubPlansWithEmptyResults" ]
         [ ec:javaClassName "se.liu.ida.hefquin.engine.queryproc.impl.loptimizer.heuristics.MergeRequests" ]
         [ ec:javaClassName "se.liu.ida.hefquin.engine.queryproc.impl.loptimizer.heuristics.FilterPushDown" ]
@@ -80,6 +80,7 @@ _:bListOfPhysicalOpFactories
         [ ec:javaClassName "se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpDuplicateRemoval$Factory" ]
         [ ec:javaClassName "se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpProject$Factory" ]
         [ ec:javaClassName "se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpRequest$Factory" ]
+        [ ec:javaClassName "se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpMultiRequest$Factory" ]
         [ ec:javaClassName "se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpGlobalToLocal$Factory" ]
         [ ec:javaClassName "se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpLocalToGlobal$Factory" ]
         [ ec:javaClassName "se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpBindJoinBRTPF$Factory" ;

--- a/config/DefaultConfDescrExtended.ttl
+++ b/config/DefaultConfDescrExtended.ttl
@@ -91,6 +91,7 @@ _:bListOfPhysicalOpFactories
         [ ec:javaClassName "se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpDuplicateRemoval$Factory" ]
         [ ec:javaClassName "se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpProject$Factory" ]
         [ ec:javaClassName "se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpRequest$Factory" ]
+        [ ec:javaClassName "se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpMultiRequest$Factory" ]
         [ ec:javaClassName "se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpGlobalToLocal$Factory" ]
         [ ec:javaClassName "se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpLocalToGlobal$Factory" ]
         [ ec:javaClassName "se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpBindJoinBRTPF$Factory" ;

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/FederationMember.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/FederationMember.java
@@ -14,6 +14,13 @@ public interface FederationMember
 	int getID();
 
 	/**
+	 * Returns the (unique) service URI of this federation member. The
+	 * service URI is the URI via which the federation member is referred
+	 * to in the SERVICE clauses.
+	 */
+	String getServiceURI();
+
+	/**
 	 * Returns {@code false} if the only types of graph patterns that
 	 * can be answered by a single request to this federation member
 	 * are triple patterns.

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImpl.java
@@ -20,6 +20,8 @@ public class SPARQLRequestImpl implements SPARQLRequest
 
 	protected final SPARQLQuery query;
 
+	// We materialize the ExpectedVariables in this case to avoid
+	// producing it over and over again whenever it is used.
 	protected final ExpectedVariables expectedVars;
 
 	public SPARQLRequestImpl( final SPARQLGraphPattern pattern ) {
@@ -35,8 +37,6 @@ public class SPARQLRequestImpl implements SPARQLRequest
 		this.projectionVars = projectionVars;
 		this.distinctRequired = distinctRequired;
 
-		// we materialize the ExpectedVariables in this case
-		// to avoid producing it again whenever it is used
 		expectedVars = determineExpectedVars( pattern.getExpectedVariables(),
 		                                      projectionVars );
 	}
@@ -50,8 +50,6 @@ public class SPARQLRequestImpl implements SPARQLRequest
 		this.projectionVars = jena.isQueryResultStar() ? null : new HashSet<>( jena.getProjectVars() );
 		this.distinctRequired = jena.isDistinct();
 
-		// we materialize the ExpectedVariables in this case
-		// to avoid producing it again whenever it is used
 		expectedVars = determineExpectedVars( query.getExpectedVariables(),
 		                                      projectionVars );
 	}

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImpl.java
@@ -37,7 +37,8 @@ public class SPARQLRequestImpl implements SPARQLRequest
 
 		// we materialize the ExpectedVariables in this case
 		// to avoid producing it again whenever it is used
-		expectedVars = pattern.getExpectedVariables();
+		expectedVars = determineExpectedVars( pattern.getExpectedVariables(),
+		                                      projectionVars );
 	}
 
 	public SPARQLRequestImpl( final SPARQLQuery query ) {
@@ -51,7 +52,48 @@ public class SPARQLRequestImpl implements SPARQLRequest
 
 		// we materialize the ExpectedVariables in this case
 		// to avoid producing it again whenever it is used
-		expectedVars = query.getExpectedVariables();
+		expectedVars = determineExpectedVars( query.getExpectedVariables(),
+		                                      projectionVars );
+	}
+
+	protected ExpectedVariables determineExpectedVars( final ExpectedVariables expVarsOfPattern,
+	                                                   final Set<Var> projectionVars ) {
+		if ( projectionVars == null )
+			return expVarsOfPattern;
+
+		// Determine the set of certain variables of the request, which is
+		// the intersection between the certain variables of the pattern and
+		// the projection variables.
+		final Set<Var> certVars;
+		final Set<Var> certVarsOfPattern = expVarsOfPattern.getCertainVariables();
+		if ( projectionVars.containsAll(certVarsOfPattern) ) {
+			certVars = certVarsOfPattern;
+		}
+		else {
+			certVars = new HashSet<>(certVarsOfPattern);
+			certVars.retainAll(projectionVars);
+		}
+
+		// Determine the set of possible variables of the request, which is
+		// the intersection between the possible variables of the pattern and
+		// the projection variables.
+		final Set<Var> possVars;
+		final Set<Var> possVarsOfPattern = expVarsOfPattern.getPossibleVariables();
+		if ( projectionVars.containsAll(possVarsOfPattern) ) {
+			possVars = possVarsOfPattern;
+		}
+		else {
+			possVars = new HashSet<>(possVarsOfPattern);
+			possVars.retainAll(projectionVars);
+		}
+
+		if ( certVars == certVarsOfPattern && possVars == possVarsOfPattern )
+			return expVarsOfPattern;
+
+		return new ExpectedVariables() {
+			@Override public Set<Var> getCertainVariables() { return certVars; }
+			@Override public Set<Var> getPossibleVariables() { return possVars; }
+		};
 	}
 
 	@Override

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/catalog/FederationDescriptionReader.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/catalog/FederationDescriptionReader.java
@@ -106,15 +106,17 @@ public class FederationDescriptionReader
 				throw new IllegalArgumentException( "Illegal serviceURI value: " + st.getObject().toString() );
 			}
 
-			membersByURI.put( serviceURI,
-			                  createFederationMember(fedMember, serviceURI, fd) );
+			final FederationMember fm = createFederationMember( fedMember,
+			                                                    NodeFactory.createURI(serviceURI),
+			                                                    fd );
+			membersByURI.put(serviceURI, fm);
 		}
 
 		return new FederationCatalogImpl(membersByURI);
 	}
 
 	protected FederationMember createFederationMember( final Resource fedMember,
-	                                                   final String serviceURI,
+	                                                   final Node serviceURI,
 	                                                   final Model fd ) {
 		final VocabularyMapping vocabMap = parseVocabMapping(fedMember, fd);
 
@@ -129,7 +131,7 @@ public class FederationDescriptionReader
 		}
 		else if ( ifaceType.equals(FDVocab.FragmentInterface) )
 		{
-			return handleFragmentInterface( iface, protocol, vocabMap );
+			return handleFragmentInterface( iface, protocol, vocabMap, serviceURI );
 		}
 		else if ( ifaceType.equals(FDVocab.TemplateBasedInterface) )
 		{
@@ -184,7 +186,7 @@ public class FederationDescriptionReader
 	                                                         final VocabularyMapping vocabMap,
 	                                                         final Resource fedMember,
 	                                                         final Model fd,
-	                                                         final String serviceURI ) {
+	                                                         final Node serviceURI ) {
 		if ( protocol.equals(FDVocab.SPARQLProtocol) ) {
 			final String addrStr = getSingleURIProperty(
 				iface,
@@ -192,7 +194,7 @@ public class FederationDescriptionReader
 				"SPARQL endpointAddress is required!",
 				"More than one SPARQL endpointAddress!" );
 
-			return createSPARQLEndpoint(addrStr, vocabMap);
+			return createSPARQLEndpoint(serviceURI, addrStr, vocabMap);
 		}
 
 		if ( protocol.equals(FDVocab.GenericWebAPIProtocol) ) {
@@ -210,7 +212,7 @@ public class FederationDescriptionReader
 			if ( trMaps.isEmpty() )
 				throw new IllegalArgumentException("The wrapped REST endpoint with service URI <" + serviceURI + "> does not have any RML triples maps.");
 
-			return createWrappedRESTEndpoint(addrStr, null, trMaps);
+			return createWrappedRESTEndpoint(serviceURI, addrStr, null, trMaps);
 		}
 
 		if ( protocol.equals(FDVocab.BoltProtocol) ) {
@@ -223,7 +225,7 @@ public class FederationDescriptionReader
 				"Bolt endpointAddress is required!",
 				"More than one Bolt endpointAddress!" );
 
-			return createNeo4jServer(addrStr);
+			return createNeo4jServer(serviceURI, addrStr);
 		}
 
 		if ( protocol.equals(FDVocab.GraphQLProtocol) ) {
@@ -236,7 +238,7 @@ public class FederationDescriptionReader
 				"GraphQL endpointAddress is required!",
 				"More than one GraphQL endpointAddress!" );
 
-			return createGraphQLServer(addrStr);
+			return createGraphQLServer(serviceURI, addrStr);
 		}
 
 		throw new IllegalArgumentException( protocol.toString() );
@@ -247,7 +249,8 @@ public class FederationDescriptionReader
 	 */
 	protected FederationMember handleFragmentInterface( final Resource iface,
 	                                                    final Resource protocol,
-	                                                    final VocabularyMapping vocabMap ) {
+	                                                    final VocabularyMapping vocabMap,
+	                                                    final Node serviceURI ) {
 		if ( protocol.equals(FDVocab.TPFProtocol) ) {
 			final String addrStr = getSingleURIProperty(
 				iface,
@@ -255,7 +258,7 @@ public class FederationDescriptionReader
 				"TPF exampleFragmentAddress is required!",
 				"More than one TPF exampleFragmentAddress!" );
 
-			return createTPFServer(addrStr, vocabMap);
+			return createTPFServer(serviceURI, addrStr, vocabMap);
 		}
 		else if ( protocol.equals(FDVocab.brTPFProtocol) ) {
 			final String addrStr = getSingleURIProperty(
@@ -264,7 +267,7 @@ public class FederationDescriptionReader
 				"brTPF exampleFragmentAddress is required!",
 				"More than one brTPF exampleFragmentAddress!" );
 
-			return createBRTPFServer(addrStr, vocabMap);
+			return createBRTPFServer(serviceURI, addrStr, vocabMap);
 		}
 		else {
 			throw new IllegalArgumentException( protocol.toString() );
@@ -280,7 +283,7 @@ public class FederationDescriptionReader
 	                                                    final VocabularyMapping vocabMap,
 	                                                    final Resource fedMember,
 	                                                    final Model fd,
-	                                                    final String serviceURI ) {
+	                                                    final Node serviceURI ) {
 		if ( protocol.equals(FDVocab.GenericWebAPIProtocol) ) {
 			if ( vocabMap != null )
 				throw new IllegalArgumentException("REST APIs cannot have a vocabulary mapping.");
@@ -342,7 +345,7 @@ public class FederationDescriptionReader
 			if ( trMaps.isEmpty() )
 				throw new IllegalArgumentException("The wrapped REST endpoint with service URI <" + serviceURI + "> does not have any RML triples maps.");
 
-			return createWrappedRESTEndpoint(uriTemplateString, params, trMaps);
+			return createWrappedRESTEndpoint(serviceURI, uriTemplateString, params, trMaps);
 		}
 		else {
 			throw new IllegalArgumentException( protocol.toString() );
@@ -351,7 +354,7 @@ public class FederationDescriptionReader
 
 	protected List<MappingExpression> parseRMLMapping( final Resource fedMember,
 	                                                   final Model fd,
-	                                                   final String serviceURI ) {
+	                                                   final Node serviceURI ) {
 		final Resource wrapper = ModelUtils.getSingleMandatoryResourceProperty( fedMember, FDVocab.wrapper );
 
 		// TODO: Each of the TrMap-expressions created in the following
@@ -375,7 +378,7 @@ public class FederationDescriptionReader
 					                                    null );
 				}
 				catch ( final RMLParserException e ) {
-					throw new IllegalArgumentException("There is a problem in the RML mapping for <" + serviceURI + ">: " +  e.getMessage(), e );
+					throw new IllegalArgumentException("There is a problem in the RML mapping for <" + serviceURI.toString() + ">: " +  e.getMessage(), e );
 				}
 
 				trMaps.add(trMap);
@@ -385,27 +388,35 @@ public class FederationDescriptionReader
 		return trMaps;
 	}
 
-	protected FederationMember createSPARQLEndpoint( final String uri, final VocabularyMapping vm ) {
+	protected FederationMember createSPARQLEndpoint( final Node serviceURI,
+	                                                 final String uri,
+	                                                 final VocabularyMapping vm ) {
 		verifyExpectedURI(uri);
-		return new SPARQLEndpointImpl(uri, vm);
+		return new SPARQLEndpointImpl(serviceURI, uri, vm);
 	}
 
-	protected FederationMember createTPFServer( final String uri, final VocabularyMapping vm ) {
+	protected FederationMember createTPFServer( final Node serviceURI,
+	                                            final String uri,
+	                                            final VocabularyMapping vm ) {
 		verifyExpectedURI(uri);
-		return new TPFServerImpl(uri, vm);
+		return new TPFServerImpl(serviceURI, uri, vm);
 	}
 
-	protected FederationMember createBRTPFServer( final String uri, final VocabularyMapping vm ) {
+	protected FederationMember createBRTPFServer( final Node serviceURI,
+	                                              final String uri,
+	                                              final VocabularyMapping vm ) {
 		verifyExpectedURI(uri);
-		return new BRTPFServerImpl(uri, vm);
+		return new BRTPFServerImpl(serviceURI, uri, vm);
 	}
 
-	protected FederationMember createNeo4jServer( final String uri ) {
+	protected FederationMember createNeo4jServer( final Node serviceURI,
+	                                              final String uri ) {
 		verifyExpectedURI(uri);
-		return new Neo4jServerImpl(uri);
+		return new Neo4jServerImpl(serviceURI, uri);
 	}
 
-	protected FederationMember createGraphQLServer( final String uri ) {
+	protected FederationMember createGraphQLServer( final Node serviceURI,
+	                                                final String uri ) {
 		verifyExpectedURI(uri);
 
 		final GraphQLSchemaInitializer init = new GraphQLSchemaInitializerImpl();
@@ -423,17 +434,18 @@ public class FederationDescriptionReader
 			throw new IllegalArgumentException(e);
 		}
 
-		return new GraphQLEndpointImpl(uri, schema);
+		return new GraphQLEndpointImpl(serviceURI, uri, schema);
 	}
 
-	protected FederationMember createWrappedRESTEndpoint( final String uri,
+	protected FederationMember createWrappedRESTEndpoint( final Node serviceURI,
+	                                                      final String uri,
 	                                                      final List<RESTEndpoint.Parameter> params,
 	                                                      final List<MappingExpression> trMaps ) {
 		assert ! trMaps.isEmpty();
 
 		if ( trMaps.size() == 1 ) {
 			final MappingExpression expr = trMaps.get(0);
-			return new WrappedRESTEndpointImpl(uri, params, expr);
+			return new WrappedRESTEndpointImpl(serviceURI, uri, params, expr);
 		}
 
 		final MappingExpression[] exprs = new MappingExpression[ trMaps.size() ];
@@ -446,7 +458,7 @@ public class FederationDescriptionReader
 		final MappingExpression expr = MappingExpressionFactory.create(
 				MappingOpUnion.getInstance(),
 				exprs );
-		return new WrappedRESTEndpointImpl(uri, params, expr);
+		return new WrappedRESTEndpointImpl(serviceURI, uri, params, expr);
 	}
 
 	/**

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/members/impl/BRTPFServerImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/members/impl/BRTPFServerImpl.java
@@ -2,6 +2,7 @@ package se.liu.ida.hefquin.federation.members.impl;
 
 import java.util.Set;
 
+import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.engine.binding.Binding;
 import org.apache.jena.sparql.exec.http.Params;
 import org.apache.jena.sparql.serializer.SerializationContext;
@@ -22,9 +23,11 @@ public class BRTPFServerImpl extends TPFServerImpl implements BRTPFServer
 
 	public final String httpQueryArgumentForBindings;
 
-	public BRTPFServerImpl( final String baseURL,
+	public BRTPFServerImpl( final Node serviceURI,
+	                        final String baseURL,
 	                        final VocabularyMapping vm ) {
-		this( baseURL,
+		this( serviceURI,
+		      baseURL,
 		      DfltHttpQueryArgumentForSubject,
 		      DfltHttpQueryArgumentForPredicate,
 		      DfltHttpQueryArgumentForObject,
@@ -32,13 +35,15 @@ public class BRTPFServerImpl extends TPFServerImpl implements BRTPFServer
 		      vm );
 	}
 
-	public BRTPFServerImpl( final String baseURL,
+	public BRTPFServerImpl( final Node serviceURI,
+	                        final String baseURL,
 	                        final String httpQueryArgumentForSubject,
 	                        final String httpQueryArgumentForPredicate,
 	                        final String httpQueryArgumentForObject,
 	                        final String httpQueryArgumentForBindings,
 	                        final VocabularyMapping vm ) {
-		super( baseURL,
+		super( serviceURI,
+		       baseURL,
 		       httpQueryArgumentForSubject,
 		       httpQueryArgumentForPredicate,
 		       httpQueryArgumentForObject,

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/members/impl/BaseForFederationMember.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/members/impl/BaseForFederationMember.java
@@ -1,5 +1,7 @@
 package se.liu.ida.hefquin.federation.members.impl;
 
+import org.apache.jena.graph.Node;
+
 import se.liu.ida.hefquin.federation.FederationMember;
 
 /**
@@ -13,10 +15,22 @@ public abstract class BaseForFederationMember implements FederationMember
 	private static int counter = 0;
 
 	protected final int id;
+	protected final String serviceURI;
 
-	protected BaseForFederationMember() { id = ++counter; }
+	protected BaseForFederationMember( final Node serviceURI ) {
+		this( serviceURI.getURI() );
+	}
+
+	private BaseForFederationMember( final String serviceURI ) {
+		assert serviceURI != null;
+
+		this.serviceURI = serviceURI;
+		this.id = ++counter;
+	}
 
 	@Override public int getID() { return id; }
+
+	@Override public String getServiceURI() { return serviceURI; }
 
 	@Override
 	public boolean equals( final Object o ) {
@@ -24,6 +38,7 @@ public abstract class BaseForFederationMember implements FederationMember
 			return true;
 
 		return    o instanceof BaseForFederationMember fm
-		       && fm.getID() == id;
+		       && fm.getID() == id
+		       && fm.getServiceURI().equals(serviceURI);
 	}
 }

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/members/impl/BaseForRDFBasedFederationMember.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/members/impl/BaseForRDFBasedFederationMember.java
@@ -2,6 +2,8 @@ package se.liu.ida.hefquin.federation.members.impl;
 
 import java.util.Objects;
 
+import org.apache.jena.graph.Node;
+
 import se.liu.ida.hefquin.base.data.VocabularyMapping;
 import se.liu.ida.hefquin.federation.members.RDFBasedFederationMember;
 
@@ -11,11 +13,13 @@ public abstract class BaseForRDFBasedFederationMember
 {
 	private final VocabularyMapping vm;
 
-	protected BaseForRDFBasedFederationMember() {
-		this.vm = null;
+	protected BaseForRDFBasedFederationMember( final Node serviceURI ) {
+		this(serviceURI, null);
 	}
 
-	protected BaseForRDFBasedFederationMember( final VocabularyMapping vm ) {
+	protected BaseForRDFBasedFederationMember( final Node serviceURI,
+	                                           final VocabularyMapping vm ) {
+		super(serviceURI);
 		this.vm = vm;
 	}
 

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/members/impl/GraphQLEndpointImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/members/impl/GraphQLEndpointImpl.java
@@ -1,5 +1,7 @@
 package se.liu.ida.hefquin.federation.members.impl;
 
+import org.apache.jena.graph.Node;
+
 import se.liu.ida.hefquin.engine.wrappers.graphql.data.GraphQLSchema;
 import se.liu.ida.hefquin.federation.members.GraphQLEndpoint;
 
@@ -9,8 +11,11 @@ public class GraphQLEndpointImpl extends BaseForFederationMember
 	protected final String url;
 	protected final GraphQLSchema schema;
 
-	public GraphQLEndpointImpl( final String url,
+	public GraphQLEndpointImpl( final Node serviceURI,
+	                            final String url,
 	                            final GraphQLSchema schema ) {
+		super(serviceURI);
+
 		assert url != null && ! url.isEmpty();
 		assert schema != null;
 

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/members/impl/Neo4jServerImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/members/impl/Neo4jServerImpl.java
@@ -1,5 +1,7 @@
 package se.liu.ida.hefquin.federation.members.impl;
 
+import org.apache.jena.graph.Node;
+
 import se.liu.ida.hefquin.federation.members.Neo4jServer;
 
 public class Neo4jServerImpl extends BaseForFederationMember
@@ -7,7 +9,9 @@ public class Neo4jServerImpl extends BaseForFederationMember
 {
 	protected final String url;
 
-	public Neo4jServerImpl( final String url ) {
+	public Neo4jServerImpl( final Node serviceURI, final String url ) {
+		super(serviceURI);
+
 		assert url != null && ! url.isEmpty();
 
 		this.url = url;

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/members/impl/RESTEndpointImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/members/impl/RESTEndpointImpl.java
@@ -2,6 +2,8 @@ package se.liu.ida.hefquin.federation.members.impl;
 
 import java.util.List;
 
+import org.apache.jena.graph.Node;
+
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
 import se.liu.ida.hefquin.federation.members.RESTEndpoint;
 
@@ -11,7 +13,11 @@ public class RESTEndpointImpl extends BaseForFederationMember
 	protected final String urlTemplate;
 	protected final List<RESTEndpoint.Parameter> params;
 
-	public RESTEndpointImpl( final String urlTemplate, final List<RESTEndpoint.Parameter> params ) {
+	public RESTEndpointImpl( final Node serviceURI,
+	                         final String urlTemplate,
+	                         final List<RESTEndpoint.Parameter> params ) {
+		super(serviceURI);
+
 		assert urlTemplate != null && ! urlTemplate.isEmpty();
 		this.urlTemplate = urlTemplate;
 		this.params = (params == null) ? List.of() : params;

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/members/impl/SPARQLEndpointImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/members/impl/SPARQLEndpointImpl.java
@@ -1,5 +1,7 @@
 package se.liu.ida.hefquin.federation.members.impl;
 
+import org.apache.jena.graph.Node;
+
 import se.liu.ida.hefquin.base.data.VocabularyMapping;
 import se.liu.ida.hefquin.federation.members.SPARQLEndpoint;
 
@@ -8,8 +10,10 @@ public class SPARQLEndpointImpl extends BaseForRDFBasedFederationMember
 {
 	protected final String url;
 
-	public SPARQLEndpointImpl( final String url, final VocabularyMapping vm ) {
-		super(vm);
+	public SPARQLEndpointImpl( final Node serviceURI,
+	                           final String url,
+	                           final VocabularyMapping vm ) {
+		super(serviceURI, vm);
 
 		assert url != null && ! url.isEmpty();
 		this.url = url;

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/members/impl/TPFServerImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/members/impl/TPFServerImpl.java
@@ -29,21 +29,24 @@ public class TPFServerImpl extends BaseForRDFBasedFederationMember
 	public final String httpQueryArgumentForPredicate;
 	public final String httpQueryArgumentForObject;
 
-	public TPFServerImpl( final String baseURL,
+	public TPFServerImpl( final Node serviceURI,
+	                      final String baseURL,
 	                      final VocabularyMapping vm ) {
-		this( baseURL,
+		this( serviceURI,
+		      baseURL,
 		      DfltHttpQueryArgumentForSubject,
 		      DfltHttpQueryArgumentForPredicate,
 		      DfltHttpQueryArgumentForObject,
 		      vm );
 	}
 
-	public TPFServerImpl( final String baseURL,
+	public TPFServerImpl( final Node serviceURI,
+	                      final String baseURL,
 	                      final String httpQueryArgumentForSubject,
 	                      final String httpQueryArgumentForPredicate,
 	                      final String httpQueryArgumentForObject,
 	                      final VocabularyMapping vm ) {
-		super(vm);
+		super(serviceURI, vm);
 
 		assert baseURL != null;
 		assert httpQueryArgumentForSubject    != null;

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/members/impl/WrappedRESTEndpointImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/members/impl/WrappedRESTEndpointImpl.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.jena.graph.Node;
 import org.apache.jena.query.Dataset;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryExecution;
@@ -32,10 +33,11 @@ public class WrappedRESTEndpointImpl extends RESTEndpointImpl
 	protected final MappingExpression mappingExpression;
 	protected final Set<SourceReference> srcRefs;
 
-	public WrappedRESTEndpointImpl( final String urlTemplate,
+	public WrappedRESTEndpointImpl( final Node serviceURI,
+	                                final String urlTemplate,
 	                                final List<RESTEndpoint.Parameter> params,
 	                                final MappingExpression mappingExpression ) {
-		super(urlTemplate, params);
+		super(serviceURI, urlTemplate, params);
 
 		assert mappingExpression != null;
 		this.mappingExpression = mappingExpression;

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/FederationTestBase.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/FederationTestBase.java
@@ -1,5 +1,7 @@
 package se.liu.ida.hefquin.federation;
 
+import org.apache.jena.graph.NodeFactory;
+
 import se.liu.ida.hefquin.federation.members.TPFServer;
 import se.liu.ida.hefquin.federation.members.impl.BRTPFServerImpl;
 import se.liu.ida.hefquin.federation.members.impl.Neo4jServerImpl;
@@ -27,47 +29,61 @@ public abstract class FederationTestBase
 
 
 	protected TPFServer getDBpediaTPFServer() {
-		return new TPFServerImpl( "http://fragments.dbpedia.org/2016-04/en",
+		return new TPFServerImpl( NodeFactory.createURI("http://example.org/tpf"),
+		                          "http://fragments.dbpedia.org/2016-04/en",
 		                          null ); // no vocab.mapping
 	}
 
 	protected static class SPARQLEndpointForTest extends SPARQLEndpointImpl
 	{
 		public SPARQLEndpointForTest() {
-			super("http://example.org/sparql", null);
+			super( NodeFactory.createURI("http://example.org/sparql"),
+			       "http://example.org/sparql",
+			       null );
 		}
 
 		public SPARQLEndpointForTest( final String url ) {
-			super(url, null);
+			super( NodeFactory.createURI("http://example.org/sparql"),
+			       url,
+			       null );
 		}
 	}
 
 	protected static class TPFServerForTest extends TPFServerImpl
 	{
 		public TPFServerForTest() {
-			super("http://example.org/", null);
+			super( NodeFactory.createURI("http://example.org/tpf"),
+			       "http://example.org/",
+			       null );
 		}
 
 		public TPFServerForTest( final String baseURL ) {
-			super(baseURL, null);
+			super( NodeFactory.createURI("http://example.org/tpf"),
+			       baseURL,
+			       null );
 		}
 	}
 
 	protected static class BRTPFServerForTest extends BRTPFServerImpl
 	{
 		public BRTPFServerForTest() {
-			super("http://example.org/", null);
+			super( NodeFactory.createURI("http://example.org/brtpf"),
+			       "http://example.org/",
+			       null );
 		}
 
 		public BRTPFServerForTest( final String baseURL ) {
-			super(baseURL, null);
+			super( NodeFactory.createURI("http://example.org/brtpf"),
+			       baseURL,
+			       null );
 		}
 	}
 
 	protected static class Neo4jServerImpl4Test extends Neo4jServerImpl
 	{
 		public Neo4jServerImpl4Test() {
-			super("http://localhost:7474/db/neo4j/tx");
+			super( NodeFactory.createURI("http://example.org/neo"),
+			       "http://localhost:7474/db/neo4j/tx" );
 		}
 	}
 

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImplTest.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/req/SPARQLRequestImplTest.java
@@ -45,8 +45,10 @@ public class SPARQLRequestImplTest extends FederationTestBase
 	@Test
 	public void testProjectionVariablesInitialization() throws FederationAccessException {
 		// setting up
-		final String queryString = "SELECT ?s ?o2 WHERE { ?s <http://xmlns.com/foaf/0.1/name> \"Berlin\"@en . " +
-									"?s <http://xmlns.com/foaf/0.1/name> ?o2 . }";
+		final String queryString =
+				"SELECT ?s ?o2 WHERE { " +
+				    "?s <http://example.org/1> ?o1 . " +
+				    "?s <http://example.org/2> ?o2 }";
 
 		final SPARQLQuery baseQuery = new SPARQLQueryImpl( QueryFactory.create(queryString) );
 
@@ -57,8 +59,19 @@ public class SPARQLRequestImplTest extends FederationTestBase
 		final SPARQLRequest req2 = new SPARQLRequestImpl(pattern, Set.of(Var.alloc("s")), false);
 
 		// checking
-		// ensure projection is applied
-		assertEquals( Set.of(Var.alloc("s"), Var.alloc("o2")), req1.getProjectionVars() );
-		assertEquals( Set.of(Var.alloc("s")), req2.getProjectionVars() );
+		// i) ensure projection is applied
+		assertEquals( Set.of(Var.alloc("s"), Var.alloc("o2")),
+		              req1.getProjectionVars() );
+		assertEquals( Set.of(Var.alloc("s")),
+		              req2.getProjectionVars() );
+
+		// ii) ensure that determining the expected variables considers projection
+		assertEquals( Set.of(Var.alloc("s"), Var.alloc("o2")),
+		              req1.getExpectedVariables().getCertainVariables() );
+		assertEquals( Set.of(Var.alloc("s")),
+		              req2.getExpectedVariables().getCertainVariables() );
+
+		assertTrue( req1.getExpectedVariables().getPossibleVariables().isEmpty() );
+		assertTrue( req2.getExpectedVariables().getPossibleVariables().isEmpty() );
 	}
 }

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/reqproc/GraphQLRequestProcessorImplTest.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/reqproc/GraphQLRequestProcessorImplTest.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.apache.jena.atlas.json.JsonString;
+import org.apache.jena.graph.NodeFactory;
 import org.junit.Test;
 
 import se.liu.ida.hefquin.engine.wrappers.graphql.data.GraphQLArgument;
@@ -28,7 +29,8 @@ public class GraphQLRequestProcessorImplTest extends FederationTestBase
 	protected static class GraphQLEndpointTest extends GraphQLEndpointImpl
 	{
 		public GraphQLEndpointTest() {
-			super( "http://localhost:4000/graphql",
+			super( NodeFactory.createURI("http://example.org/graphql"),
+			       "http://localhost:4000/graphql",
 			       new GraphQLSchemaForTest() );
 		}
 	}

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/members/impl/WrappedRESTEndpointImplTest.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/members/impl/WrappedRESTEndpointImplTest.java
@@ -79,7 +79,8 @@ public class WrappedRESTEndpointImplTest
 	}
 
 	protected WrappedRESTEndpoint createEndpointForTests() {
-		return new WrappedRESTEndpointImpl( "http://example.org/",
+		return new WrappedRESTEndpointImpl( NodeFactory.createURI("http://example.org/"),
+		                                    "http://example.org/",
 		                                    null,
 		                                    createMappingExpressionForTests() );
 	}

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/SPARQLGraphPattern.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/SPARQLGraphPattern.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.core.VarExprList;
 import org.apache.jena.sparql.engine.binding.Binding;
+import org.apache.jena.sparql.expr.Expr;
 import org.apache.jena.sparql.expr.ExprList;
 import org.apache.jena.sparql.syntax.Element;
 
@@ -117,8 +118,20 @@ public interface SPARQLGraphPattern extends Query
 	SPARQLGraphPattern mergeWith( SPARQLGraphPattern other );
 
 	/**
-	 * Merges this graph pattern with FILTERS that use the given expressions
-	 * and returns the resulting, merged pattern.
+	 * Extends this graph pattern with a FILTER that uses the given
+	 * expression, and returns the resulting, merged pattern. More
+	 * specifically, the FILTER is appended to this pattern.
+	 */
+	default SPARQLGraphPattern mergeWith( final Expr expr ) {
+		final Element elmtThis = QueryPatternUtils.convertToJenaElement(this);
+		final Element elmtMerged = ElementUtils.merge(expr, elmtThis);
+		return new GenericSPARQLGraphPatternImpl1(elmtMerged);
+	}
+
+	/**
+	 * Extends this graph pattern with FILTERS that use the given
+	 * expressions, and returns the resulting, merged pattern. More
+	 * specifically, the FILTERS are appended to this pattern.
 	 */
 	default SPARQLGraphPattern mergeWith( final ExprList exprs ) {
 		final Element elmtThis = QueryPatternUtils.convertToJenaElement(this);

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/SPARQLQuery.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/SPARQLQuery.java
@@ -1,11 +1,5 @@
 package se.liu.ida.hefquin.base.query;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
-
-import org.apache.jena.sparql.core.Var;
-
 public interface SPARQLQuery extends Query
 {
 	/**
@@ -18,13 +12,5 @@ public interface SPARQLQuery extends Query
 	 * Returns the sets of variables that can be expected in the
 	 * solution mappings produced for this query.
 	 */
-	default ExpectedVariables getExpectedVariables() {
-		final Set<Var> vars = new HashSet<>( asJenaQuery().getProjectVars() );
-
-		return new ExpectedVariables() {
-			@Override public Set<Var> getPossibleVariables() { return vars; }
-			@Override public Set<Var> getCertainVariables() { return Collections.emptySet(); }
-		};
-	}
-
+	ExpectedVariables getExpectedVariables();
 }

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/impl/SPARQLQueryImpl.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/query/impl/SPARQLQueryImpl.java
@@ -7,17 +7,25 @@ import org.apache.jena.query.QueryFactory;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.syntax.Element;
 
+import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
 import se.liu.ida.hefquin.base.query.SPARQLQuery;
 import se.liu.ida.hefquin.base.query.utils.QueryPatternUtils;
+import se.liu.ida.hefquin.jenaext.query.QueryUtils;
 
 public class SPARQLQueryImpl implements SPARQLQuery
 {
 	protected final Query jenaQuery;
 
+	// We materialize the ExpectedVariables in this case to avoid
+	// producing it over and over again whenever it is used.
+	protected final ExpectedVariables expectedVars;
+
 	public SPARQLQueryImpl( final Query jenaQuery ) {
 		assert jenaQuery != null;
 		this.jenaQuery = jenaQuery;
+
+		expectedVars = QueryUtils.determineExpectedVariables(jenaQuery);
 	}
 
 	public SPARQLQueryImpl( final SPARQLGraphPattern p,
@@ -44,6 +52,13 @@ public class SPARQLQueryImpl implements SPARQLQuery
 
 		jenaQuery.setDistinct( distinctRequired );
 		jenaQuery.setQueryPattern( jenaElement );
+
+		expectedVars = QueryUtils.determineExpectedVariables(jenaQuery);
+	}
+
+	@Override
+	public ExpectedVariables getExpectedVariables() {
+		return expectedVars;
 	}
 
 	@Override

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/jenaext/query/QueryUtils.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/jenaext/query/QueryUtils.java
@@ -1,0 +1,35 @@
+package se.liu.ida.hefquin.jenaext.query;
+
+import java.util.Set;
+
+import org.apache.jena.query.Query;
+import org.apache.jena.sparql.algebra.Algebra;
+import org.apache.jena.sparql.algebra.Op;
+import org.apache.jena.sparql.algebra.OpVars;
+import org.apache.jena.sparql.core.Var;
+
+import se.liu.ida.hefquin.base.query.ExpectedVariables;
+
+/**
+ * HeFQUIN-specific helper functionality related to Jena's {@link Query} class.
+ */
+public class QueryUtils
+{
+	public static ExpectedVariables determineExpectedVariables( final Query q ) {
+		final Op pattern = Algebra.compile( q.getQueryPattern() );
+		final Set<Var> certainVars = OpVars.fixedVars(pattern);
+		final Set<Var> possibleVars = OpVars.visibleVars(pattern);
+		possibleVars.removeAll(certainVars);
+
+		if ( ! q.isQueryResultStar() ) {
+			certainVars.retainAll( q.getProjectVars() );
+			possibleVars.retainAll( q.getProjectVars() );
+		}
+
+		return new ExpectedVariables() {
+			@Override public Set<Var> getCertainVariables() { return certainVars; }
+			@Override public Set<Var> getPossibleVariables() { return possibleVars; }
+		};
+	}
+
+}

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/jenaext/sparql/algebra/AlgebraGeneratorForHeFQUIN.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/jenaext/sparql/algebra/AlgebraGeneratorForHeFQUIN.java
@@ -8,7 +8,9 @@ import org.apache.jena.sparql.syntax.ElementSubQuery;
 import org.apache.jena.sparql.util.Context;
 
 import se.liu.ida.hefquin.jenaext.sparql.algebra.op.OpServiceWithParams;
+import se.liu.ida.hefquin.jenaext.sparql.algebra.op.OpServiceWithValues;
 import se.liu.ida.hefquin.jenaext.sparql.syntax.ElementServiceWithParams;
+import se.liu.ida.hefquin.jenaext.sparql.syntax.ElementServiceWithValues;
 
 /**
  * This class is an extension of Jena's {@link AlgebraGenerator} that
@@ -27,7 +29,7 @@ public class AlgebraGeneratorForHeFQUIN extends AlgebraGenerator
 
 	protected AlgebraGeneratorForHeFQUIN( final Context cxt, final int depth ) {
 		super(cxt, depth);
-		
+
 		this.context = cxt;
 		this.subQueryDepth = depth;
 	}
@@ -39,6 +41,12 @@ public class AlgebraGeneratorForHeFQUIN extends AlgebraGenerator
 			                                compileElement( ewp.getElement() ),
 			                                ewp.getSilent(),
 			                                ewp.getParamVars() );
+		}
+		else if ( e instanceof ElementServiceWithValues ewv ) {
+			return new OpServiceWithValues( ewv.getServiceNode(),
+			                                compileElement( ewv.getElement() ),
+			                                ewv.getSilent(),
+			                                ewv.getPossibleValues() );
 		}
 		else
 			return super.compileElementService(e);

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/jenaext/sparql/algebra/op/OpServiceWithValues.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/jenaext/sparql/algebra/op/OpServiceWithValues.java
@@ -1,0 +1,59 @@
+package se.liu.ida.hefquin.jenaext.sparql.algebra.op;
+
+import java.util.Set;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.algebra.Op;
+import org.apache.jena.sparql.algebra.op.Op1;
+import org.apache.jena.sparql.algebra.op.OpService;
+import org.apache.jena.sparql.util.NodeIsomorphismMap;
+
+/**
+ * Represents the combination of a SERVICE clause that has a variable as
+ * service node, together with a set of possible service URIs to be used
+ * for that variable.
+ */
+public class OpServiceWithValues extends OpService
+{
+	protected final Set<Node> values;
+
+	/**
+	 * @param n - the service node, must be a variable
+	 * @param subOp - represents the graph pattern inside the SERVICE clause
+	 * @param silent - {@code true} if the SERVICE clause has the SILENT keyword
+	 * @param values- set of possible URIs for the given variable
+	 */
+	public OpServiceWithValues( final Node n,
+	                            final Op subOp,
+	                            final boolean silent,
+	                            final Set<Node> values ) {
+		super(n, subOp, silent);
+
+		assert values != null;
+		this.values = values;
+	}
+
+	/**
+	 * Returns the set of possible URIs for the variable of this SERVICE clause.
+	 *
+	 * @return the set of possible service URIs
+	 */
+	public Set<Node> getPossibleValues() {
+		return values;
+	}
+
+	@Override
+	public Op1 copy( final Op newOp ) {
+		return new OpServiceWithValues( getService(), newOp, getSilent(), values );
+	}
+
+	@Override
+	public boolean equalTo( final Op other, final NodeIsomorphismMap labelMap ) {
+		if ( ! super.equalTo(other, labelMap) )
+			return false;
+
+		return    other instanceof OpServiceWithValues owv
+		       && owv.values.equals(values);
+	}
+
+}

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/jenaext/sparql/syntax/ElementServiceWithValues.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/jenaext/sparql/syntax/ElementServiceWithValues.java
@@ -1,0 +1,43 @@
+package se.liu.ida.hefquin.jenaext.sparql.syntax;
+
+import java.util.Set;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.syntax.Element;
+import org.apache.jena.sparql.syntax.ElementService;
+
+/**
+ * Represents the combination of a SERVICE clause that has a variable as
+ * service node, together with a set of possible service URIs to be used
+ * for that variable.
+ */
+public class ElementServiceWithValues extends ElementService
+{
+	protected final Set<Node> values;
+
+	/**
+	 * @param v - the variable that is the service node of this SERVICE clause
+	 * @param el - represents the graph pattern inside the SERVICE clause
+	 * @param silent - {@code true} if the SERVICE clause has the SILENT keyword
+	 * @param values- set of possible URIs for the given variable
+	 */
+	public ElementServiceWithValues( final Var v,
+	                                 final Element el,
+	                                 final boolean silent,
+	                                 final Set<Node> values ) {
+		super(v, el, silent);
+
+		assert values != null;
+		this.values = values;
+	}
+
+	/**
+	 * Returns the set of possible URIs for the variable of this SERVICE clause.
+	 *
+	 * @return the set of possible service URIs
+	 */
+	public Set<Node> getPossibleValues() {
+		return values;
+	}
+}

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/jenaext/sparql/syntax/ElementServiceWithValues.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/jenaext/sparql/syntax/ElementServiceWithValues.java
@@ -6,6 +6,7 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.syntax.Element;
 import org.apache.jena.sparql.syntax.ElementService;
+import org.apache.jena.sparql.util.NodeIsomorphismMap;
 
 /**
  * Represents the combination of a SERVICE clause that has a variable as
@@ -39,5 +40,15 @@ public class ElementServiceWithValues extends ElementService
 	 */
 	public Set<Node> getPossibleValues() {
 		return values;
+	}
+
+	@Override
+	public boolean equalTo( final Element other, final NodeIsomorphismMap isoMap ) {
+		if ( other == this ) return true;
+		if ( ! (other instanceof ElementServiceWithValues) ) return false;
+		if ( ! super.equalTo(other, isoMap) ) return false;
+
+		final ElementServiceWithValues o = (ElementServiceWithValues) other;
+		return o.values.equals(values);
 	}
 }

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/jenaext/sparql/syntax/ElementUtils.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/jenaext/sparql/syntax/ElementUtils.java
@@ -23,6 +23,37 @@ import org.apache.jena.sparql.syntax.ElementTriplesBlock;
 public class ElementUtils
 {
 	/**
+	 * Appends the given expression as a filter at the end of the graph
+	 * pattern represented by the given {@link Element} object.
+	 */
+	public static Element merge( final Expr expr, final Element elmt ) {
+		// Create a new ElementGroup object, add into it the Element represented
+		// by the given graph pattern, add into it the filters, and create a new
+		// graph pattern from it.
+		final ElementGroup group = new ElementGroup();
+
+		// - convert the given graph pattern into an Element and add it to the group
+		if ( elmt instanceof ElementGroup eg ) {
+			// If the given graph pattern was converted to an ElementGroup, instead
+			// of simply adding it into the new group, copy its sub-elements over
+			// to the new group, which avoids unnecessary nesting of groups.
+			for ( final Element subElmt : eg.getElements() ) {
+				group.addElement(subElmt);
+			}
+		}
+		else {
+			// If the given graph pattern was converted to something other
+			// than an ElementGroup, simply add it into the new group.
+			group.addElement(elmt);
+		}
+
+		// - now add the filter to the group
+		final ElementFilter f = new ElementFilter(expr);
+		group.addElement(f);
+
+		return group;
+	}
+	/**
 	 * Merges the given expressions as filters into the graph
 	 * pattern represented by the given {@link Element} object.
 	 */

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/jenaext/sparql/syntax/syntaxtransform/ExtendedElementTransformCleanGroupsOfOne.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/jenaext/sparql/syntax/syntaxtransform/ExtendedElementTransformCleanGroupsOfOne.java
@@ -1,0 +1,41 @@
+package se.liu.ida.hefquin.jenaext.sparql.syntax.syntaxtransform;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.syntax.Element;
+import org.apache.jena.sparql.syntax.ElementService;
+import org.apache.jena.sparql.syntax.syntaxtransform.ElementTransformCleanGroupsOfOne;
+
+import se.liu.ida.hefquin.jenaext.sparql.syntax.ElementServiceWithParams;
+import se.liu.ida.hefquin.jenaext.sparql.syntax.ElementServiceWithValues;
+
+public class ExtendedElementTransformCleanGroupsOfOne extends ElementTransformCleanGroupsOfOne
+{
+	@Override
+	public Element transform( final ElementService el,
+	                          final Node serviceNode,
+	                          final Element subElmt ) {
+		if (    ! alwaysCopy
+		     && el.getServiceNode() == serviceNode
+		     && el.getElement() == subElmt )
+			return el;
+
+		if ( el instanceof ElementServiceWithParams elParams )
+			return new ElementServiceWithParams( serviceNode,
+			                                     subElmt,
+			                                     el.getSilent(),
+			                                     elParams.getParamVars() );
+
+		if ( el instanceof ElementServiceWithValues elValues ) {
+			if ( ! serviceNode.isVariable() ) throw new IllegalArgumentException();
+
+			return new ElementServiceWithValues( Var.alloc(serviceNode),
+			                                     subElmt,
+			                                     el.getSilent(),
+			                                     elValues.getPossibleValues() );
+		}
+
+		return new ElementService( serviceNode, subElmt, el.getSilent() );
+	}
+
+}

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/jenaext/sparql/syntax/syntaxtransform/ExtendedElementTransformCleanGroupsOfOne.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/jenaext/sparql/syntax/syntaxtransform/ExtendedElementTransformCleanGroupsOfOne.java
@@ -9,6 +9,10 @@ import org.apache.jena.sparql.syntax.syntaxtransform.ElementTransformCleanGroups
 import se.liu.ida.hefquin.jenaext.sparql.syntax.ElementServiceWithParams;
 import se.liu.ida.hefquin.jenaext.sparql.syntax.ElementServiceWithValues;
 
+/**
+ * Extends the base class functionality such that the HeFQUIN-specific
+ * extensions of Jena's {@link Element} classes are handled correctly.
+ */
 public class ExtendedElementTransformCleanGroupsOfOne extends ElementTransformCleanGroupsOfOne
 {
 	@Override

--- a/hefquin-base/src/test/java/se/liu/ida/hefquin/jenaext/sparql/syntax/syntaxtransform/ExtendedElementTransformCleanGroupsOfOneTest.java
+++ b/hefquin-base/src/test/java/se/liu/ida/hefquin/jenaext/sparql/syntax/syntaxtransform/ExtendedElementTransformCleanGroupsOfOneTest.java
@@ -1,0 +1,105 @@
+package se.liu.ida.hefquin.jenaext.sparql.syntax.syntaxtransform;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.graph.Triple;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.syntax.Element;
+import org.apache.jena.sparql.syntax.ElementGroup;
+import org.apache.jena.sparql.syntax.ElementTriplesBlock;
+import org.apache.jena.sparql.syntax.syntaxtransform.ElementTransform;
+import org.apache.jena.sparql.syntax.syntaxtransform.ElementTransformer;
+import org.junit.Test;
+
+import se.liu.ida.hefquin.jenaext.sparql.syntax.ElementServiceWithParams;
+import se.liu.ida.hefquin.jenaext.sparql.syntax.ElementServiceWithValues;
+
+public class ExtendedElementTransformCleanGroupsOfOneTest
+{
+	@Test
+	public void transformSingletonGroupWithElementServiceWithParams() {
+		// set up
+		final ElementTriplesBlock bgp = new ElementTriplesBlock();
+		bgp.addTriple( Triple.create(Var.alloc("s"),
+		                             Var.alloc("p"),
+		                             Var.alloc("o")) );
+
+		final ElementGroup innerGroup1 = new ElementGroup();
+		innerGroup1.addElement(bgp);
+
+		final ElementGroup innerGroup2 = new ElementGroup();
+		innerGroup2.addElement(innerGroup1);
+
+		final ElementServiceWithParams elmtService = new ElementServiceWithParams(
+				NodeFactory.createURI("http://example.org"),
+				innerGroup2,
+				false, // no SILENT
+				Map.of("param", Var.alloc("v")) );
+
+		final ElementGroup outerGroup = new ElementGroup();
+		outerGroup.addElement(elmtService);
+
+		// run
+		final ElementTransform t = new ExtendedElementTransformCleanGroupsOfOne();
+		final Element result = ElementTransformer.transform(outerGroup, t);
+
+		// check
+		assertTrue( result instanceof ElementServiceWithParams );
+		assertEquals( ElementServiceWithParams.class, result.getClass() );
+
+		final ElementServiceWithParams s = (ElementServiceWithParams) result;
+		assertEquals( elmtService.getServiceNode(), s.getServiceNode() );
+		assertEquals( elmtService.getSilent(),      s.getSilent() );
+		assertEquals( elmtService.getParamVars(),   s.getParamVars() );
+
+		final Element subElmt = s.getElement();
+		assertEquals( ElementGroup.class, subElmt.getClass() );
+		assertEquals( innerGroup1, subElmt );
+	}
+
+	@Test
+	public void transformSingletonGroupWithElementServiceWithValues() {
+		// set up
+		final ElementTriplesBlock bgp = new ElementTriplesBlock();
+		bgp.addTriple( Triple.create(Var.alloc("s"),
+		                             Var.alloc("p"),
+		                             Var.alloc("o")) );
+
+		final ElementGroup innerGroup1 = new ElementGroup();
+		innerGroup1.addElement(bgp);
+
+		final ElementGroup innerGroup2 = new ElementGroup();
+		innerGroup2.addElement(innerGroup1);
+
+		final ElementServiceWithValues elmtService = new ElementServiceWithValues(
+				Var.alloc("s"),
+				innerGroup2,
+				false, // no SILENT
+				Set.of(NodeFactory.createURI("http://example.org")) );
+
+		final ElementGroup outerGroup = new ElementGroup();
+		outerGroup.addElement(elmtService);
+
+		// run
+		final ElementTransform t = new ExtendedElementTransformCleanGroupsOfOne();
+		final Element result = ElementTransformer.transform(outerGroup, t);
+
+		// check
+		assertTrue( result instanceof ElementServiceWithValues );
+		assertEquals( ElementServiceWithValues.class, result.getClass() );
+
+		final ElementServiceWithValues s = (ElementServiceWithValues) result;
+		assertEquals( elmtService.getServiceNode(),    s.getServiceNode() );
+		assertEquals( elmtService.getSilent(),         s.getSilent() );
+		assertEquals( elmtService.getPossibleValues(), s.getPossibleValues() );
+
+		final Element subElmt = s.getElement();
+		assertEquals( ElementGroup.class, subElmt.getClass() );
+		assertEquals( innerGroup1, subElmt );
+	}
+}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/ValuesServiceQueryResolver.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/ValuesServiceQueryResolver.java
@@ -24,7 +24,6 @@ import org.apache.jena.sparql.syntax.ElementVisitor;
 import org.apache.jena.sparql.syntax.ElementVisitorBase;
 import org.apache.jena.sparql.syntax.ElementWalker;
 import org.apache.jena.sparql.syntax.syntaxtransform.ElementTransform;
-import org.apache.jena.sparql.syntax.syntaxtransform.ElementTransformCleanGroupsOfOne;
 import org.apache.jena.sparql.syntax.syntaxtransform.ElementTransformCopyBase;
 import org.apache.jena.sparql.syntax.syntaxtransform.ElementTransformer;
 
@@ -459,63 +458,72 @@ public class ValuesServiceQueryResolver
 	                                        final List<Element> elmts,
 	                                        final int startPos,
 	                                        final int endPos ) {
-		// First, rewrite the relevant list elements based on the
-		// first solution mapping of the given VALUES clause.
-		final Iterator<Binding> it = valClause.getRows().iterator();
-		final Binding firstRow = it.next();
-
-		// If the given VALUES clause contains only one solution mapping,
-		// we may simply rewrite the relevant list elements based on that
-		// solution mapping and are done.
-		if ( ! it.hasNext() ) {
+		// First, we handle the special case in which the given
+		// VALUES clause contains only one solution mapping. In
+		// this case, we simply rewrite the relevant list elements
+		// based on that solution mapping and are done. We do not
+		// use the multi-request operator in this case.
+		if ( valClause.getRows().size() == 1 ) {
+			final Binding firstRow = valClause.getRows().get(0);
 			return rewrite( firstRow, elmts, startPos, endPos, valClause.getVars() );
 		}
 
-// --- quick hack --------------
-		// assuming there are only SERVICE clauses between the VALUES clauses
-		final List<Element> result = new ArrayList<>( endPos - startPos + 1 );
-		for ( int i = startPos; i <= endPos; i++ ) {
-			final Element eOld = elmts.get(i);
+		// Now we check whether we can use the multi-request operator.
+		// For the moment, we use it only if the given VALUES clause
+		// is a single column table. Additionally, we assume that the
+		// relevant list elements include only one SERVICE clause that
+		// has a variable as service node, where this variable must be
+		// the one assigned by the VALUES clause.
+		if ( valClause.getVars().size() == 1 ) {
+			final List<Element> result = new ArrayList<>( endPos - startPos + 1 );
+			boolean foundServiceWithVariable = false;
+			for ( int i = startPos; i <= endPos; i++ ) {
+				final Element eOld = elmts.get(i);
 
-			if ( ! (eOld instanceof ElementService) )
-				throw new MyIllegalQueryException("The POC assumes that there are only SERVICE clauses between the VALUES clauses.");
+				if (    eOld instanceof ElementService oldServiceClause
+				     && oldServiceClause.getServiceNode().isVariable() )
+				{
+					final Var var = Var.alloc( oldServiceClause.getServiceNode() );
+					if ( ! valClause.getVars().contains(var) )
+						throw new MyIllegalQueryException("There is a SERVICE clause with a variable (" + var.toString() + ") that is not assigned by the previous VALUES clause.");
 
-			final ElementService oldServiceClause = (ElementService) eOld;
-			if ( oldServiceClause.getServiceNode().isVariable() ) {
-				final Var var = Var.alloc( oldServiceClause.getServiceNode() );
-				if ( ! valClause.getVars().contains(var) )
-					throw new MyIllegalQueryException("There is a SERVICE clause with a variable (" + var.toString() + ") that is not assigned by the previous VALUES clause.");
+					if ( foundServiceWithVariable == true )
+						throw new MyIllegalQueryException("There are two SERVICE clauses with a variable under the scope of the previous VALUES clause.");
 
-				final Set<Node> valuesForVar = new HashSet<>();
-				final Iterator<Binding> it2 = valClause.getRows().iterator();
-				while ( it2.hasNext() ) {
-					final Node n = it2.next().get(var);
-					if ( ! n.isURI() ) {
-						final String typeNameForMsg = ( n.isLiteral() ) ? "literal" : n.getClass().getName();
-						throw new MyIllegalQueryException("A VALUES clause can only assign IRIs to service variables. This is not the case for variable ?" + var.getName() + ", which is assigned a " + typeNameForMsg + " (" + n.toString()+ ").");
+					foundServiceWithVariable = true;
+
+					final Set<Node> valuesForVar = new HashSet<>();
+					final Iterator<Binding> it2 = valClause.getRows().iterator();
+					while ( it2.hasNext() ) {
+						final Node n = it2.next().get(var);
+						if ( ! n.isURI() ) {
+							final String typeNameForMsg = ( n.isLiteral() ) ? "literal" : n.getClass().getName();
+							throw new MyIllegalQueryException("A VALUES clause can only assign IRIs to service variables. This is not the case for variable ?" + var.getName() + ", which is assigned a " + typeNameForMsg + " (" + n.toString()+ ").");
+						}
+
+						valuesForVar.add(n);
 					}
 
-					valuesForVar.add(n);
+					result.add( new ElementServiceWithValues(var,
+					                                         oldServiceClause.getElement(),
+					                                         oldServiceClause.getSilent(),
+					                                         valuesForVar) );
 				}
+				else {
+					result.add(eOld);
+				}
+			}
 
-				result.add( new ElementServiceWithValues(var,
-				                                         oldServiceClause.getElement(),
-				                                         oldServiceClause.getSilent(),
-				                                         valuesForVar) );
-			}
-			else {
-				result.add(oldServiceClause);
-			}
+			return result;
 		}
 
-		return result;
-// ------------------
-/*
-		// If the given VALUES clause contains more than one solution mapping,
-		// then we need to combine the rewritings obtained based on each of
-		// these solution mappings into a UNION pattern. The rewriting created
-		// based on the first solution mapping becomes the first part of this
-		// UNION pattern.
+		// If the given VALUES clause contains more than one column / variable
+		// and more than one row / solution mapping, then we need to combine
+		// the rewritings obtained based on each of these solution mappings
+		// into a UNION pattern. The rewriting created based on the first
+		// solution mapping becomes the first part of this UNION pattern.
+		final Iterator<Binding> it = valClause.getRows().iterator();
+		final Binding firstRow = it.next();
 		final List<Element> rewriteUsingFirstRow = rewrite( firstRow, elmts, startPos, endPos, valClause.getVars() );
 		final ElementUnion eu = new ElementUnion();
 		eu.addElement( ElementUtils.createElementGroupIfNeeded(rewriteUsingFirstRow) );
@@ -532,7 +540,6 @@ public class ValuesServiceQueryResolver
 		final List<Element> result = new ArrayList<>();
 		result.add(eu);
 		return result;
-*/
 	}
 
 	/**

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/ValuesServiceQueryResolver.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/ValuesServiceQueryResolver.java
@@ -29,7 +29,9 @@ import org.apache.jena.sparql.syntax.syntaxtransform.ElementTransformCopyBase;
 import org.apache.jena.sparql.syntax.syntaxtransform.ElementTransformer;
 
 import se.liu.ida.hefquin.jenaext.PatternVarsAll;
+import se.liu.ida.hefquin.jenaext.sparql.syntax.ElementServiceWithValues;
 import se.liu.ida.hefquin.jenaext.sparql.syntax.ElementUtils;
+import se.liu.ida.hefquin.jenaext.sparql.syntax.syntaxtransform.ExtendedElementTransformCleanGroupsOfOne;
 
 /**
  * Queries with a WHERE clause of a form such as the following one need to be
@@ -220,7 +222,7 @@ public class ValuesServiceQueryResolver
 			}
 
 			// Clean up groups of one in the new query pattern (if any) and ...
-			final ElementTransform t = new ElementTransformCleanGroupsOfOne();
+			final ElementTransform t = new ExtendedElementTransformCleanGroupsOfOne();
 			final Element newQueryPattern2 = ElementTransformer.transform(newQueryPattern, t);
 			// ... establish the result as the new query pattern.
 			q.setQueryPattern(newQueryPattern2);
@@ -460,19 +462,61 @@ public class ValuesServiceQueryResolver
 		// First, rewrite the relevant list elements based on the
 		// first solution mapping of the given VALUES clause.
 		final Iterator<Binding> it = valClause.getRows().iterator();
-		final List<Element> rewriteUsingFirstRow = rewrite( it.next(), elmts, startPos, endPos, valClause.getVars() );
+		final Binding firstRow = it.next();
 
 		// If the given VALUES clause contains only one solution mapping,
-		// we are done and can return the result of rewriting based on
-		// that solution mapping.
-		if ( ! it.hasNext() )
-			return rewriteUsingFirstRow;
+		// we may simply rewrite the relevant list elements based on that
+		// solution mapping and are done.
+		if ( ! it.hasNext() ) {
+			return rewrite( firstRow, elmts, startPos, endPos, valClause.getVars() );
+		}
 
+// --- quick hack --------------
+		// assuming there are only SERVICE clauses between the VALUES clauses
+		final List<Element> result = new ArrayList<>( endPos - startPos + 1 );
+		for ( int i = startPos; i <= endPos; i++ ) {
+			final Element eOld = elmts.get(i);
+
+			if ( ! (eOld instanceof ElementService) )
+				throw new MyIllegalQueryException("The POC assumes that there are only SERVICE clauses between the VALUES clauses.");
+
+			final ElementService oldServiceClause = (ElementService) eOld;
+			if ( oldServiceClause.getServiceNode().isVariable() ) {
+				final Var var = Var.alloc( oldServiceClause.getServiceNode() );
+				if ( ! valClause.getVars().contains(var) )
+					throw new MyIllegalQueryException("There is a SERVICE clause with a variable (" + var.toString() + ") that is not assigned by the previous VALUES clause.");
+
+				final Set<Node> valuesForVar = new HashSet<>();
+				final Iterator<Binding> it2 = valClause.getRows().iterator();
+				while ( it2.hasNext() ) {
+					final Node n = it2.next().get(var);
+					if ( ! n.isURI() ) {
+						final String typeNameForMsg = ( n.isLiteral() ) ? "literal" : n.getClass().getName();
+						throw new MyIllegalQueryException("A VALUES clause can only assign IRIs to service variables. This is not the case for variable ?" + var.getName() + ", which is assigned a " + typeNameForMsg + " (" + n.toString()+ ").");
+					}
+
+					valuesForVar.add(n);
+				}
+
+				result.add( new ElementServiceWithValues(var,
+				                                         oldServiceClause.getElement(),
+				                                         oldServiceClause.getSilent(),
+				                                         valuesForVar) );
+			}
+			else {
+				result.add(oldServiceClause);
+			}
+		}
+
+		return result;
+// ------------------
+/*
 		// If the given VALUES clause contains more than one solution mapping,
 		// then we need to combine the rewritings obtained based on each of
 		// these solution mappings into a UNION pattern. The rewriting created
 		// based on the first solution mapping becomes the first part of this
 		// UNION pattern.
+		final List<Element> rewriteUsingFirstRow = rewrite( firstRow, elmts, startPos, endPos, valClause.getVars() );
 		final ElementUnion eu = new ElementUnion();
 		eu.addElement( ElementUtils.createElementGroupIfNeeded(rewriteUsingFirstRow) );
 
@@ -488,6 +532,7 @@ public class ValuesServiceQueryResolver
 		final List<Element> result = new ArrayList<>();
 		result.add(eu);
 		return result;
+*/
 	}
 
 	/**

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/ValuesServiceQueryResolver.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/ValuesServiceQueryResolver.java
@@ -157,80 +157,113 @@ import se.liu.ida.hefquin.jenaext.sparql.syntax.syntaxtransform.ExtendedElementT
  */
 public class ValuesServiceQueryResolver
 {
+	// Set to false to disable the use of multi-request operators,
+	// which should be done only for testing/evaluation purposes.
+	protected static final boolean useMultiRequestOperators = true;
+
 	/**
 	 * If the WHERE clause of the given query is of a form that should be
 	 * rewritten, then this method replaces the WHERE clause of the query
 	 * by the rewritten one. Otherwise, the WHERE clause of the query is
 	 * not changed.
 	 *
-	 * An {@link UnsupportedQueryException} is thrown if it is discovered
-	 * that the WHERE clause of the given query uses VALUES clauses and
-	 * SERVICE clauses in a way that is currently not supported.
+	 * @throws UnsupportedQueryException if the WHERE clause of the
+	 * given query uses VALUES clauses and SERVICE clauses in a way
+	 * that is currently not supported.
 	 *
-	 * An {@link IllegalQueryException} is thrown if it is discovered
-	 * that the WHERE clause of the given query uses VALUES clauses in an
-	 * incorrect way.
+	 * @throws IllegalQueryException if the WHERE clause of the given
+	 * query uses VALUES clauses in an incorrect way.
 	 */
 	public static void expandValuesPlusServicePattern( final Query q )
 			throws UnsupportedQueryException, IllegalQueryException
 	{
-		if ( q.getQueryPattern() instanceof ElementGroup eg ) {
-			// If the query pattern does not have at least two elements, there
-			// is nothing to do here (because we need at least a VALUES clause
-			// and a SERVICE clause to do something).
-			if ( eg.size() < 2 )
-				return;
+		final Element elmt = q.getQueryPattern();
 
-			// Rewrite the elements of the query pattern.
-			final List<Element> newElmts;
-			try {
-				newElmts = expandValuesPlusServicePattern( eg.getElements() );
-			}
-			catch ( final MyUnsupportedQueryException e ) {
-				throw new UnsupportedQueryException( q, e.getMessage(), e );
-			}
-			catch ( final MyIllegalQueryException e ) {
-				throw new IllegalQueryException( q, e.getMessage(), e );
-			}
-
-			// If the attempt to rewrite the elements of the query
-			// pattern did not result in any change (as indicated
-			// by a null value), there is nothing to be done here.
-			if ( newElmts == null )
-				return;
-
-			// Safety check.
-			assert newElmts.size() > 0;
-
-			final Element newQueryPattern;
-			if ( newElmts.size() == 1 ) {
-				// If rewriting the elements of the query pattern resulted
-				// in a single new element, use that element as the new
-				// query pattern.
-				newQueryPattern = newElmts.get(0);
-			}
-			else {
-				// If rewriting the elements of the query pattern resulted
-				// in multiple new elements, gorup them together as the new
-				// query pattern.
-				final ElementGroup newGroup = new ElementGroup();
-				for ( final Element elmt : newElmts ) {
-					newGroup.addElement(elmt);
-				}
-				newQueryPattern = newGroup;
-			}
-
-			// Clean up groups of one in the new query pattern (if any) and ...
-			final ElementTransform t = new ExtendedElementTransformCleanGroupsOfOne();
-			final Element newQueryPattern2 = ElementTransformer.transform(newQueryPattern, t);
-			// ... establish the result as the new query pattern.
-			q.setQueryPattern(newQueryPattern2);
-		}
-		else {
-			// We are not expecting the query pattern to be
-			// anything else than a group graph pattern.
+		// We are not expecting the query pattern to be
+		// anything else than a group graph pattern.
+		if ( ! (elmt instanceof ElementGroup) ) {
 			throw new UnsupportedOperationException();
 		}
+
+		// Attempt to rewrite the query pattern.
+		final Element resultingElmt;
+		try {
+			resultingElmt = expandValuesPlusServicePattern( (ElementGroup) elmt );
+		}
+		catch ( final MyUnsupportedQueryException e ) {
+			throw new UnsupportedQueryException( q, e.getMessage(), e );
+		}
+		catch ( final MyIllegalQueryException e ) {
+			throw new IllegalQueryException( q, e.getMessage(), e );
+		}
+
+		// If the query pattern did not change, there is nothing more
+		// to do here (i.e., the given query can remain as is).
+		if ( resultingElmt == elmt )
+			return;
+
+		// Otherwise, change the query pattern of the given query to
+		// be the new, rewritten one.
+		q.setQueryPattern(resultingElmt);
+	}
+
+	/**
+	 * Rewrites the given group graph pattern (if needed). Returns the given
+	 * group graph pattern itself if it turns out that nothing needs to be
+	 * rewritten, which is the case if there is no VALUES clause in the given
+	 * pattern or there is a VALUES clause but only as the very last element
+	 * of the pattern.
+	 *
+	 * @throws MyIllegalQueryException if the given pattern contains two
+	 * VALUES clauses whose sets of variables are not disjoint.
+	 *
+	 * @throws MyUnsupportedQueryException if the given pattern contains
+	 * VALUES clauses and SERVICE clauses that are used in a way that is
+	 * currently not supported.
+	 */
+	protected static Element expandValuesPlusServicePattern( final ElementGroup eg )
+			throws MyUnsupportedQueryException, MyIllegalQueryException
+	{
+		// If the query pattern does not have at least two elements, there
+		// is nothing to do here (because we need at least a VALUES clause
+		// and a SERVICE clause to do something).
+		if ( eg.size() < 2 )
+			return eg;
+
+		// Rewrite the elements of the query pattern.
+		final List<Element> newElmts = expandValuesPlusServicePattern( eg.getElements() );
+
+		// If the attempt to rewrite the elements of the query
+		// pattern did not result in any change (as indicated
+		// by a null value), there is nothing to be done here.
+		if ( newElmts == null )
+			return eg;
+
+		// Safety check.
+		assert newElmts.size() > 0;
+
+		final Element result;
+		if ( newElmts.size() == 1 ) {
+			// If rewriting the elements of the query pattern resulted
+			// in a single new element, use that element as the new
+			// query pattern.
+			result = newElmts.get(0);
+		}
+		else {
+			// If rewriting the elements of the query pattern resulted
+			// in multiple new elements, group them together as the new
+			// query pattern.
+			final ElementGroup newGroup = new ElementGroup();
+			for ( final Element elmt : newElmts ) {
+				newGroup.addElement(elmt);
+			}
+			result = newGroup;
+		}
+
+		// Finally, clean up groups of one in the new query pattern (if any).
+		final ElementTransform t = new ExtendedElementTransformCleanGroupsOfOne();
+		final Element cleanedUpResult = ElementTransformer.transform(result, t);
+		return cleanedUpResult;
 	}
 
 	/**
@@ -239,8 +272,12 @@ public class ValuesServiceQueryResolver
 	 * which is the case if there is no VALUES clause in the given list or
 	 * there is a VALUES clause but only as the very last element of the list.
 	 *
-	 * Throws an {@link MyIllegalQueryException} if it discovers two
+	 * @throws MyIllegalQueryException if the given list contains two
 	 * VALUES clauses whose sets of variables are not disjoint.
+	 *
+	 * @throws MyUnsupportedQueryException if the given list contains
+	 * VALUES clauses and SERVICE clauses that are used in a way that is
+	 * currently not supported.
 	 */
 	protected static List<Element> expandValuesPlusServicePattern( final List<Element> elmts )
 			throws MyUnsupportedQueryException, MyIllegalQueryException
@@ -269,8 +306,8 @@ public class ValuesServiceQueryResolver
 
 		// If the remaining query elements have been changed and the first
 		// VALUES clause (based on which they have been changed) is the first
-		// element of the given list of query elements, then the rewritten
-		// version of the remaining elements is the result of this function.
+		// element of the given list of query elements, then the result of
+		// this function is the rewritten version of the remaining elements.
 		if ( posFirstValuesClause == 0 ) {
 			return rewrittenRemainder;
 		}
@@ -298,8 +335,12 @@ public class ValuesServiceQueryResolver
 	 * is the very last position of the list and there is another VALUES
 	 * clause at that position.
 	 *
-	 * Throws an {@link MyIllegalQueryException} if it discovers two
+	 * @throws MyIllegalQueryException if the given list contains two
 	 * VALUES clauses whose sets of variables are not disjoint.
+	 *
+	 * @throws MyUnsupportedQueryException if the given list contains
+	 * VALUES clauses and SERVICE clauses that are used in a way that is
+	 * currently not supported.
 	 */
 	protected static List<Element> expandValuesPlusServicePattern( final List<Element> elmts,
 	                                                               final ElementData valClause,
@@ -361,7 +402,10 @@ public class ValuesServiceQueryResolver
 
 		// Rewrite the elements that are in scope of the given VALUES clause
 		// (by using the solution mappings of the VALUES clause as a basis).
-		final List<Element> rewrittenValuesScope = rewrite(valClause, elmts, startPos, endOfScope );
+		final List<Element> rewrittenValuesScope = rewrite( elmts,
+		                                                    startPos,
+		                                                    endOfScope,
+		                                                    valClause );
 
 		// Create the resulting list of elements, for which we need to consider
 		// two cases: either there is no next VALUES clause or there is.
@@ -395,7 +439,8 @@ public class ValuesServiceQueryResolver
 	 * list from the given position until the end of the list, then this
 	 * function returns -1.
 	 */
-	protected static int positionOfNextVALUES( final List<Element> elmts, final int startPos ) {
+	protected static int positionOfNextVALUES( final List<Element> elmts,
+	                                           final int startPos ) {
 		// We simply iterate over the list, starting from the
 		// given position, until we find a VALUES clause.
 		int i = startPos - 1;
@@ -413,8 +458,8 @@ public class ValuesServiceQueryResolver
 	 * Merges the two given VALUES clauses into a single one by creating
 	 * a cross-product of their respective sets of solution mappings.
 	 *
-	 * Throws an {@link MyIllegalQueryException} if the sets of variables
-	 * of the two given VALUES clauses are not disjoint.
+	 * @throws MyIllegalQueryException if the sets of variables of the two
+	 * given VALUES clauses are not disjoint.
 	 */
 	protected static ElementData merge( final ElementData valClause1,
 	                                    final ElementData valClause2 )
@@ -454,10 +499,10 @@ public class ValuesServiceQueryResolver
 	 * elements from the given start position until (and including) the given
 	 * end position. Assumes that none of these elements is a VALUES clause.
 	 */
-	protected static List<Element> rewrite( final ElementData valClause,
-	                                        final List<Element> elmts,
+	protected static List<Element> rewrite( final List<Element> elmts,
 	                                        final int startPos,
-	                                        final int endPos ) {
+	                                        final int endPos,
+	                                        final ElementData valClause ) {
 		// First, we handle the special case in which the given
 		// VALUES clause contains only one solution mapping. In
 		// this case, we simply rewrite the relevant list elements
@@ -465,7 +510,7 @@ public class ValuesServiceQueryResolver
 		// use the multi-request operator in this case.
 		if ( valClause.getRows().size() == 1 ) {
 			final Binding firstRow = valClause.getRows().get(0);
-			return rewrite( firstRow, elmts, startPos, endPos, valClause.getVars() );
+			return rewrite( elmts, startPos, endPos, firstRow, valClause.getVars() );
 		}
 
 		// Now we check whether we can use the multi-request operator.
@@ -474,7 +519,7 @@ public class ValuesServiceQueryResolver
 		// relevant list elements include only one SERVICE clause that
 		// has a variable as service node, where this variable must be
 		// the one assigned by the VALUES clause.
-		if ( valClause.getVars().size() == 1 ) {
+		if ( useMultiRequestOperators && valClause.getVars().size() == 1 ) {
 			final List<Element> result = new ArrayList<>( endPos - startPos + 1 );
 			boolean foundServiceWithVariable = false;
 			for ( int i = startPos; i <= endPos; i++ ) {
@@ -517,14 +562,18 @@ public class ValuesServiceQueryResolver
 			return result;
 		}
 
-		// If the given VALUES clause contains more than one column / variable
-		// and more than one row / solution mapping, then we need to combine
+		// If the given VALUES clause contains more than one column/variable
+		// and more than one row/solution mapping, then we need to combine
 		// the rewritings obtained based on each of these solution mappings
 		// into a UNION pattern. The rewriting created based on the first
 		// solution mapping becomes the first part of this UNION pattern.
 		final Iterator<Binding> it = valClause.getRows().iterator();
 		final Binding firstRow = it.next();
-		final List<Element> rewriteUsingFirstRow = rewrite( firstRow, elmts, startPos, endPos, valClause.getVars() );
+		final List<Element> rewriteUsingFirstRow = rewrite( elmts,
+		                                                    startPos,
+		                                                    endPos,
+		                                                    firstRow,
+		                                                    valClause.getVars() );
 		final ElementUnion eu = new ElementUnion();
 		eu.addElement( ElementUtils.createElementGroupIfNeeded(rewriteUsingFirstRow) );
 
@@ -533,7 +582,11 @@ public class ValuesServiceQueryResolver
 		// and add each of the resulting rewritings as another part of the
 		// UNION clause.
 		while ( it.hasNext() ) {
-			final List<Element> rewriteUsingNextRow = rewrite( it.next(), elmts, startPos, endPos, valClause.getVars() );
+			final List<Element> rewriteUsingNextRow = rewrite( elmts,
+			                                                   startPos,
+			                                                   endPos,
+			                                                   it.next(),
+			                                                   valClause.getVars() );
 			eu.addElement( ElementUtils.createElementGroupIfNeeded(rewriteUsingNextRow) );
 		}
 
@@ -553,10 +606,10 @@ public class ValuesServiceQueryResolver
 	 * the variable, then a BIND clause is added that assigns the variable to
 	 * the corresponding RDF term of the solution mapping.
 	 */
-	protected static List<Element> rewrite( final Binding solmap,
-	                                        final List<Element> elmts,
+	protected static List<Element> rewrite( final List<Element> elmts,
 	                                        final int startPos,
 	                                        final int endPos,
+	                                        final Binding solmap,
 	                                        final List<Var> varsForBind ) {
 		// Initialization of the element transformer that changes the SERVICE
 		// clauses and of the group pattern into which the potentially rewritten

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/utils/FederationAccessUtils.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/federation/access/utils/FederationAccessUtils.java
@@ -6,6 +6,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 
 import se.liu.ida.hefquin.base.utils.CompletableFutureUtils;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiRequest;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
 import se.liu.ida.hefquin.federation.FederationMember;
 import se.liu.ida.hefquin.federation.access.*;
@@ -68,41 +69,64 @@ public class FederationAccessUtils
 	                                                                final LogicalOpRequest<?,?>... reqOps )
 					throws FederationAccessException
 	{
-		return performCardinalityRequests( fedAccessMgr, Arrays.asList(reqOps) );
+		return performCardinalityRequests( fedAccessMgr, Arrays.asList(reqOps), null );
 	}
 
 	public static CardinalityResponse[] performCardinalityRequests( final FederationAccessManager fedAccessMgr,
-	                                                                final List<LogicalOpRequest<?,?>> reqOps )
+	                                                                final List<LogicalOpRequest<?,?>> reqOps,
+	                                                                final List<LogicalOpMultiRequest> mreqOps )
 					throws FederationAccessException
 	{
+		// First, determine the number of cardinality requests needed to do.
+		int numberOfCardReqs = 0;
+		if ( reqOps != null && ! reqOps.isEmpty() ) {
+			numberOfCardReqs += reqOps.size();
+		}
+		if ( mreqOps != null && ! mreqOps.isEmpty() ) {
+			for ( final LogicalOpMultiRequest mreq : mreqOps )
+				numberOfCardReqs += mreq.getFederationMembers().size();
+		}
+
 		@SuppressWarnings("unchecked")
-		final CompletableFuture<CardinalityResponse>[] futures = new CompletableFuture[reqOps.size()];
+		final CompletableFuture<CardinalityResponse>[] futures = new CompletableFuture[numberOfCardReqs];
 
-		for ( int i = 0; i < reqOps.size(); ++i ) {
-			final LogicalOpRequest<?,?> reqOp = reqOps.get(i);
-			final DataRetrievalRequest req = reqOp.getRequest();
-			final FederationMember fm = reqOp.getFederationMember();
-			if ( fm instanceof SPARQLEndpoint && req instanceof SPARQLRequest ) {
-				futures[i] = fedAccessMgr.issueCardinalityRequest( (SPARQLRequest) req, (SPARQLEndpoint) fm );
-			}
-			else if ( fm instanceof TPFServer && req instanceof TriplePatternRequest ) {
-				final TPFRequest reqTPF = ensureTPFRequest( (TriplePatternRequest) req );
-				futures[i] = fedAccessMgr.issueCardinalityRequest( reqTPF, (TPFServer) fm );
-			}
-			else if ( fm instanceof BRTPFServer && req instanceof TriplePatternRequest ) {
-				final TPFRequest reqTPF = ensureTPFRequest( (TriplePatternRequest) req );
-				futures[i] = fedAccessMgr.issueCardinalityRequest( reqTPF, (BRTPFServer) fm );
-			}
-			else if ( fm instanceof BRTPFServer && req instanceof BindingsRestrictedTriplePatternRequest ) {
-				final BRTPFRequest reqBRTPF = ensureBRTPFRequest( (BindingsRestrictedTriplePatternRequest) req );
-				futures[i] = fedAccessMgr.issueCardinalityRequest( reqBRTPF, (BRTPFServer) fm );
-			}
-			else {
-				throw new IllegalArgumentException("Unsupported combination of federation member (type: " + fm.getClass().getName() + ") and request type (" + req.getClass().getName() + ")");
-			}
+		if ( reqOps != null && ! reqOps.isEmpty() ) {
+			for ( int i = 0; i < reqOps.size(); ++i ) {
+				final LogicalOpRequest<?,?> reqOp = reqOps.get(i);
+				final DataRetrievalRequest req = reqOp.getRequest();
+				final FederationMember fm = reqOp.getFederationMember();
+				if ( fm instanceof SPARQLEndpoint && req instanceof SPARQLRequest ) {
+					futures[i] = fedAccessMgr.issueCardinalityRequest( (SPARQLRequest) req, (SPARQLEndpoint) fm );
+				}
+				else if ( fm instanceof TPFServer && req instanceof TriplePatternRequest ) {
+					final TPFRequest reqTPF = ensureTPFRequest( (TriplePatternRequest) req );
+					futures[i] = fedAccessMgr.issueCardinalityRequest( reqTPF, (TPFServer) fm );
+				}
+				else if ( fm instanceof BRTPFServer && req instanceof TriplePatternRequest ) {
+					final TPFRequest reqTPF = ensureTPFRequest( (TriplePatternRequest) req );
+					futures[i] = fedAccessMgr.issueCardinalityRequest( reqTPF, (BRTPFServer) fm );
+				}
+				else if ( fm instanceof BRTPFServer && req instanceof BindingsRestrictedTriplePatternRequest ) {
+					final BRTPFRequest reqBRTPF = ensureBRTPFRequest( (BindingsRestrictedTriplePatternRequest) req );
+					futures[i] = fedAccessMgr.issueCardinalityRequest( reqBRTPF, (BRTPFServer) fm );
+				}
+				else {
+					throw new IllegalArgumentException("Unsupported combination of federation member (type: " + fm.getClass().getName() + ") and request type (" + req.getClass().getName() + ")");
+				}
 
-			if ( futures[i] == null ) {
-				throw new FederationAccessException("Unexpected null returned by the federation access manager (i=" + i + ")", req, fm);
+				if ( futures[i] == null ) {
+					throw new FederationAccessException("Unexpected null returned by the federation access manager (i=" + i + ")", req, fm);
+				}
+			}
+		}
+
+		if ( mreqOps != null && ! mreqOps.isEmpty() ) {
+			int i = (reqOps == null) ? 0 : reqOps.size();
+			for ( final LogicalOpMultiRequest mreqOp : mreqOps ) {
+				final SPARQLRequest req = mreqOp.getRequest();
+				for ( final FederationMember fm : mreqOp.getFederationMembers() ) {
+					futures[i++] = fedAccessMgr.issueCardinalityRequest(req, fm);
+				}
 			}
 		}
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpMultiRequest.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpMultiRequest.java
@@ -1,11 +1,10 @@
 package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.Vector;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
 
 import org.apache.jena.graph.Node;
@@ -39,10 +38,12 @@ public class ExecOpMultiRequest extends NullaryExecutableOpBase
 	protected final boolean serviceVarIsInPattern;
 
 	// statistics
-	private AtomicLong numberOfOutputMappingsProduced = new AtomicLong(0L);
 	protected int numberOfRequestsIssued = 0;
-	protected List<Long> requestDurationsInMS = new Vector<>(); // Vector is thread safe
-	protected List<Integer> numOfSolMapsRetrievedPerReq = new Vector<>();
+	// (access to any of the following three statistics must be
+	//  synchronized on the first of them, requestDurationsInMS)
+	private List<Long> requestDurationsInMS = new ArrayList<>();
+	private List<Integer> numOfSolMapsRetrievedPerReq = new ArrayList<>();
+	private long numberOfOutputMappingsProduced = 0L;
 
 	public ExecOpMultiRequest( final SPARQLRequest req,
 	                           final Var serviceVar,
@@ -70,13 +71,18 @@ public class ExecOpMultiRequest extends NullaryExecutableOpBase
 	protected void _execute( final IntermediateResultElementSink sink,
 	                         final QueryProcContextExt ctx )
 			throws ExecOpExecutionException {
-		log.debug( "Starting to execute multi-request for {}", serviceVar.toString() );
+		log.debug( "Starting to execute the multi-request operator for {}", serviceVar.toString() );
 
+		// Create an array to collect the CompletableFuture:s for all
+		// the requests that we are going to issue (which will be one
+		// per federation member covered by this operator).
 		final CompletableFuture<?>[] futures = new CompletableFuture[ fms.size() ];
 
 		int i = 0;
 		for ( final FederationMember fm : fms ) {
-			// Issue the request via the federation access manager.
+			// For every federation member covered by this operator:
+			// i) issue the request of this operator via the federation
+			// access manager, ...
 			final CompletableFuture<SolMapsResponse> f;
 			try {
 				f = ctx.getFederationAccessMgr().issueRequest(req, fm);
@@ -87,23 +93,25 @@ public class ExecOpMultiRequest extends NullaryExecutableOpBase
 
 			numberOfRequestsIssued++;
 
-			// Create a response processor that shall handle the response
-			// obtained via the request.
+			// ... ii) create a response processor that shall handle the
+			// response obtained via the request issued in the previous
+			// step, and ...
 			final Consumer<SolMapsResponse> respProc;
 			if ( serviceVarIsInPattern )
 				respProc = new MyResponseProcessor2( fm.getServiceURI(), sink );
 			else
 				respProc = new MyResponseProcessor1( fm.getServiceURI(), sink );
 
-			// Attach the response processor to the future for the request and
-			// remember the future so that we can wait for its completion later.
+			// ... iii) attach the response processor to the future for
+			// the request and remember the future so that we can wait
+			// for its completion later.
 			futures[i++] = f.thenAccept(respProc);
 		}
 
-		// Now we wait for all the futures to be completed. Note that this
-		// needs to be done outside of the previous if-block because, even
-		// if we had to switch into full-retrieval mode, we may have futures
-		// from before we made that switch.
+		log.debug( "All requests for the multi-request operator for {} are issued; waiting for them to complete now.", serviceVar.toString() );
+
+		// Now we simply wait for all the futures to be completed. Once
+		// they are, the execution of this operator is finished.
 		final CompletableFuture<?> combinedFuture = CompletableFuture.allOf(futures);
 		try {
 			combinedFuture.get();
@@ -114,25 +122,74 @@ public class ExecOpMultiRequest extends NullaryExecutableOpBase
 		catch ( final ExecutionException e ) {
 			throw new ExecOpExecutionException("The execution of the futures that perform the requests and process the responses caused an exception.", e, this);
 		}
+
+		log.debug( "Execution of the multi-request operator for {} is finished.", serviceVar.toString() );
 	}
 
 	@Override
 	public void resetStats() {
 		super.resetStats();
-//		timeAfterResponse = 0L;
-//		solMapsRetrieved = 0L;
-//		numberOfOutputMappingsProduced = 0L;
+
+		numberOfRequestsIssued = 0;
+
+		synchronized (requestDurationsInMS) {
+			requestDurationsInMS.clear();
+			numOfSolMapsRetrievedPerReq.clear();
+			numberOfOutputMappingsProduced = 0L;
+		}
 	}
 
 	protected ExecutableOperatorStatsImpl createStats() {
 		final ExecutableOperatorStatsImpl s = super.createStats();
-//		s.put( "requestExecTime",                Long.valueOf( timeAtExecEnd - timeAfterResponse ) );
-//		s.put( "responseProcTime",               Long.valueOf( timeAfterResponse - timeAtExecStart ) );
-//		s.put( "solMapsRetrieved",               Long.valueOf( solMapsRetrieved ) );
-//		s.put( "numberOfOutputMappingsProduced", Long.valueOf( numberOfOutputMappingsProduced ) );
+
+		final double avgRequestDurationInMS;
+		long minRequestDurationInMS = Long.MAX_VALUE;
+		long maxRequestDurationInMS = Long.MIN_VALUE;
+		final double avgNumOfSolMapsRetrievedPerReq;
+		int minNumOfSolMapsRetrievedPerReq = Integer.MAX_VALUE;
+		int maxNumOfSolMapsRetrievedPerReq = Integer.MIN_VALUE;
+		final long totalNumOfSolMapsRetrieved;
+		final long outputSize;
+		synchronized (requestDurationsInMS) {
+			long sumRequestDuration = 0L;
+			for ( final long x : requestDurationsInMS ) {
+				sumRequestDuration += x;
+				if ( x < minRequestDurationInMS ) minRequestDurationInMS = x;
+				if ( x > maxRequestDurationInMS ) maxRequestDurationInMS = x;
+			}
+
+			long sumSolMapsRetrieved = 0L;
+			for ( final int x : numOfSolMapsRetrievedPerReq ) {
+				sumSolMapsRetrieved += x;
+				if ( x < minNumOfSolMapsRetrievedPerReq ) minNumOfSolMapsRetrievedPerReq = x;
+				if ( x > maxNumOfSolMapsRetrievedPerReq ) maxNumOfSolMapsRetrievedPerReq = x;
+			}
+
+			avgRequestDurationInMS = sumRequestDuration / requestDurationsInMS.size();
+			avgNumOfSolMapsRetrievedPerReq = sumSolMapsRetrieved / numOfSolMapsRetrievedPerReq.size();
+			totalNumOfSolMapsRetrieved = sumSolMapsRetrieved;
+			outputSize = numberOfOutputMappingsProduced;
+		}
+
+		s.put( "numberOfRequestsIssued",          Integer.valueOf(numberOfRequestsIssued) );
+		s.put( "avgRequestDurationInMS",          Double.valueOf(avgRequestDurationInMS) );
+		s.put( "minRequestDurationInMS",          Long.valueOf(minRequestDurationInMS) );
+		s.put( "maxRequestDurationInMS",          Long.valueOf(maxRequestDurationInMS) );
+		s.put( "avgNumOfSolMapsRetrievedPerReq",  Double.valueOf(avgNumOfSolMapsRetrievedPerReq) );
+		s.put( "minNumOfSolMapsRetrievedPerReq",  Integer.valueOf(minNumOfSolMapsRetrievedPerReq) );
+		s.put( "maxNumOfSolMapsRetrievedPerReq",  Integer.valueOf(maxNumOfSolMapsRetrievedPerReq) );
+		s.put( "totalNumOfSolMapsRetrieved",      Long.valueOf(totalNumOfSolMapsRetrieved) );
+		s.put( "numberOfOutputMappingsProduced",  Long.valueOf(outputSize) );
+
 		return s;
 	}
 
+	/**
+	 * This response processor can be used for cases in which the service
+	 * variable of this operator is not in the request of this operator
+	 * and, thus, does not show up in the solution mappings obtained via
+	 * this request.
+	 */
 	protected class MyResponseProcessor1 implements Consumer<SolMapsResponse> {
 		protected final Node serviceURI;
 		protected final IntermediateResultElementSink sink;
@@ -172,7 +229,11 @@ public class ExecOpMultiRequest extends NullaryExecutableOpBase
 				}
 			}
 
-			numberOfOutputMappingsProduced.addAndGet(cntOut);
+			synchronized (requestDurationsInMS) {
+				requestDurationsInMS.add( response.getRequestDuration().toMillis() );
+				numOfSolMapsRetrievedPerReq.add(cntIn);
+				numberOfOutputMappingsProduced += cntOut;
+			}
 
 			log.info("Retrieved {} solution mappings from the endpoint with service URI {}, and produced {} output solution mappings from them", cntIn, serviceURI, cntOut);
 		}
@@ -184,6 +245,13 @@ public class ExecOpMultiRequest extends NullaryExecutableOpBase
 		}
 	}
 
+	/**
+	 * This response processor can be used for cases in which the service
+	 * variable of this operator is also in the request of this operator,
+	 * which means that the solution mappings obtained via this request
+	 * may already have a binding for this variable and, thus, need to
+	 * be checked for compatibility.
+	 */
 	protected class MyResponseProcessor2 extends MyResponseProcessor1 {
 		public MyResponseProcessor2( final String serviceURI,
 		                             final IntermediateResultElementSink sink ) {

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpMultiRequest.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpMultiRequest.java
@@ -1,0 +1,215 @@
+package se.liu.ida.hefquin.engine.queryplan.executable.impl.ops;
+
+import java.util.List;
+import java.util.Set;
+import java.util.Vector;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
+import org.apache.jena.sparql.core.Var;
+import org.apache.jena.sparql.engine.binding.BindingBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import se.liu.ida.hefquin.base.data.SolutionMapping;
+import se.liu.ida.hefquin.base.data.impl.SolutionMappingImpl;
+import se.liu.ida.hefquin.base.query.ExpectedVariables;
+import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
+import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
+import se.liu.ida.hefquin.engine.queryproc.QueryProcContextExt;
+import se.liu.ida.hefquin.federation.FederationMember;
+import se.liu.ida.hefquin.federation.access.FederationAccessException;
+import se.liu.ida.hefquin.federation.access.SPARQLRequest;
+import se.liu.ida.hefquin.federation.access.SolMapsResponse;
+import se.liu.ida.hefquin.federation.access.UnsupportedOperationDueToRetrievalError;
+
+public class ExecOpMultiRequest extends NullaryExecutableOpBase
+{
+	private static final Logger log = LoggerFactory.getLogger( ExecOpMultiRequest.class );
+
+	protected final SPARQLRequest req;
+	protected final Var serviceVar;
+	protected final Set<FederationMember> fms;
+	protected final boolean serviceVarIsInPattern;
+
+	// statistics
+	private AtomicLong numberOfOutputMappingsProduced = new AtomicLong(0L);
+	protected int numberOfRequestsIssued = 0;
+	protected List<Long> requestDurationsInMS = new Vector<>(); // Vector is thread safe
+	protected List<Integer> numOfSolMapsRetrievedPerReq = new Vector<>();
+
+	public ExecOpMultiRequest( final SPARQLRequest req,
+	                           final Var serviceVar,
+	                           final Set<FederationMember> fms,
+	                           final boolean collectExceptions,
+	                           final QueryPlanningInfo qpInfo ) {
+		super( req.getDistinctRequired(), collectExceptions, qpInfo );
+
+		assert req != null;
+		assert serviceVar != null;
+		assert fms != null;
+
+		this.req = req;
+		this.serviceVar = serviceVar;
+		this.fms = fms;
+
+		final ExpectedVariables expVars = req.getQueryPattern().getExpectedVariables();
+		serviceVarIsInPattern =    expVars.getCertainVariables().contains(serviceVar)
+		                        || expVars.getPossibleVariables().contains(serviceVar);
+
+		log.debug( "Initialized ExecOpMultiRequest for {}", serviceVar.toString() );
+	}
+
+	@Override
+	protected void _execute( final IntermediateResultElementSink sink,
+	                         final QueryProcContextExt ctx )
+			throws ExecOpExecutionException {
+		log.debug( "Starting to execute multi-request for {}", serviceVar.toString() );
+
+		final CompletableFuture<?>[] futures = new CompletableFuture[ fms.size() ];
+
+		int i = 0;
+		for ( final FederationMember fm : fms ) {
+			// Issue the request via the federation access manager.
+			final CompletableFuture<SolMapsResponse> f;
+			try {
+				f = ctx.getFederationAccessMgr().issueRequest(req, fm);
+			}
+			catch ( final FederationAccessException e ) {
+				throw new ExecOpExecutionException("Issuing a request caused an exception.", e, this);
+			}
+
+			numberOfRequestsIssued++;
+
+			// Create a response processor that shall handle the response
+			// obtained via the request.
+			final Consumer<SolMapsResponse> respProc;
+			if ( serviceVarIsInPattern )
+				respProc = new MyResponseProcessor2( fm.getServiceURI(), sink );
+			else
+				respProc = new MyResponseProcessor1( fm.getServiceURI(), sink );
+
+			// Attach the response processor to the future for the request and
+			// remember the future so that we can wait for its completion later.
+			futures[i++] = f.thenAccept(respProc);
+		}
+
+		// Now we wait for all the futures to be completed. Note that this
+		// needs to be done outside of the previous if-block because, even
+		// if we had to switch into full-retrieval mode, we may have futures
+		// from before we made that switch.
+		final CompletableFuture<?> combinedFuture = CompletableFuture.allOf(futures);
+		try {
+			combinedFuture.get();
+		}
+		catch ( final InterruptedException e ) {
+			throw new ExecOpExecutionException("Interruption of the futures that perform the requests and process the responses", e, this);
+		}
+		catch ( final ExecutionException e ) {
+			throw new ExecOpExecutionException("The execution of the futures that perform the requests and process the responses caused an exception.", e, this);
+		}
+	}
+
+	@Override
+	public void resetStats() {
+		super.resetStats();
+//		timeAfterResponse = 0L;
+//		solMapsRetrieved = 0L;
+//		numberOfOutputMappingsProduced = 0L;
+	}
+
+	protected ExecutableOperatorStatsImpl createStats() {
+		final ExecutableOperatorStatsImpl s = super.createStats();
+//		s.put( "requestExecTime",                Long.valueOf( timeAtExecEnd - timeAfterResponse ) );
+//		s.put( "responseProcTime",               Long.valueOf( timeAfterResponse - timeAtExecStart ) );
+//		s.put( "solMapsRetrieved",               Long.valueOf( solMapsRetrieved ) );
+//		s.put( "numberOfOutputMappingsProduced", Long.valueOf( numberOfOutputMappingsProduced ) );
+		return s;
+	}
+
+	protected class MyResponseProcessor1 implements Consumer<SolMapsResponse> {
+		protected final Node serviceURI;
+		protected final IntermediateResultElementSink sink;
+
+		public MyResponseProcessor1( final String serviceURI,
+		                             final IntermediateResultElementSink sink ) {
+			this( NodeFactory.createURI(serviceURI), sink );
+		}
+
+		public MyResponseProcessor1( final Node serviceURI,
+		                             final IntermediateResultElementSink sink ) {
+			this.serviceURI = serviceURI;
+			this.sink = sink;
+		}
+
+		@Override
+		public void accept( final SolMapsResponse response ) {
+			log.info("Received response from endpoint with service URI {}", serviceURI);
+
+			final Iterable<SolutionMapping> solMaps;
+			try {
+				solMaps = response.getResponseData();
+			}
+			catch ( final UnsupportedOperationDueToRetrievalError e ) {
+				recordException( "Accessing the response caused an exception that indicates a data retrieval error (message: " + e.getMessage() + ").", e );
+				return;
+			}
+
+			int cntIn = 0;
+			int cntOut = 0;
+			for ( final SolutionMapping sm : solMaps ) {
+				cntIn++;
+				final SolutionMapping sm2 = tryToExtend(sm);
+				if ( sm2 != null ) {
+					sink.send(sm2);
+					cntOut++;
+				}
+			}
+
+			numberOfOutputMappingsProduced.addAndGet(cntOut);
+
+			log.info("Retrieved {} solution mappings from the endpoint with service URI {}, and produced {} output solution mappings from them", cntIn, serviceURI, cntOut);
+		}
+
+		protected SolutionMapping tryToExtend( final SolutionMapping sm ) {
+			final BindingBuilder bb = BindingBuilder.create( sm.asJenaBinding() );
+			bb.add(serviceVar, serviceURI);
+			return new SolutionMappingImpl( bb.build() );
+		}
+	}
+
+	protected class MyResponseProcessor2 extends MyResponseProcessor1 {
+		public MyResponseProcessor2( final String serviceURI,
+		                             final IntermediateResultElementSink sink ) {
+			super(serviceURI, sink);
+		}
+
+		public MyResponseProcessor2( final Node serviceURI,
+		                             final IntermediateResultElementSink sink ) {
+			super(serviceURI, sink);
+		}
+
+		@Override
+		protected SolutionMapping tryToExtend( final SolutionMapping sm ) {
+			final Node n = sm.asJenaBinding().get(serviceVar);
+			if ( n == null )
+				return super.tryToExtend(sm);
+			else if ( n.equals(serviceURI) )
+				return sm;
+			else
+				return null;
+		}
+	}
+
+	protected void recordException( final String msg,
+	                                final Exception cause ) {
+		final ExecOpExecutionException e = new ExecOpExecutionException(msg, cause, this);
+		recordExceptionCaughtDuringExecution(e);
+	}
+}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpMultiRequest.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpMultiRequest.java
@@ -11,12 +11,20 @@ import org.apache.jena.graph.Node;
 import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.engine.binding.BindingBuilder;
+import org.apache.jena.sparql.expr.E_Bound;
+import org.apache.jena.sparql.expr.E_Equals;
+import org.apache.jena.sparql.expr.E_LogicalNot;
+import org.apache.jena.sparql.expr.E_LogicalOr;
+import org.apache.jena.sparql.expr.Expr;
+import org.apache.jena.sparql.expr.ExprVar;
+import org.apache.jena.sparql.expr.NodeValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import se.liu.ida.hefquin.base.data.SolutionMapping;
 import se.liu.ida.hefquin.base.data.impl.SolutionMappingImpl;
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
+import se.liu.ida.hefquin.base.query.SPARQLGraphPattern;
 import se.liu.ida.hefquin.engine.queryplan.executable.ExecOpExecutionException;
 import se.liu.ida.hefquin.engine.queryplan.executable.IntermediateResultElementSink;
 import se.liu.ida.hefquin.engine.queryplan.executable.impl.ExecutableOperatorStatsImpl;
@@ -27,7 +35,31 @@ import se.liu.ida.hefquin.federation.access.FederationAccessException;
 import se.liu.ida.hefquin.federation.access.SPARQLRequest;
 import se.liu.ida.hefquin.federation.access.SolMapsResponse;
 import se.liu.ida.hefquin.federation.access.UnsupportedOperationDueToRetrievalError;
+import se.liu.ida.hefquin.federation.access.impl.req.SPARQLRequestImpl;
 
+/**
+ * Issues the same request (same query pattern) at multiple federation members
+ * and processes their respective responses, all in parallel. Every solution
+ * mapping obtained via each such response is extended with a binding for the
+ * given service variable and, then, passed on to the output. Specifically,
+ * the service variable is assigned to the service URI of the corresponding
+ * federation member.
+ * <p>
+ * In cases in which the query pattern of this request mentions the service
+ * variable, the implementation checks that the solution mappings obtained
+ * via a response bind this variable to the service URI of the federation
+ * member from which the response was received. As an additional optimization,
+ * to avoid even receiving the solution mappings that will be filtered out
+ * by this check, the implementation tries to add the following member-specific
+ * FILTER condition into the requests (which is possible only for federation
+ * members that support requests with FILTER conditions; e.g., SPARQL
+ * endpoints):
+ * <p>
+ * (! BOUND(?s)) || (?s = _uri_)
+ * <p>
+ * where ?s is the service variable and _uri_ is the service URI of the
+ * federation member.
+ */
 public class ExecOpMultiRequest extends NullaryExecutableOpBase
 {
 	private static final Logger log = LoggerFactory.getLogger( ExecOpMultiRequest.class );
@@ -35,7 +67,12 @@ public class ExecOpMultiRequest extends NullaryExecutableOpBase
 	protected final SPARQLRequest req;
 	protected final Var serviceVar;
 	protected final Set<FederationMember> fms;
+
 	protected final boolean serviceVarIsInPattern;
+
+	// to be created by {@link #makeRequestMemberSpecific} if needed
+	protected ExprVar serviceVarForExpressions = null;
+	protected Expr subExpr1 = null;
 
 	// statistics
 	protected int numberOfRequestsIssued = 0;
@@ -81,11 +118,28 @@ public class ExecOpMultiRequest extends NullaryExecutableOpBase
 		int i = 0;
 		for ( final FederationMember fm : fms ) {
 			// For every federation member covered by this operator:
-			// i) issue the request of this operator via the federation
-			// access manager, ...
+
+			// i) if the graph pattern of the request of this operator
+			// mentions the service variable, create a member-specific
+			// version of this request in which the graph pattern is
+			// append with a FILTER that restricts the service variable
+			// to the service URI of the federation member;
+			final SPARQLRequest req2;
+			if ( serviceVarIsInPattern ) {
+				final SPARQLRequest tmp = makeRequestMemberSpecific(fm);
+				// If the federation member does not support the member-
+				// specific version of the request, fall back to the
+				// original request.
+				req2 = ( tmp != null ) ? tmp : req;
+			}
+			else {
+				req2 = req;
+			}
+
+			// ii) issue the request via the federation access manager;
 			final CompletableFuture<SolMapsResponse> f;
 			try {
-				f = ctx.getFederationAccessMgr().issueRequest(req, fm);
+				f = ctx.getFederationAccessMgr().issueRequest(req2, fm);
 			}
 			catch ( final FederationAccessException e ) {
 				throw new ExecOpExecutionException("Issuing a request caused an exception.", e, this);
@@ -93,18 +147,18 @@ public class ExecOpMultiRequest extends NullaryExecutableOpBase
 
 			numberOfRequestsIssued++;
 
-			// ... ii) create a response processor that shall handle the
+			// iii) create a response processor that shall handle the
 			// response obtained via the request issued in the previous
-			// step, and ...
+			// step;
 			final Consumer<SolMapsResponse> respProc;
 			if ( serviceVarIsInPattern )
 				respProc = new MyResponseProcessor2( fm.getServiceURI(), sink );
 			else
 				respProc = new MyResponseProcessor1( fm.getServiceURI(), sink );
 
-			// ... iii) attach the response processor to the future for
-			// the request and remember the future so that we can wait
-			// for its completion later.
+			// iv) attach the response processor to the future for the
+			// request and remember the future so that we can wait for
+			// its completion later.
 			futures[i++] = f.thenAccept(respProc);
 		}
 
@@ -124,6 +178,46 @@ public class ExecOpMultiRequest extends NullaryExecutableOpBase
 		}
 
 		log.debug( "Execution of the multi-request operator for {} is finished.", serviceVar.toString() );
+	}
+
+	/**
+	 * Returns a request with a graph pattern that is created by extending
+	 * the graph pattern of {@link #req} with a FILTER of the form
+	 *
+	 *    (! BOUND(?s)) || (?s = _uri_)
+	 *
+	 * where ?s is the service variable (see {@link #serviceVar}) and
+	 * _uri_ is the service URI of the given federation member. If the
+	 * given federation member does not support the extended graph
+	 * pattern, <code>null</code> is returned.
+	 */
+	protected SPARQLRequest makeRequestMemberSpecific( final FederationMember fm ) {
+		if ( ! fm.supportsMoreThanTriplePatterns() )
+			return null;
+
+		// Since the first subexpression is independent of the federation
+		// member, we create only one copy of the Java object for it.
+		if ( subExpr1 == null ) {
+			serviceVarForExpressions = new ExprVar(serviceVar);
+			subExpr1 = new E_LogicalNot( new E_Bound(serviceVarForExpressions) );
+		}
+
+		// Create the second subexpression.
+		final Node serviceURI = NodeFactory.createURI( fm.getServiceURI() );
+		final Expr subExpr2 = new E_Equals( serviceVarForExpressions,
+		                                    NodeValue.makeNode(serviceURI) );
+
+		// Create the overall filter expression and append it to the graph
+		// pattern of the (general) request.
+		final Expr expr = new E_LogicalOr(subExpr1, subExpr2);
+		final SPARQLGraphPattern p = req.getQueryPattern().mergeWith(expr);
+
+		if ( ! fm.isSupportedPattern(p) )
+			return null;
+
+		return new SPARQLRequestImpl( p,
+		                              req.getProjectionVars(),
+		                              req.getDistinctRequired() );
 	}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanUtils.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanUtils.java
@@ -190,6 +190,9 @@ public class LogicalPlanUtils
 		public void visit( final LogicalOpRequest<?,?> op )     { subplanCount++; }
 
 		@Override
+		public void visit( final LogicalOpMultiRequest op )     { subplanCount++; }
+
+		@Override
 		public void visit( final LogicalOpFixedSolMap op )      { subplanCount++; }
 
 		@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanVisitor.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanVisitor.java
@@ -5,6 +5,7 @@ import se.liu.ida.hefquin.engine.queryplan.logical.impl.*;
 public interface LogicalPlanVisitor
 {
 	void visit( final LogicalOpRequest<?,?> op );
+	void visit( final LogicalOpMultiRequest op );
 	void visit( final LogicalOpFixedSolMap op );
 
 	void visit( final LogicalOpGPAdd op );

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanVisitorBase.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/LogicalPlanVisitorBase.java
@@ -8,6 +8,9 @@ public class LogicalPlanVisitorBase implements LogicalPlanVisitor
 	public void visit( final LogicalOpRequest<?,?> op )      {}
 
 	@Override
+	public void visit( final LogicalOpMultiRequest op )      {}
+
+	@Override
 	public void visit( final LogicalOpFixedSolMap op )       {}
 
 	@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalOpMultiRequest.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalOpMultiRequest.java
@@ -1,6 +1,9 @@
 package se.liu.ida.hefquin.engine.queryplan.logical.impl;
 
+import java.util.HashSet;
 import java.util.Set;
+
+import org.apache.jena.sparql.core.Var;
 
 import se.liu.ida.hefquin.base.query.ExpectedVariables;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanVisitor;
@@ -12,21 +15,29 @@ public class LogicalOpMultiRequest extends BaseForLogicalOps
                                    implements NullaryLogicalOp
 {
 	protected final SPARQLRequest req;
+	protected final Var var;
 	protected final Set<FederationMember> fms;
 
 	public LogicalOpMultiRequest( final SPARQLRequest req,
+	                              final Var var, 
 	                              final Set<FederationMember> fms ) {
 		super( req.getDistinctRequired() );
 
 		assert req != null;
+		assert var != null;
 		assert fms != null;
 
 		this.req = req;
+		this.var = var;
 		this.fms = fms;
 	}
 
 	public SPARQLRequest getRequest() {
 		return req;
+	}
+
+	public Var getServiceVariable() {
+		return var;
 	}
 
 	public Set<FederationMember> getFederationMembers() {
@@ -37,7 +48,33 @@ public class LogicalOpMultiRequest extends BaseForLogicalOps
 	public ExpectedVariables getExpectedVariables( final ExpectedVariables... inputVars ) {
 		assert inputVars.length == 0;
 
-		return req.getExpectedVariables();
+		// The expected variables of a multi-request operator are the
+		// expected variables of the request pattern, plus the service
+		// variable as another certain variable.
+
+		final ExpectedVariables reqEVars = req.getExpectedVariables();
+		final Set<Var> reqCVars = reqEVars.getCertainVariables();
+		final Set<Var> reqPVars = reqEVars.getPossibleVariables();
+
+		if ( reqCVars.contains(var) )
+			return reqEVars;
+
+		final Set<Var> myCertainVars = new HashSet<>(reqCVars);
+		myCertainVars.add(var);
+
+		final Set<Var> myPossibleVars;
+		if ( reqPVars.contains(var) ) {
+			myPossibleVars = new HashSet<>(reqPVars);
+			myPossibleVars.remove(var);
+		}
+		else {
+			myPossibleVars = reqPVars;
+		}
+
+		return new ExpectedVariables() {
+			@Override public Set<Var> getCertainVariables() { return myCertainVars; }
+			@Override public Set<Var> getPossibleVariables() { return myPossibleVars; }
+		};
 	}
 
 	@Override
@@ -52,16 +89,17 @@ public class LogicalOpMultiRequest extends BaseForLogicalOps
 
 		return (    o instanceof LogicalOpMultiRequest oo
 		         && oo.req.equals(req)
+		         && oo.var.equals(var)
 		         && oo.fms.equals(fms) );
 	}
 
 	@Override
 	public int hashCode() {
-		return getClass().hashCode() ^ req.hashCode() ^ fms.hashCode();
+		return getClass().hashCode() ^ req.hashCode() ^ var.hashCode() ^ fms.hashCode();
 	}
 
 	@Override
 	public String toString() {
-		return "mreq (req: " + req.hashCode() + ", fms: " + fms.hashCode() + ")";
+		return "mreq (var: " + var.toString() + ", req: " + req.hashCode() + ", fms: " + fms.hashCode() + ")";
 	}
 }

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalOpMultiRequest.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalOpMultiRequest.java
@@ -1,0 +1,67 @@
+package se.liu.ida.hefquin.engine.queryplan.logical.impl;
+
+import java.util.Set;
+
+import se.liu.ida.hefquin.base.query.ExpectedVariables;
+import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanVisitor;
+import se.liu.ida.hefquin.engine.queryplan.logical.NullaryLogicalOp;
+import se.liu.ida.hefquin.federation.FederationMember;
+import se.liu.ida.hefquin.federation.access.SPARQLRequest;
+
+public class LogicalOpMultiRequest extends BaseForLogicalOps
+                                   implements NullaryLogicalOp
+{
+	protected final SPARQLRequest req;
+	protected final Set<FederationMember> fms;
+
+	public LogicalOpMultiRequest( final SPARQLRequest req,
+	                              final Set<FederationMember> fms ) {
+		super( req.getDistinctRequired() );
+
+		assert req != null;
+		assert fms != null;
+
+		this.req = req;
+		this.fms = fms;
+	}
+
+	public SPARQLRequest getRequest() {
+		return req;
+	}
+
+	public Set<FederationMember> getFederationMembers() {
+		return fms;
+	}
+
+	@Override
+	public ExpectedVariables getExpectedVariables( final ExpectedVariables... inputVars ) {
+		assert inputVars.length == 0;
+
+		return req.getExpectedVariables();
+	}
+
+	@Override
+	public void visit( final LogicalPlanVisitor visitor ) {
+		visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals( final Object o ) {
+		if ( o == this )
+			return true;
+
+		return (    o instanceof LogicalOpMultiRequest oo
+		         && oo.req.equals(req)
+		         && oo.fms.equals(fms) );
+	}
+
+	@Override
+	public int hashCode() {
+		return getClass().hashCode() ^ req.hashCode() ^ fms.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return "mreq (req: " + req.hashCode() + ", fms: " + fms.hashCode() + ")";
+	}
+}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalOpMultiRequest.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/logical/impl/LogicalOpMultiRequest.java
@@ -11,6 +11,28 @@ import se.liu.ida.hefquin.engine.queryplan.logical.NullaryLogicalOp;
 import se.liu.ida.hefquin.federation.FederationMember;
 import se.liu.ida.hefquin.federation.access.SPARQLRequest;
 
+/**
+ * This operator has three arguments:
+ * i) a SPARQL graph pattern P (given in the form of a {@link SPARQLRequest},
+ * ii) a variable ?v, and
+ * iii) a set of federation members.
+ *
+ * The evaluation semantics is equivalent to the one of the following SPARQL
+ * query, assuming that the URIs in the VALUES clause are the service URIs
+ * of the given federation members.
+ * <pre>
+ * SELECT * WHERE {
+ *    VALUES ?v { ex:serviceURI_1 ex:serviceURI_2 ... ex:serviceURI_n }
+ *    SERVICE ?v {
+ *       # pattern P
+ *    }
+ * }
+ * </pre>
+ *
+ * Notice that every solution mapping in the result of this operator will
+ * bind the given variable ?v to the service URI of the federation member
+ * from which the rest of this solution mapping has been received.
+ */
 public class LogicalOpMultiRequest extends BaseForLogicalOps
                                    implements NullaryLogicalOp
 {

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/PhysicalPlanVisitor.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/PhysicalPlanVisitor.java
@@ -5,6 +5,7 @@ import se.liu.ida.hefquin.engine.queryplan.physical.impl.*;
 public interface PhysicalPlanVisitor
 {
 	void visit( PhysicalOpRequest<?,?> op );
+	void visit( PhysicalOpMultiRequest op );
 	void visit( PhysicalOpFixedSolMap op );
 
 	void visit( PhysicalOpBindJoinBRTPF op );

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpMultiRequest.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpMultiRequest.java
@@ -1,0 +1,93 @@
+package se.liu.ida.hefquin.engine.queryplan.physical.impl;
+
+import se.liu.ida.hefquin.base.query.ExpectedVariables;
+import se.liu.ida.hefquin.engine.queryplan.executable.NullaryExecutableOp;
+import se.liu.ida.hefquin.engine.queryplan.executable.impl.ops.ExecOpMultiRequest;
+import se.liu.ida.hefquin.engine.queryplan.info.QueryPlanningInfo;
+import se.liu.ida.hefquin.engine.queryplan.logical.LogicalOperator;
+import se.liu.ida.hefquin.engine.queryplan.logical.NullaryLogicalOp;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiRequest;
+import se.liu.ida.hefquin.engine.queryplan.physical.NullaryPhysicalOpForLogicalOp;
+import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalOpFactory;
+import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
+
+/**
+ * A physical operator that performs requests with the same graph
+ * pattern at multiple federation members in parallel and, then,
+ * outputs the solution mappings obtained via all these requests,
+ * where each solution mapping is extended with a binding that
+ * captures the service variable with the service URI of the
+ * federation member from which it was obtained.
+ *
+ * The actual algorithm of this operator is implemented in the
+ * {@link ExecOpMultiRequest} class.
+ */
+public class PhysicalOpMultiRequest implements NullaryPhysicalOpForLogicalOp
+{
+	protected static final Factory factory = new Factory();
+	public static PhysicalOpFactory getFactory() { return factory; }
+
+	protected final LogicalOpMultiRequest lop;
+
+	protected PhysicalOpMultiRequest( final LogicalOpMultiRequest lop ) {
+		assert lop != null;
+		this.lop = lop;
+	}
+
+	@Override
+	public LogicalOpMultiRequest getLogicalOperator() {
+		return lop;
+	}
+
+	@Override
+	public NullaryExecutableOp createExecOp( final boolean collectExceptions,
+	                                         final QueryPlanningInfo qpInfo,
+	                                         final ExpectedVariables ... inputVars ) {
+		return new ExecOpMultiRequest( lop.getRequest(),
+		                               lop.getServiceVariable(),
+		                               lop.getFederationMembers(),
+		                               collectExceptions,
+		                               qpInfo );
+	}
+
+	@Override
+	public void visit( final PhysicalPlanVisitor visitor ) {
+		visitor.visit(this);
+	}
+
+	@Override
+	public boolean equals( final Object o ) {
+		if ( o == this ) return true;
+
+		return    o instanceof PhysicalOpMultiRequest oo
+		       && oo.lop.equals(lop);
+	}
+
+	@Override
+	public int hashCode() {
+		return getClass().hashCode() ^ lop.hashCode();
+	}
+
+	@Override
+	public String toString() {
+		return lop.toString();
+	}
+
+	public static class Factory implements PhysicalOpFactory
+	{
+		@Override
+		public boolean supports( final LogicalOperator lop, final ExpectedVariables... inputVars ) {
+			return ( lop instanceof LogicalOpMultiRequest );
+		}
+
+		@Override
+		public PhysicalOpMultiRequest create( final NullaryLogicalOp lop ) {
+			if ( lop instanceof LogicalOpMultiRequest op ) {
+				return new PhysicalOpMultiRequest(op);
+			}
+
+			throw new UnsupportedOperationException( "Unsupported type of logical operator: " + lop.getClass().getName() + "." );
+		}
+	}
+
+}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpMultiRequest.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/physical/impl/PhysicalOpMultiRequest.java
@@ -12,12 +12,13 @@ import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalOpFactory;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanVisitor;
 
 /**
- * A physical operator that performs requests with the same graph
- * pattern at multiple federation members in parallel and, then,
- * outputs the solution mappings obtained via all these requests,
- * where each solution mapping is extended with a binding that
- * captures the service variable with the service URI of the
- * federation member from which it was obtained.
+ * A physical operator that is meant to be used for the logical operator
+ * {@link LogicalOpMultiRequest}. It performs requests with the same graph
+ * pattern at multiple federation members in parallel and, then, outputs
+ * the solution mappings obtained via all these requests, where each
+ * solution mapping is extended with a binding that captures the service
+ * variable with the service URI of the federation member from which it
+ * was obtained.
  *
  * The actual algorithm of this operator is implemented in the
  * {@link ExecOpMultiRequest} class.

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/BaseForTextBasedPlanPrinters.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/BaseForTextBasedPlanPrinters.java
@@ -123,6 +123,9 @@ public class BaseForTextBasedPlanPrinters
 		public void visit( final LogicalOpRequest<?, ?> op )    { name = "req"; }
 
 		@Override
+		public void visit( final LogicalOpMultiRequest op )     { name = "mreq"; }
+
+		@Override
 		public void visit( final LogicalOpFixedSolMap op )      { name = "sm"; }
 
 		@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/PhysicalPlanFactory.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/PhysicalPlanFactory.java
@@ -464,8 +464,8 @@ public class PhysicalPlanFactory
 	/**
 	 * This function takes two physical plans as input, with the assumptions
 	 * that the second of these plans i) has a union as its root operator and
-	 * ii) every sub plan under this union is either a request or a filter
-	 * with a request.
+	 * ii) every sub plan under this union is either a request, a filter with
+	 * a request or a bind operator over a request.
 	 *
 	 * Given such input plans, the function turns the requests under the union
 	 * into gpAdd operators with the first given plan as a common subplan.
@@ -498,8 +498,9 @@ public class PhysicalPlanFactory
 
 	/**
 	 * If the second of the two given plans is either a request, a filter
-	 * with request, or a union over requests, then this function turns the
-	 * request(s) into gpAdd operators with the first given plan as subplan.
+	 * with request, a bind operator over a request, or a union over requests,
+	 * then this function turns the request(s) into gpAdd operators with the
+	 * first given plan as subplan.
 	 *
 	 * Otherwise, the function returns a plan with a binary join over the two
 	 * given plans (using the default physical operator).
@@ -519,6 +520,36 @@ public class PhysicalPlanFactory
 	                                                                   final LogicalToPhysicalOpConverter lop2pop ) {
 		final PhysicalOperator rootOp = nextPlan.getRootOperator();
 
+		// Handle special cases first.
+		// Special case 1: The second plan is a fin operator (providing
+		// a fixed solution mapping). In this case, we return a plan with
+		// a binary join over the two given plans. This case should actually
+		// never happen because, during join ordering, the fin subplan should
+		// become the first subplan. In this sense, handling this case here
+		// is more to be on the safe side.
+		if ( rootOp instanceof PhysicalOpFixedSolMap ) {
+			return createPlanWithJoin(inputPlan, nextPlan, qpInfo, lop2pop);
+		}
+
+		// Special case 2: The second plan is a mreq operator. In this case,
+		// we also return a plan with a binary join over the two given plans.
+		// TODO: we may change this behavior and consider decomposing the
+		// mreq operator into its individual requests and, then, turn them
+		// into a union of gpAdd operators that all have the first plan as
+		// subplan. Or, even more sophisticated, after decomposing the mreq
+		// operator, identify the extracted requests for which turning them
+		// into gpAdd operators does not seem to be a good idea and put them
+		// back into an mreq operator again. 
+		if ( rootOp instanceof PhysicalOpMultiRequest ) {
+			return createPlanWithJoin(inputPlan, nextPlan, qpInfo, lop2pop);
+		}
+
+		// Now we come to the actual functionality, where we consider all
+		// cases in which turning the second plan into a gpAdd operator
+		// is possible.
+
+		// Case 1: The second plan is simply a request. In this case, we
+		// turn this request directly into a gpAdd operator.
 		if ( rootOp instanceof PhysicalOpRequest reqOp ) {
 			final UnaryLogicalOp addOp = LogicalOpUtils.createLogicalAddOpFromPhysicalReqOp(reqOp);
 			return PhysicalPlanFactory.createPlan(addOp, qpInfo, lop2pop, inputPlan);
@@ -526,6 +557,9 @@ public class PhysicalPlanFactory
 
 		final PhysicalOperator subPlanRootOp = nextPlan.getSubPlan(0).getRootOperator();
 
+		// Case 2: The second plan is a request with a filter on top. In this
+		// case, we turn the request into a gpAdd operator and put the filter
+		// on top of that one.
 		if (    rootOp instanceof PhysicalOpFilter filterOp
 		     && subPlanRootOp instanceof PhysicalOpRequest reqOp ) {
 			final UnaryLogicalOp addOp = LogicalOpUtils.createLogicalAddOpFromPhysicalReqOp(reqOp);
@@ -533,6 +567,21 @@ public class PhysicalPlanFactory
 			return PhysicalPlanFactory.createPlan(filterOp, qpInfo, addOpPlan);
 		}
 
+		// Case 3: The second plan is a request with a bind operator on top.
+		// In this case, we turn the request into a gpAdd operator and put
+		// the bind operator on top of that one.
+		if (    rootOp instanceof PhysicalOpBind bindOp
+			     && subPlanRootOp instanceof PhysicalOpRequest reqOp ) {
+			final UnaryLogicalOp addOp = LogicalOpUtils.createLogicalAddOpFromPhysicalReqOp(reqOp);
+			final PhysicalPlan addOpPlan = PhysicalPlanFactory.createPlan(addOp, lop2pop, inputPlan);
+			return PhysicalPlanFactory.createPlan(bindOp, qpInfo, addOpPlan);
+		}
+
+		// Case 4: The second plan is a request with an l2g operator on top.
+		// In this case, we create a corresponding g2l operator, put that one
+		// on top of the first given plan, use that as input to the gpAdd
+		// operator created from the request, and put the l2g operator on
+		// top of that.
 		if (    rootOp instanceof PhysicalOpLocalToGlobal l2gPOP
 		     && subPlanRootOp instanceof PhysicalOpRequest reqOp ) {
 			final LogicalOpLocalToGlobal l2gLOP = (LogicalOpLocalToGlobal) l2gPOP.getLogicalOperator();
@@ -548,6 +597,9 @@ public class PhysicalPlanFactory
 			return PhysicalPlanFactory.createPlan(l2gPOP, qpInfo, addOpPlan);
 		}
 
+		// Case 5: The second plan is a union. In this case, we check whether
+		// the subplans under that union can be turned into gpAdd operators
+		// with the first given plan as input.
 		if (    (rootOp instanceof PhysicalOpBinaryUnion || rootOp instanceof PhysicalOpMultiwayUnion)
 		     && PhysicalPlanFactory.checkUnaryOpApplicableToUnionPlan(nextPlan) ) {
 			return PhysicalPlanFactory.createPlanWithUnaryOpForUnionPlan(inputPlan, nextPlan, qpInfo, lop2pop);
@@ -562,7 +614,8 @@ public class PhysicalPlanFactory
 	 * following forms:
 	 * i) a request,
 	 * ii) a filter over a request,
-	 * iii) an l2g operator over either a request or a filter with a request.
+	 * iii) a bind over a request,
+	 * iv) an l2g operator over either a request or a filter with a request.
 	 */
 	public static boolean checkUnaryOpApplicableToUnionPlan( final PhysicalPlan unionPlan ){
 		final PhysicalOperator rootOp = unionPlan.getRootOperator();
@@ -577,6 +630,7 @@ public class PhysicalPlanFactory
 
 			if (    ! (subRootOp instanceof PhysicalOpRequest)
 			     && ! (subRootOp instanceof PhysicalOpFilter)
+			     && ! (subRootOp instanceof PhysicalOpBind)
 			     && ! (subRootOp instanceof PhysicalOpLocalToGlobal) ) {
 				return false;
 			}
@@ -598,7 +652,8 @@ public class PhysicalPlanFactory
 				}
 			}
 
-			if ( subRootOp instanceof PhysicalOpFilter ) {
+			if (    subRootOp instanceof PhysicalOpFilter
+			     || subRootOp instanceof PhysicalOpBind ) {
 				final PhysicalOperator subSubRootOp = subPlan.getSubPlan(0).getRootOperator();
 
 				if ( ! (subSubRootOp instanceof PhysicalOpRequest) ) {

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedLogicalPlanPrinterImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedLogicalPlanPrinterImpl.java
@@ -156,7 +156,7 @@ public class TextBasedLogicalPlanPrinterImpl extends BaseForTextBasedPlanPrinter
 
 		@Override
 		public void visit( final LogicalOpMultiRequest op ) {
-			record( op.getRequest() );
+			props.add( "service variable: " + op.getServiceVariable().toString() );
 
 			final int n = op.getFederationMembers().size();
 			props.add( "number of fed.members: " + n );
@@ -172,6 +172,8 @@ public class TextBasedLogicalPlanPrinterImpl extends BaseForTextBasedPlanPrinter
 					props.add( "             " + it.next().toString() );
 				}
 			}
+
+			record( op.getRequest() );
 
 			props.add( "may reduce duplicates: " + op.mayReduce() );
 		}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedLogicalPlanPrinterImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedLogicalPlanPrinterImpl.java
@@ -155,6 +155,28 @@ public class TextBasedLogicalPlanPrinterImpl extends BaseForTextBasedPlanPrinter
 		}
 
 		@Override
+		public void visit( final LogicalOpMultiRequest op ) {
+			record( op.getRequest() );
+
+			final int n = op.getFederationMembers().size();
+			props.add( "number of fed.members: " + n );
+
+			if ( n > 0 ) {
+				final Iterator<FederationMember> it = op.getFederationMembers().iterator();
+
+				// print first member at the same line
+				props.add( "fed.members: " + it.next().toString() );
+
+				// print each of the remaining members at a separate line
+				while ( it.hasNext() ) {
+					props.add( "             " + it.next().toString() );
+				}
+			}
+
+			props.add( "may reduce duplicates: " + op.mayReduce() );
+		}
+
+		@Override
 		public void visit( final LogicalOpFixedSolMap op ) {
 			props.add( "solmap: " + op.getSolutionMapping().toString() );
 			props.add( "may reduce duplicates: " + op.mayReduce() );

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedLogicalPlanPrinterImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedLogicalPlanPrinterImpl.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.core.VarExprList;
@@ -327,6 +328,26 @@ public class TextBasedLogicalPlanPrinterImpl extends BaseForTextBasedPlanPrinter
 		protected void record( final DataRetrievalRequest req ) {
 			if ( req instanceof SPARQLRequest sreq ) {
 				record( sreq.getQueryPattern() );
+
+				final String prVarsString;
+				final Set<Var> prVars = sreq.getProjectionVars();
+				if ( prVars == null ) {
+					prVarsString = "*";
+				}
+				else if ( prVars.isEmpty() ) {
+					prVarsString = "-none-";
+				}
+				else {
+					final StringBuilder sb = new StringBuilder();
+					final Iterator<Var> it = prVars.iterator();
+					sb.append( it.next().toString() );
+					while ( it.hasNext() ) {
+						sb.append( ", " + it.next().toString() );
+					}
+					prVarsString = sb.toString();
+				}
+
+				props.add( "projection variables: " + prVarsString );
 			}
 			else {
 				props.add( "request (" + req.hashCode() +  "): " + req.toString() );

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedPhysicalPlanPrinterImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/utils/TextBasedPhysicalPlanPrinterImpl.java
@@ -130,6 +130,12 @@ public class TextBasedPhysicalPlanPrinterImpl extends BaseForTextBasedPlanPrinte
 		}
 
 		@Override
+		public void visit( final PhysicalOpMultiRequest op ) {
+			rootOpString = "mreq";
+			record( op.getLogicalOperator() );
+		}
+
+		@Override
 		public void visit( final PhysicalOpFixedSolMap op ) {
 			rootOpString = "sm";
 			record( op.getLogicalOperator() );

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/CardinalityEstimationWorkerImpl.java
@@ -94,6 +94,14 @@ public class CardinalityEstimationWorkerImpl implements CardinalityEstimationWor
 	}
 
 	@Override
+	public void visit( final LogicalOpMultiRequest op ) {
+		// Since we assume that the nullary plans (which have a request
+		// operator) have all been annotated already, we should never
+		// end up here.
+		throw new IllegalArgumentException( op.toString() );
+	}
+
+	@Override
 	public void visit( final LogicalOpFixedSolMap op ) {
 		// Since we assume that the nullary plans (which have a fin operator)
 		// have all been annotated already, we should never end up here.

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/RequestBasedCardinalityEstimator.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/RequestBasedCardinalityEstimator.java
@@ -19,6 +19,7 @@ import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlanWithNullaryRoot;
 import se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpFixedSolMap;
+import se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpMultiRequest;
 import se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpRequest;
 import se.liu.ida.hefquin.engine.queryproc.CardinalityEstimator;
 import se.liu.ida.hefquin.engine.queryproc.QueryProcContext;
@@ -145,13 +146,30 @@ public class RequestBasedCardinalityEstimator implements CardinalityEstimator
 		// extracted subplans, obtain the request operator and the
 		// QueryPlanningInfo object of each of these subplans (and,
 		// also, handle the special case of fixed-input operators).
-		final List<LogicalOpRequest<?,?>> reqOps  = new ArrayList<>( subPlans.size() );
-		final List<QueryPlanningInfo> infoObjs    = new ArrayList<>( subPlans.size() );
-		for ( final PhysicalPlan subPlan : subPlans ) {
+		List<LogicalOpRequest<?,?>> reqOps  = null;
+		List<LogicalOpMultiRequest> mreqOps = null;
+		List<QueryPlanningInfo> infoObjs1 = null;
+		List<QueryPlanningInfo> infoObjs2 = null;
+		for ( final PhysicalPlan subPlan : subPlans )
+		{
 			final PhysicalOperator rootOp = subPlan.getRootOperator();
+			if ( rootOp instanceof PhysicalOpMultiRequest mreqOp ) {
+				if ( mreqOps == null ) {
+					mreqOps   = new ArrayList<>( subPlans.size() );
+					infoObjs2 = new ArrayList<>( subPlans.size() );
+				}
+
+				mreqOps.add( mreqOp.getLogicalOperator() );
+				infoObjs2.add( subPlan.getQueryPlanningInfo() );
+			}
 			if ( rootOp instanceof PhysicalOpRequest reqOp ) {
+				if ( reqOps == null ) {
+					reqOps    = new ArrayList<>( subPlans.size() );
+					infoObjs1 = new ArrayList<>( subPlans.size() );
+				}
+
 				reqOps.add( reqOp.getLogicalOperator() );
-				infoObjs.add( subPlan.getQueryPlanningInfo() );
+				infoObjs1.add( subPlan.getQueryPlanningInfo() );
 			}
 			else if ( rootOp instanceof PhysicalOpFixedSolMap ) {
 				addCardinalityForFixedInputOps( subPlan.getQueryPlanningInfo() );
@@ -162,7 +180,7 @@ public class RequestBasedCardinalityEstimator implements CardinalityEstimator
 		}
 
 		// Now we are ready to add the cardinality estimates.
-		addCardinalitiesForRequests(reqOps, infoObjs, null, null, ctx);
+		addCardinalitiesForRequests(reqOps, infoObjs1, mreqOps, infoObjs2, ctx);
 	}
 
 	protected void addCardinalitiesForRequests( final List<LogicalOpRequest<?,?>> reqOps,

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/RequestBasedCardinalityEstimator.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/RequestBasedCardinalityEstimator.java
@@ -13,6 +13,7 @@ import se.liu.ida.hefquin.engine.queryplan.logical.LogicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlan;
 import se.liu.ida.hefquin.engine.queryplan.logical.LogicalPlanWithNullaryRoot;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpFixedSolMap;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiRequest;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpRequest;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalOperator;
 import se.liu.ida.hefquin.engine.queryplan.physical.PhysicalPlan;
@@ -21,6 +22,7 @@ import se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpFixedSolMap;
 import se.liu.ida.hefquin.engine.queryplan.physical.impl.PhysicalOpRequest;
 import se.liu.ida.hefquin.engine.queryproc.CardinalityEstimator;
 import se.liu.ida.hefquin.engine.queryproc.QueryProcContext;
+import se.liu.ida.hefquin.federation.FederationMember;
 import se.liu.ida.hefquin.federation.access.CardinalityResponse;
 import se.liu.ida.hefquin.federation.access.FederationAccessException;
 import se.liu.ida.hefquin.federation.members.RDFBasedFederationMember;
@@ -77,15 +79,31 @@ public class RequestBasedCardinalityEstimator implements CardinalityEstimator
 		// the extracted subplans, obtain the request operator and the
 		// QueryPlanningInfo object of each of these subplans (and,
 		// also, handle the special case of fixed-input operators).
-		final List<LogicalOpRequest<?,?>> reqOps  = new ArrayList<>( subPlans.size() );
-		final List<QueryPlanningInfo> infoObjs    = new ArrayList<>( subPlans.size() );
+		List<LogicalOpRequest<?,?>> reqOps  = null;
+		List<LogicalOpMultiRequest> mreqOps = null;
+		List<QueryPlanningInfo> infoObjs1 = null;
+		List<QueryPlanningInfo> infoObjs2 = null;
 		for ( final LogicalPlan subPlan : subPlans )
 		{
 			final LogicalOperator rootOp = subPlan.getRootOperator();
-			if (    rootOp instanceof LogicalOpRequest reqOp
-			     && reqOp.getFederationMember() instanceof RDFBasedFederationMember ) {
+			if ( rootOp instanceof LogicalOpMultiRequest mreqOp ) {
+				if ( mreqOps == null ) {
+					mreqOps   = new ArrayList<>( subPlans.size() );
+					infoObjs2 = new ArrayList<>( subPlans.size() );
+				}
+
+				mreqOps.add( mreqOp );
+				infoObjs2.add( subPlan.getQueryPlanningInfo() );
+			}
+			else if ( rootOp instanceof LogicalOpRequest reqOp
+			       && reqOp.getFederationMember() instanceof RDFBasedFederationMember ) {
+				if ( reqOps == null ) {
+					reqOps    = new ArrayList<>( subPlans.size() );
+					infoObjs1 = new ArrayList<>( subPlans.size() );
+				}
+
 				reqOps.add( reqOp );
-				infoObjs.add( subPlan.getQueryPlanningInfo() );
+				infoObjs1.add( subPlan.getQueryPlanningInfo() );
 			}
 			else if ( rootOp instanceof LogicalOpRequest reqOp ) {
 				addCardinalityForRequestViaWrapper( subPlan.getQueryPlanningInfo(), reqOp );
@@ -98,8 +116,14 @@ public class RequestBasedCardinalityEstimator implements CardinalityEstimator
 			}
 		}
 
+		if ( reqOps == null && mreqOps == null ) {
+			// The plan did not contain any requests operator
+			// for which we need to do cardinality requests.
+			return;
+		}
+
 		// Now we are ready to add the cardinality estimates.
-		addCardinalitiesForRequests(reqOps, infoObjs, ctx);
+		addCardinalitiesForRequests(reqOps, infoObjs1, mreqOps, infoObjs2, ctx);
 	}
 
 	/**
@@ -138,16 +162,23 @@ public class RequestBasedCardinalityEstimator implements CardinalityEstimator
 		}
 
 		// Now we are ready to add the cardinality estimates.
-		addCardinalitiesForRequests(reqOps, infoObjs, ctx);
+		addCardinalitiesForRequests(reqOps, infoObjs, null, null, ctx);
 	}
 
 	protected void addCardinalitiesForRequests( final List<LogicalOpRequest<?,?>> reqOps,
-	                                            final List<QueryPlanningInfo> infoObjs,
+	                                            final List<QueryPlanningInfo> reqInfoObjs,
+	                                            final List<LogicalOpMultiRequest> mreqOps,
+	                                            final List<QueryPlanningInfo> mreqInfoObjs,
 	                                            final QueryProcContext ctx ) {
+		assert reqOps != null || mreqOps != null;
+		assert reqOps  == null || ( reqInfoObjs != null && reqInfoObjs.size() == reqOps.size() );
+		assert mreqOps == null || ( mreqInfoObjs != null && mreqInfoObjs.size() == mreqOps.size() );
+
 		final CardinalityResponse[] resps;
 		try {
 			resps = FederationAccessUtils.performCardinalityRequests( ctx.getFederationAccessMgr(),
-			                                                          reqOps );
+			                                                          reqOps,
+			                                                          mreqOps );
 		}
 		catch ( final FederationAccessException e ) {
 			// If the cardinality requests fail, we need to guess. For the
@@ -162,52 +193,40 @@ public class RequestBasedCardinalityEstimator implements CardinalityEstimator
 			                                                               Quality.MIN_OR_MAX_POSSIBLE);
 			final QueryPlanProperty max = QueryPlanProperty.maxCardinality(Integer.MAX_VALUE,
 			                                                               Quality.MIN_OR_MAX_POSSIBLE);
-			for ( final QueryPlanningInfo qpInfo : infoObjs ) {
-				qpInfo.addProperty(est);
-				qpInfo.addProperty(min);
-				qpInfo.addProperty(max);
+			if ( reqOps != null ) {
+				for ( final QueryPlanningInfo qpInfo : reqInfoObjs ) {
+					qpInfo.addProperty(est);
+					qpInfo.addProperty(min);
+					qpInfo.addProperty(max);
+				}
+			}
+
+			if ( mreqOps != null ) {
+				for ( final QueryPlanningInfo qpInfo : mreqInfoObjs ) {
+					qpInfo.addProperty(est);
+					qpInfo.addProperty(min);
+					qpInfo.addProperty(max);
+				}
 			}
 			return;
 		}
 
-		if ( resps.length != reqOps.size() )
-			throw new IllegalStateException("Wrong number of cardinality responses (namely, " + resps.length + ", but " + reqOps.size() + " expected).");
+		if ( reqOps != null ) {
+			if ( resps.length < reqOps.size() )
+				throw new IllegalStateException("Wrong number of cardinality responses (namely, " + resps.length + ", but at least " + reqOps.size() + " expected).");
 
-		for ( int i = 0; i < resps.length; i++ ) {
-			final LogicalOpRequest<?,?> reqOp = reqOps.get(i);
-			final QueryPlanningInfo infoObj = infoObjs.get(i);
+			for ( int i = 0; i < reqOps.size(); i++ ) {
+				final LogicalOpRequest<?,?> reqOp = reqOps.get(i);
+				final QueryPlanningInfo infoObj = reqInfoObjs.get(i);
 
-			final int cardValue;
-			final int minCardValue;
-			final int maxCardValue;
-			final QueryPlanProperty.Quality cardQuality;
-			final QueryPlanProperty.Quality minCardQuality;
-			final QueryPlanProperty.Quality maxCardQuality;
+				final int cardValue;
+				final int minCardValue;
+				final int maxCardValue;
+				final QueryPlanProperty.Quality cardQuality;
+				final QueryPlanProperty.Quality minCardQuality;
+				final QueryPlanProperty.Quality maxCardQuality;
 
-			if ( resps[i].isError() ) {
-				cardValue = Integer.MAX_VALUE;
-				cardQuality = Quality.PURE_GUESS;
-				minCardValue = 0;
-				minCardQuality = Quality.MIN_OR_MAX_POSSIBLE;
-				maxCardValue = Integer.MAX_VALUE;
-				maxCardQuality = Quality.MIN_OR_MAX_POSSIBLE;
-			}
-			else {
-				final int cardValueOfResponse;
-				try {
-					cardValueOfResponse = resps[i].getCardinality();
-				}
-				catch ( final Exception e ) {
-					// We should not get an exception here because we are
-					// in the branch where resps[i].isError() is false.
-					throw new IllegalStateException();
-				}
-
-				// Check that the cardinality value retrieved via the
-				// request is valid, where we consider any non-negative
-				// integer a valid value.
-				if ( cardValueOfResponse < 0 ) {
-					// This is the case in which the value is invalid.
+				if ( resps[i].isError() ) {
 					cardValue = Integer.MAX_VALUE;
 					cardQuality = Quality.PURE_GUESS;
 					minCardValue = 0;
@@ -216,27 +235,133 @@ public class RequestBasedCardinalityEstimator implements CardinalityEstimator
 					maxCardQuality = Quality.MIN_OR_MAX_POSSIBLE;
 				}
 				else {
-					// This is the case in which the value is valid.
-					cardValue = cardValueOfResponse;
-					minCardValue = cardValueOfResponse;
-					maxCardValue = cardValueOfResponse;
+					final int cardValueOfResponse;
+					try {
+						cardValueOfResponse = resps[i].getCardinality();
+					}
+					catch ( final Exception e ) {
+						// We should not get an exception here because we are
+						// in the branch where resps[i].isError() is false.
+						throw new IllegalStateException();
+					}
 
-					if ( reqOp.getFederationMember() instanceof SPARQLEndpoint )
-						cardQuality = Quality.ACCURATE;
-					else
-						cardQuality = Quality.DIRECT_ESTIMATE;
+					// Check that the cardinality value retrieved via the
+					// request is valid, where we consider any non-negative
+					// integer a valid value.
+					if ( cardValueOfResponse < 0 ) {
+						// This is the case in which the value is invalid.
+						cardValue = Integer.MAX_VALUE;
+						cardQuality = Quality.PURE_GUESS;
+						minCardValue = 0;
+						minCardQuality = Quality.MIN_OR_MAX_POSSIBLE;
+						maxCardValue = Integer.MAX_VALUE;
+						maxCardQuality = Quality.MIN_OR_MAX_POSSIBLE;
+					}
+					else {
+						// This is the case in which the value is valid.
+						cardValue = cardValueOfResponse;
+						minCardValue = cardValueOfResponse;
+						maxCardValue = cardValueOfResponse;
 
-					minCardQuality = cardQuality;
-					maxCardQuality = cardQuality;
+						if ( reqOp.getFederationMember() instanceof SPARQLEndpoint )
+							cardQuality = Quality.ACCURATE;
+						else
+							cardQuality = Quality.DIRECT_ESTIMATE;
+
+						minCardQuality = cardQuality;
+						maxCardQuality = cardQuality;
+					}
+				}
+
+				infoObj.addProperty( QueryPlanProperty.cardinality(cardValue,
+				                                                   cardQuality) );
+
+				infoObj.addProperty( QueryPlanProperty.minCardinality(minCardValue,
+				                                                      minCardQuality) );
+
+				infoObj.addProperty( QueryPlanProperty.maxCardinality(maxCardValue,
+				                                                      maxCardQuality) );
+			}
+		}
+
+		if ( mreqOps == null || mreqOps.isEmpty() )
+			return;
+
+		int respIdx = (reqOps == null) ? -1 : reqOps.size() - 1;
+		for ( int i = 0; i < mreqOps.size(); i++ ) {
+			final LogicalOpMultiRequest mreqOp = mreqOps.get(i);
+
+			int cardValue = 0; // to be updated in the loop below
+			boolean errorFound = false;
+			boolean nonSparqlEndpointFound = false;
+
+			for ( final FederationMember fm : mreqOp.getFederationMembers() ) {
+				if ( ! (fm instanceof SPARQLEndpoint) ) {
+					nonSparqlEndpointFound = true;
+				}
+
+				respIdx++;
+				if ( resps.length < respIdx - 1 )
+					throw new IllegalStateException("Wrong number of cardinality responses (namely, " + resps.length + ", but at least " + respIdx + " expected).");
+
+				if ( resps[respIdx].isError() ) {
+					errorFound = true;
+				}
+				else {
+					final int cardValueOfResponse;
+					try {
+						cardValueOfResponse = resps[respIdx].getCardinality();
+					}
+					catch ( final Exception e ) {
+						// We should not get an exception here because we are
+						// in the branch where resps[i].isError() is false.
+						throw new IllegalStateException();
+					}
+
+					// Check that the cardinality value retrieved via the
+					// request is valid, where we consider any non-negative
+					// integer a valid value.
+					if ( cardValueOfResponse < 0 ) {
+						// This is the case in which the value is invalid.
+						errorFound = true;
+					}
+					else {
+						// This is the case in which the value is valid.
+						cardValue += cardValueOfResponse;
+					}
 				}
 			}
 
+			final int minCardValue;
+			final int maxCardValue;
+			final QueryPlanProperty.Quality cardQuality;
+			final QueryPlanProperty.Quality minCardQuality;
+			final QueryPlanProperty.Quality maxCardQuality;
+			if ( errorFound ) {
+				cardValue    = Integer.MAX_VALUE;
+				minCardValue = cardValue;
+				maxCardValue = Integer.MAX_VALUE;
+				cardQuality    = Quality.PURE_GUESS;
+				minCardQuality = Quality.MIN_OR_MAX_POSSIBLE;
+				maxCardQuality = Quality.MIN_OR_MAX_POSSIBLE;
+			}
+			else {
+				if ( nonSparqlEndpointFound )
+					cardQuality = Quality.DIRECT_ESTIMATE;
+				else
+					cardQuality = Quality.ACCURATE;
+
+				minCardValue = cardValue;
+				maxCardValue = cardValue;
+				minCardQuality = cardQuality;
+				maxCardQuality = cardQuality;
+			}
+
+			final QueryPlanningInfo infoObj = mreqInfoObjs.get(i);
 			infoObj.addProperty( QueryPlanProperty.cardinality(cardValue,
 			                                                   cardQuality) );
-
 			infoObj.addProperty( QueryPlanProperty.minCardinality(minCardValue,
 			                                                      minCardQuality) );
-
 			infoObj.addProperty( QueryPlanProperty.maxCardinality(maxCardValue,
 			                                                      maxCardQuality) );
 		}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/ApplyVocabularyMappings.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/ApplyVocabularyMappings.java
@@ -27,6 +27,7 @@ import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpLeftJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpLocalToGlobal;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMinus;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiRequest;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayLeftJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayUnion;
@@ -98,6 +99,11 @@ public class ApplyVocabularyMappings implements HeuristicForLogicalOptimization
 			else {
 				rewrittenPlan = inputPlan;
 			}
+		}
+
+		@Override
+		public void visit( final LogicalOpMultiRequest op ) {
+			throw new UnsupportedOperationException("Unimplemented method 'visit'");
 		}
 
 		@Override

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDown.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDown.java
@@ -284,8 +284,10 @@ public class FilterPushDown implements HeuristicForLogicalOptimization
 
 		final SPARQLRequest mergedReq = new SPARQLRequestImpl( mergedPattern, req.getProjectionVars(), req.getDistinctRequired() );
 
-		final LogicalOpMultiRequest mergedReqOp = new LogicalOpMultiRequest( mergedReq, reqOp.getFederationMembers() );
-		return new LogicalPlanWithNullaryRootImpl(mergedReqOp, null);
+		final LogicalOpMultiRequest mergedOp = new LogicalOpMultiRequest( mergedReq,
+		                                                                  reqOp.getServiceVariable(),
+		                                                                  reqOp.getFederationMembers() );
+		return new LogicalPlanWithNullaryRootImpl(mergedOp, null);
 	}
 
 	protected LogicalPlan createPlanForFilterUnderFilter( final LogicalOpFilter parentFilterOp,

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDown.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDown.java
@@ -120,6 +120,13 @@ public class FilterPushDown implements HeuristicForLogicalOptimization
 		}
 
 		@Override
+		public void visit( final LogicalOpMultiRequest op ) {
+			createdPlan = createPlanForMultiRequestUnderFilter( filterOp,
+			                                                    op,
+			                                                    inputPlan );
+		}
+
+		@Override
 		public void visit( final LogicalOpFixedSolMap op ) {
 			// The filter cannot be pushed below this operator. However, since the
 			// root operator of the subplan is a FixedSolMap with a known solution
@@ -252,8 +259,8 @@ public class FilterPushDown implements HeuristicForLogicalOptimization
 			return inputPlan;
 		}
 
-		final SPARQLRequest req = (SPARQLRequest) reqOp.getRequest();
 		final ExprList exprList = filterOp.getFilterExpressions();
+		final SPARQLRequest req = (SPARQLRequest) reqOp.getRequest();
 		final SPARQLGraphPattern mergedPattern = req.getQueryPattern().mergeWith(exprList);
 
 		if ( ! fm.isSupportedPattern(mergedPattern) ) {
@@ -265,6 +272,19 @@ public class FilterPushDown implements HeuristicForLogicalOptimization
 		final boolean mayReduce = filterOp.mayReduce();
 
 		final LogicalOpRequest<?,?> mergedReqOp = new LogicalOpRequest<>( fm, mayReduce, mergedReq );
+		return new LogicalPlanWithNullaryRootImpl(mergedReqOp, null);
+	}
+
+	protected LogicalPlan createPlanForMultiRequestUnderFilter( final LogicalOpFilter filterOp,
+	                                                            final LogicalOpMultiRequest reqOp,
+	                                                            final LogicalPlan inputPlan ) {
+		final ExprList exprList = filterOp.getFilterExpressions();
+		final SPARQLRequest req = (SPARQLRequest) reqOp.getRequest();
+		final SPARQLGraphPattern mergedPattern = req.getQueryPattern().mergeWith(exprList);
+
+		final SPARQLRequest mergedReq = new SPARQLRequestImpl( mergedPattern, req.getProjectionVars(), req.getDistinctRequired() );
+
+		final LogicalOpMultiRequest mergedReqOp = new LogicalOpMultiRequest( mergedReq, reqOp.getFederationMembers() );
 		return new LogicalPlanWithNullaryRootImpl(mergedReqOp, null);
 	}
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDown.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/FilterPushDown.java
@@ -278,9 +278,34 @@ public class FilterPushDown implements HeuristicForLogicalOptimization
 	protected LogicalPlan createPlanForMultiRequestUnderFilter( final LogicalOpFilter filterOp,
 	                                                            final LogicalOpMultiRequest reqOp,
 	                                                            final LogicalPlan inputPlan ) {
+		// First, check whether filter evaluation may exceed the capabilities
+		// of any of the federation members of the mreq operator. Specifically,
+		// if at least one of these federation members can handle only triple
+		// pattern requests, then we are not attempting to push the filter.
+		// TODO: Instead of simply giving up, a better strategy is to split
+		// mreq operator into two: one that contains the subset of federation
+		// members that can handle the extended request and one that contains
+		// the federation members that cannot. Then, we can push the filter
+		// into the request of the first one, keep the filter operator on top
+		// of the second one, and combine both subplans via a union operator.
+		for ( final FederationMember fm : reqOp.getFederationMembers() ) {
+			if ( ! fm.supportsMoreThanTriplePatterns() ) {
+				return inputPlan;
+			}
+		}
+
+		// Now merge the filter into the graph pattern of the request.
 		final ExprList exprList = filterOp.getFilterExpressions();
 		final SPARQLRequest req = (SPARQLRequest) reqOp.getRequest();
 		final SPARQLGraphPattern mergedPattern = req.getQueryPattern().mergeWith(exprList);
+
+		// Check again that the resulting graph pattern is supported by
+		// every federation member of the operator.
+		for ( final FederationMember fm : reqOp.getFederationMembers() ) {
+			if ( ! fm.isSupportedPattern(mergedPattern) ) {
+				return inputPlan;
+			}
+		}
 
 		final SPARQLRequest mergedReq = new SPARQLRequestImpl( mergedPattern, req.getProjectionVars(), req.getDistinctRequired() );
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/MergeRequests.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/MergeRequests.java
@@ -128,6 +128,11 @@ public class MergeRequests implements HeuristicForLogicalOptimization
 		}
 
 		@Override
+		public void visit( final LogicalOpMultiRequest op ) {
+			// nothing to do here - we are in a leaf node
+		}
+
+		@Override
 		public void visit( final LogicalOpFixedSolMap op ) {
 			// nothing to do here - we are in a leaf node
 		}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/ProjectPushDown.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/ProjectPushDown.java
@@ -31,6 +31,7 @@ import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpLeftJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpLocalToGlobal;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMinus;
+import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiRequest;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayLeftJoin;
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalOpMultiwayUnion;
@@ -150,6 +151,12 @@ public class ProjectPushDown implements HeuristicForLogicalOptimization
 			createdPlan = createPlanForRequestUnderProject( projectOp,
 			                                                op,
 			                                                inputPlan );
+		}
+
+		@Override
+		public void visit( final LogicalOpMultiRequest op ) {
+			createdPlan = createPlanForMultiRequestUnderProject( projectOp,
+			                                                     op );
 		}
 
 		@Override
@@ -311,6 +318,42 @@ public class ProjectPushDown implements HeuristicForLogicalOptimization
 			return new LogicalPlanWithNullaryRootImpl(mergedReqOp, null);
 		}
 		return inputPlan;
+	}
+
+	/**
+	 * Pushes a project operator into a multi-request operator.
+	 *
+	 * A new request is created whose projection variables correspond to the
+	 * variables required by the project operator. If the request already
+	 * contains request-level projection variables, then the new request uses
+	 * the intersection of the existing projection variables and the variables
+	 * required by the project operator.
+	 *
+	 * The resulting request preserves the duplicate-elimination requirement
+	 * of the original request.
+	 *
+	 * A new request operator containing the rewritten request is then returned
+	 * as a plan with a nullary root.
+	 */
+	protected LogicalPlan createPlanForMultiRequestUnderProject(
+			final LogicalOpProject projectOp,
+			final LogicalOpMultiRequest reqOp ) {
+		final SPARQLRequest oldReq = reqOp.getRequest();
+		final Set<Var> newProj;
+		if ( oldReq.getProjectionVars() != null ) {
+			newProj = new HashSet<>( projectOp.getVariables() );
+			newProj.retainAll( oldReq.getProjectionVars() );
+		}
+		else {
+			newProj = projectOp.getVariables();
+		}
+
+		final boolean mayReduce = reqOp.mayReduce() && projectOp.mayReduce();
+
+		final SPARQLRequest newReq = new SPARQLRequestImpl( oldReq.getQueryPattern(), newProj, oldReq.getDistinctRequired() || mayReduce );
+
+		final LogicalOpMultiRequest mergedReqOp = new LogicalOpMultiRequest( newReq, reqOp.getFederationMembers() );
+		return new LogicalPlanWithNullaryRootImpl(mergedReqOp, null);
 	}
 
 	/**

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/ProjectPushDown.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/ProjectPushDown.java
@@ -352,8 +352,10 @@ public class ProjectPushDown implements HeuristicForLogicalOptimization
 
 		final SPARQLRequest newReq = new SPARQLRequestImpl( oldReq.getQueryPattern(), newProj, oldReq.getDistinctRequired() || mayReduce );
 
-		final LogicalOpMultiRequest mergedReqOp = new LogicalOpMultiRequest( newReq, reqOp.getFederationMembers() );
-		return new LogicalPlanWithNullaryRootImpl(mergedReqOp, null);
+		final LogicalOpMultiRequest mergedOp = new LogicalOpMultiRequest( newReq,
+		                                                                  reqOp.getServiceVariable(),
+		                                                                  reqOp.getFederationMembers() );
+		return new LogicalPlanWithNullaryRootImpl(mergedOp, null);
 	}
 
 	/**

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/ProjectPushDown.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/ProjectPushDown.java
@@ -43,6 +43,7 @@ import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalPlanWithNullaryRo
 import se.liu.ida.hefquin.engine.queryplan.logical.impl.LogicalPlanWithUnaryRootImpl;
 import se.liu.ida.hefquin.engine.queryproc.QueryProcContext;
 import se.liu.ida.hefquin.engine.queryproc.impl.loptimizer.HeuristicForLogicalOptimization;
+import se.liu.ida.hefquin.federation.FederationMember;
 import se.liu.ida.hefquin.federation.access.SPARQLRequest;
 import se.liu.ida.hefquin.federation.access.impl.req.SPARQLRequestImpl;
 import se.liu.ida.hefquin.federation.members.SPARQLEndpoint;
@@ -156,7 +157,8 @@ public class ProjectPushDown implements HeuristicForLogicalOptimization
 		@Override
 		public void visit( final LogicalOpMultiRequest op ) {
 			createdPlan = createPlanForMultiRequestUnderProject( projectOp,
-			                                                     op );
+			                                                     op,
+			                                                     inputPlan );
 		}
 
 		@Override
@@ -321,7 +323,8 @@ public class ProjectPushDown implements HeuristicForLogicalOptimization
 	}
 
 	/**
-	 * Pushes a project operator into a multi-request operator.
+	 * Pushes a project operator into a multi-request operator, but only if
+	 * all of the federation members of this operator are SPARQL endpoints.
 	 *
 	 * A new request is created whose projection variables correspond to the
 	 * variables required by the project operator. If the request already
@@ -337,7 +340,17 @@ public class ProjectPushDown implements HeuristicForLogicalOptimization
 	 */
 	protected LogicalPlan createPlanForMultiRequestUnderProject(
 			final LogicalOpProject projectOp,
-			final LogicalOpMultiRequest reqOp ) {
+			final LogicalOpMultiRequest reqOp,
+			final LogicalPlan inputPlan ) {
+		// First, make sure that all federation members of the mreq operator
+		// are SPARQL endpoints. If that is not the case, return the given
+		// input plan without pushing the projection into the request.
+		for ( final FederationMember fm : reqOp.getFederationMembers() ) {
+			if ( ! (fm instanceof SPARQLEndpoint) ) {
+				return inputPlan;
+			}
+		}
+
 		final SPARQLRequest oldReq = reqOp.getRequest();
 		final Set<Var> newProj;
 		if ( oldReq.getProjectionVars() != null ) {

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/RemoveUnnecessaryL2gAndG2l.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/loptimizer/heuristics/RemoveUnnecessaryL2gAndG2l.java
@@ -98,6 +98,13 @@ public class RemoveUnnecessaryL2gAndG2l implements HeuristicForLogicalOptimizati
 		}
 
 		@Override
+		public void visit( final LogicalOpMultiRequest op ) {
+			collectedTPs.addAll( op.getRequest()
+			                       .getQueryPattern()
+			                       .getAllMentionedTPs() );
+		}
+
+		@Override
 		public void visit( final LogicalOpFixedSolMap op ) {
 			// nothing to do here; this operator does not contain any triple pattern
 		}

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/simple/CardinalityBasedGreedyJoinPlanOptimizerImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/poptimizer/simple/CardinalityBasedGreedyJoinPlanOptimizerImpl.java
@@ -63,7 +63,8 @@ public class CardinalityBasedGreedyJoinPlanOptimizerImpl extends JoinPlanOptimiz
             try {
                 resps = FederationAccessUtils.performCardinalityRequests(
                         ctx.getFederationAccessMgr(),
-                        reqOpsOfAllSubPlans );
+                        reqOpsOfAllSubPlans,
+                        null );
             }
             catch ( final FederationAccessException e ) {
                 throw new PhysicalOptimizationException("Issuing a cardinality request caused an exception.", e);

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/srcsel/ServiceClauseBasedSourcePlannerImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/srcsel/ServiceClauseBasedSourcePlannerImpl.java
@@ -2,9 +2,12 @@ package se.liu.ida.hefquin.engine.queryproc.impl.srcsel;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
+import org.apache.jena.graph.Node;
 import org.apache.jena.sparql.algebra.Op;
 import org.apache.jena.sparql.algebra.op.*;
 import org.apache.jena.sparql.core.BasicPattern;
@@ -39,6 +42,7 @@ import se.liu.ida.hefquin.federation.access.impl.req.TriplePatternRequestImpl;
 import se.liu.ida.hefquin.federation.members.SPARQLEndpoint;
 import se.liu.ida.hefquin.federation.members.WrappedRESTEndpoint;
 import se.liu.ida.hefquin.jenaext.sparql.algebra.op.OpServiceWithParams;
+import se.liu.ida.hefquin.jenaext.sparql.algebra.op.OpServiceWithValues;
 
 /**
  * This implementation of {@link SourcePlanner} does not actually perform
@@ -99,6 +103,9 @@ public class ServiceClauseBasedSourcePlannerImpl extends SourcePlannerBase
 		}
 		else if ( jenaOp instanceof OpTable opTable ) {
 			return createPlanForValues(opTable, ctx);
+		}
+		else if ( jenaOp instanceof OpServiceWithValues opService ) {
+			return createPlanForServicePatternWithValues(opService, mayReduce, ctx);
 		}
 		else if ( jenaOp instanceof OpService opService ) {
 			return createPlanForServicePattern(opService, mayReduce, ctx);
@@ -259,15 +266,20 @@ public class ServiceClauseBasedSourcePlannerImpl extends SourcePlannerBase
 
 	/**
 	 * This function assumes that the given operator comes from a SERVICE
-	 * clause that did not have a PARAMS part (or an empty one), and it
+	 * clause that did not have a PARAMS part (or an empty one) and that
+	 * was not in the scope of a SERVICE-restricting VALUES clause, and it
 	 * produces a plan with a request operator as root.
 	 */
 	protected LogicalPlan createPlanForServicePattern( final OpService jenaOp,
 	                                                   final boolean mayReduce,
 	                                                   final QueryProcContext ctx ) {
 		log.debug( "SERVICE clause: {}", jenaOp.getService() );
+
+		if ( jenaOp instanceof OpServiceWithValues op )
+			return createPlanForServicePatternWithValues(op, mayReduce, ctx);
+
 		if ( jenaOp.getService().isVariable() )
-			throw new IllegalArgumentException( "unsupported SERVICE clause" );
+			throw new IllegalArgumentException( "unsupported SERVICE clause: it has a variable (" + jenaOp.getService().toString() + ") as service node" );
 
 		if (    jenaOp instanceof OpServiceWithParams op
 		     && op.getParamVars() != null
@@ -288,12 +300,41 @@ public class ServiceClauseBasedSourcePlannerImpl extends SourcePlannerBase
 				throw new IllegalArgumentException( "Invalid SERVICE clause: missing PARAMS for " + ep.toString() );
 
 			final SPARQLGraphPattern p =  new GenericSPARQLGraphPatternImpl2( jenaOp.getSubOp() );
-			final SPARQLRequest req = new SPARQLRequestImpl( p, null, false );
+			final SPARQLRequest req = new SPARQLRequestImpl( p, null, mayReduce );
 			final LogicalOpRequest<?,?> op = new LogicalOpRequest<>(ep, mayReduce, req);
 			return new LogicalPlanWithNullaryRootImpl(op, null);
 		}
 
 		return createPlan( jenaOp.getSubOp(), mayReduce, fm );
+	}
+
+	/**
+	 * This function assumes that the given operator comes from a
+	 * VALUES-extended SERVICE clause, and it produces a plan with
+	 * a multi-request operator as root.
+	 */
+	protected LogicalPlan createPlanForServicePatternWithValues(
+			final OpServiceWithValues jenaOp,
+			final boolean mayReduce,
+			final QueryProcContext ctx ) {
+		log.debug( "VALUES-extended SERVICE clause: {}", jenaOp.getService() );
+
+		if ( ! jenaOp.getService().isVariable() )
+			throw new IllegalArgumentException( "unsupported VALUES-extended SERVICE clause" );
+
+		final Set<FederationMember> fms = new HashSet<>();
+		for ( final Node n : jenaOp.getPossibleValues() ) {
+			final FederationMember fm = ctx.getFederationCatalog().getFederationMemberByURI( n.getURI() );
+			if ( ! (fm instanceof SPARQLEndpoint) )
+				throw new IllegalArgumentException( "VALUES-extended SERVICE clause with a federation member that is not a SPARQL endpoint (service URI: " + n.toString() + ")" );
+
+			fms.add(fm);
+		}
+
+		final SPARQLGraphPattern p =  new GenericSPARQLGraphPatternImpl2( jenaOp.getSubOp() );
+		final SPARQLRequest req = new SPARQLRequestImpl( p, null, mayReduce );
+		final LogicalOpMultiRequest op = new LogicalOpMultiRequest(req, fms);
+		return new LogicalPlanWithNullaryRootImpl(op, null);
 	}
 
 	/**

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/srcsel/ServiceClauseBasedSourcePlannerImpl.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/srcsel/ServiceClauseBasedSourcePlannerImpl.java
@@ -333,7 +333,8 @@ public class ServiceClauseBasedSourcePlannerImpl extends SourcePlannerBase
 
 		final SPARQLGraphPattern p =  new GenericSPARQLGraphPatternImpl2( jenaOp.getSubOp() );
 		final SPARQLRequest req = new SPARQLRequestImpl( p, null, mayReduce );
-		final LogicalOpMultiRequest op = new LogicalOpMultiRequest(req, fms);
+		final Var var = Var.alloc( jenaOp.getService() );
+		final LogicalOpMultiRequest op = new LogicalOpMultiRequest(req, var, fms);
 		return new LogicalPlanWithNullaryRootImpl(op, null);
 	}
 

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/EngineTestBase.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/EngineTestBase.java
@@ -10,6 +10,7 @@ import java.util.concurrent.ExecutorService;
 
 import org.apache.jena.graph.Graph;
 import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.sparql.algebra.Algebra;
 import org.apache.jena.sparql.algebra.Op;
 import org.apache.jena.sparql.core.Var;
@@ -190,7 +191,8 @@ public abstract class EngineTestBase
 	}
 
 	protected TPFServer getDBpediaTPFServer() {
-		return new TPFServerImpl( "http://fragments.dbpedia.org/2016-04/en",
+		return new TPFServerImpl( NodeFactory.createURI("http://example.org/tpf"),
+		                          "http://fragments.dbpedia.org/2016-04/en",
 		                          null ); // no vocab.mapping
 	}
 
@@ -199,6 +201,7 @@ public abstract class EngineTestBase
 		protected final Graph data;
 
 		public FederationMemberBaseForTest( final Graph data ) {
+			super( NodeFactory.createURI("http://example.org/fm") );
 			this.data = data;
 		}
 

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/ValuesServiceQueryResolverTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/ValuesServiceQueryResolverTest.java
@@ -2,13 +2,22 @@ package se.liu.ida.hefquin.engine;
 
 import static org.junit.Assert.assertTrue;
 
+import java.util.Set;
+
+import org.apache.jena.graph.Node;
+import org.apache.jena.graph.NodeFactory;
 import org.apache.jena.query.Query;
 import org.apache.jena.query.QueryFactory;
+import org.apache.jena.sparql.core.Var;
 import org.apache.jena.sparql.syntax.Element;
+import org.apache.jena.sparql.syntax.ElementGroup;
+import org.apache.jena.sparql.syntax.ElementService;
 import org.apache.jena.sparql.syntax.syntaxtransform.ElementTransform;
 import org.apache.jena.sparql.syntax.syntaxtransform.ElementTransformCleanGroupsOfOne;
 import org.apache.jena.sparql.syntax.syntaxtransform.ElementTransformer;
 import org.junit.Test;
+
+import se.liu.ida.hefquin.jenaext.sparql.syntax.ElementServiceWithValues;
 
 public class ValuesServiceQueryResolverTest
 {
@@ -174,21 +183,20 @@ public class ValuesServiceQueryResolverTest
 		ValuesServiceQueryResolver.expandValuesPlusServicePattern(q);
 
 		final String expectedQueryString =
-				  "SELECT * WHERE {"
-				+ " {"
-				+ "   SERVICE <http://example1.org> { ?x a ?y }"
-				+ "   BIND( <http://example1.org> AS ?s )"
-				+ " } UNION {"
-				+ "   SERVICE <http://example2.org> { ?x a ?y }"
-				+ "   BIND( <http://example2.org> AS ?s )"
-				+ " }"
-				+ "}";
-		final Element expectedPattern = QueryFactory.create(expectedQueryString).getQueryPattern();
+				  "SELECT * WHERE { SERVICE ?s { ?x a ?y }  }";
+		final Element e1 = QueryFactory.create(expectedQueryString).getQueryPattern();
+		final Element e2 = ((ElementGroup) e1).get(0);
+		final ElementService s = (ElementService) e2;
 
-		final ElementTransform t = new ElementTransformCleanGroupsOfOne();
-		final Element expectedPattern2 = ElementTransformer.transform(expectedPattern, t);
+		final Set<Node> values = Set.of( NodeFactory.createURI("http://example1.org"),
+		                                 NodeFactory.createURI("http://example2.org") );
 
-		assertTrue( q.getQueryPattern().equals(expectedPattern2) );
+		final Element expectedPattern = new ElementServiceWithValues( Var.alloc("s"),
+		                                                              s.getElement(),
+		                                                              s.getSilent(),
+		                                                              values );
+
+		assertTrue( q.getQueryPattern().equals(expectedPattern) );
 	}
 
 	@Test
@@ -291,20 +299,24 @@ public class ValuesServiceQueryResolverTest
 				  "SELECT * WHERE {"
 				+ " SERVICE <http://example1.org> { ?x a ?y }"
 				+ " BIND( <http://example1.org> AS ?s1 )"
-				+ " {"
-				+ "     SERVICE <http://example2.org> { ?z a ?y }"
-				+ "     BIND( <http://example2.org> AS ?s2 )"
-				+ " } UNION {"
-				+ "     SERVICE <http://example3.org> { ?z a ?y }"
-				+ "     BIND( <http://example3.org> AS ?s2 )"
-				+ " }"
+				+ " SERVICE ?s2 { ?z a ?y }"
 				+ "}";
-		final Element expectedPattern = QueryFactory.create(expectedQueryString).getQueryPattern();
+		final Element e1 = QueryFactory.create(expectedQueryString).getQueryPattern();
+		final ElementGroup eg = (ElementGroup) e1;
+		final ElementService s = (ElementService) eg.get(2);
 
-		final ElementTransform t = new ElementTransformCleanGroupsOfOne();
-		final Element expectedPattern2 = ElementTransformer.transform(expectedPattern, t);
+		final Set<Node> values = Set.of( NodeFactory.createURI("http://example2.org"),
+		                                 NodeFactory.createURI("http://example3.org") );
 
-		assertTrue( q.getQueryPattern().equals(expectedPattern2) );
+		final ElementGroup egExpected = new ElementGroup();
+		egExpected.addElement( eg.get(0) );
+		egExpected.addElement( eg.get(1) );
+		egExpected.addElement( new ElementServiceWithValues(Var.alloc("s2"),
+		                                                    s.getElement(),
+		                                                    s.getSilent(),
+		                                                    values) );
+
+		assertTrue( q.getQueryPattern().equals(egExpected) );
 	}
 
 	@Test


### PR DESCRIPTION
This PR adds a new logical operator called _mreq_ (multi-request), together with a corresponding pair of a physical and an executable operator.

The use case of this operator is to improve the processing of query patterns of the following type.
```
# ...
VALUES ?s ( <http://example.org/endpoint1>
            <http://example.org/endpoint2>
            <http://example.org/endpoint3> )
SERVICE ?s {
    # ... some pattern P
}
# ...
```
The initial logical (sub)plan for this pattern without the new operator would be something like the following.
```
mu
|
+-- bind ( <http://example.org/endpoint1> AS ?s )
|   |
|   +-- req ( P at <http://example.org/endpoint1> )
|
+-- bind ( <http://example.org/endpoint2> AS ?s )
|   |
|   +-- req ( P at <http://example.org/endpoint2> )
|
+-- bind ( <http://example.org/endpoint3> AS ?s )
    |
    +-- req ( P at <http://example.org/endpoint3> )
```
Clearly, these subplans can become pretty big if the corresponding VALUES clause has many service URIs. As a consequence, during query planning, HeFQUIN will have to repeatedly traverse many (sub)subplans (e.g., the 'filter push down' heuristic would recursively go into all these subplans).

The new operator avoid this problem. The complete subplan for the pattern above is just a single _mreq_ operator:
```
mreq ( P, ?s, L )
```
where `L` is a list of the service URIs from the VALUES clause. The semantics of the operator is such that it is equivalent to the semantics of the plan above. The corresponding executable operator is obviously doing the requests to the listed endpoints in parallel.

Since one aspect of the semantics of this operator is to bind the service URIs of the accessed federation members to a given variable (?s in the example above), the implementation of the operator requires access to these service URIs. Therefore, this PR adds a `getServiceURI()` method to the `FederationMember` interface, which means that all implementations of this interface need to be extended.

**Another thing that this PR fixes** is that the bind-join algorithm was not considered for cases in which the request operator under a join has a bind operator on top (i.e., between the request operator and the join operator), but it was considered---correctly so---if the request has a filter operator on top. Now, requests with a bind operator on top are also considered for the bind-join algorithm (the bind operator would then be pulled on top of the bind join).