### PR TITLE
bug fix of incorrect assertion in ExecOpRequestOther

### DIFF
--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestOther.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestOther.java
@@ -35,7 +35,7 @@ public class ExecOpRequestOther extends BaseForExecOpRequest<SPARQLRequest,
 	                           final QueryPlanningInfo qpInfo ) {
 		super(req, fm, mayReduce, collectExceptions, qpInfo);
 
-		assert fm.getNumberOfParameters() != 0;
+		assert fm.getNumberOfParameters() == 0;
 
 		log.debug( "Initialized ExecOpRequestOther for {}", fm );
 	}


### PR DESCRIPTION
As pointed out in issue #681, the constructor of `ExecOpRequestOther` contained:
```java
assert fm.getNumberOfParameters() != 0;
```
which was a typo. It should have been:
```java
assert fm.getNumberOfParameters() == 0;
```
This PR fixes that issue and, thus, closes #681