### PR TITLE
Rename defaultmaxparallelrequests to defaultparallelrequestlimitperserver

### DIFF
--- a/config/DefaultConfDescr.ttl
+++ b/config/DefaultConfDescr.ttl
@@ -24,7 +24,7 @@ _:bFederationAccessManager rdf:type ec:FederationAccessManager ;
           ec:javaClassName "se.liu.ida.hefquin.federation.access.impl.AsyncFederationAccessManagerImpl" ;
           ec:constructorArguments (
             ec:value:ExecServiceForFedAccess
-            10  # defaultMaxParallelRequests
+            10  # defaultParallelRequestLimitPerServer
           )
         ]
         # L1 cache

--- a/config/DefaultConfDescrExtended.ttl
+++ b/config/DefaultConfDescrExtended.ttl
@@ -12,7 +12,7 @@ PREFIX ex:     <http://example.org/>
               ec:javaClassName "se.liu.ida.hefquin.federation.access.impl.AsyncFederationAccessManagerImpl" ;
               ec:constructorArguments (
                 ec:value:ExecServiceForFedAccess
-                10  # defaultMaxParallelRequests
+                10  # defaultParallelRequestLimitPerServer
               )
             ]
             # L1 cache

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/AsyncFederationAccessManagerImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/AsyncFederationAccessManagerImpl.java
@@ -70,15 +70,15 @@ public class AsyncFederationAccessManagerImpl extends FederationAccessManagerBas
 	 * service and sets the default limit on the number of parallel requests to a given
 	 * server.
 	 *
-	 * @param execService                   the executor service used for asynchronous request
-	 *                                      execution
-	 * @param parallelRequestLimitPerServer the default limit on the number of parallel requests to
-	 *                                      any given server
+	 * @param execService                          the executor service used for asynchronous request
+	 *                                             execution
+	 * @param defaultParallelRequestLimitPerServer the default limit on the number of parallel requests to
+	 *                                             any given server
 	 */
-	public AsyncFederationAccessManagerImpl( final ExecutorService execService, final int parallelRequestLimitPerServer ) {
+	public AsyncFederationAccessManagerImpl( final ExecutorService execService, final int defaultParallelRequestLimitPerServer ) {
 		this(execService);
 		// Set default number of parallel request to any given server
-		HttpClientProvider.setDefaultParallelRequestLimitPerServer(parallelRequestLimitPerServer);
+		HttpClientProvider.setDefaultParallelRequestLimitPerServer(defaultParallelRequestLimitPerServer);
 	}
 
 	@Override

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/AsyncFederationAccessManagerImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/AsyncFederationAccessManagerImpl.java
@@ -67,18 +67,18 @@ public class AsyncFederationAccessManagerImpl extends FederationAccessManagerBas
 
 	/**
 	 * Creates an {@link AsyncFederationAccessManagerImpl} using the given executor
-	 * service and sets the default maximum number of parallel requests to a given
-	 * endpoint address.
+	 * service and sets the default limit on the number of parallel requests to a given
+	 * server.
 	 *
-	 * @param execService         the executor service used for asynchronous request
-	 *                            execution
-	 * @param maxParallelRequests the default maximum number of parallel requests to
-	 *                            any given endpoint address
+	 * @param execService                   the executor service used for asynchronous request
+	 *                                      execution
+	 * @param parallelRequestLimitPerServer the default limit on the number of parallel requests to
+	 *                                      any given server
 	 */
-	public AsyncFederationAccessManagerImpl( final ExecutorService execService, final int maxParallelRequests ) {
+	public AsyncFederationAccessManagerImpl( final ExecutorService execService, final int parallelRequestLimitPerServer ) {
 		this(execService);
-		// Set default number of parallel request to any given endpoint address
-		HttpClientProvider.setDefaultMaxParallelRequests(maxParallelRequests);
+		// Set default number of parallel request to any given server
+		HttpClientProvider.setDefaultParallelRequestLimitPerServer(parallelRequestLimitPerServer);
 	}
 
 	@Override

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/net/http/HttpClientProvider.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/net/http/HttpClientProvider.java
@@ -107,7 +107,7 @@ public class HttpClientProvider
 	 */
 	public static void setDefaultParallelRequestLimitPerServer( final int limit ) {
 		if ( limit <= 0 ) {
-			throw new IllegalArgumentException("parallelRequestLimitPerServer must be greater than zero");
+			throw new IllegalArgumentException("defaultParallelRequestLimitPerServer must be greater than zero");
 		}
 		defaultParallelRequestLimitPerServer = limit;
 	}

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/net/http/HttpClientProvider.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/net/http/HttpClientProvider.java
@@ -48,11 +48,11 @@ public class HttpClientProvider
 	// No timeout
 	private static final long NO_TIMEOUT = -1;
 
-	// Default max number of parallel requests per endpoint address
-	private static final int DEFAULT_MAX_PARALLEL_REQUESTS = 10;
+	// Default parallel request limit per server
+	private static final int DEFAULT_PARALLEL_REQUEST_LIMIT_PER_SERVER = 10;
 
 	// Mutable default (can be overridden)
-	private static int defaultMaxParallelRequests = DEFAULT_MAX_PARALLEL_REQUESTS;
+	private static int defaultParallelRequestLimitPerServer = DEFAULT_PARALLEL_REQUEST_LIMIT_PER_SERVER;
 
 	/** One limiter per endpoint address. The limiter for an endpoint address is shared across all clients. */
 	protected static final Map<String, Semaphore> LIMITERS_BY_ENDPOINT_ADDRESS = new ConcurrentHashMap<>();
@@ -97,20 +97,19 @@ public class HttpClientProvider
 	}
 
 	/**
-	 * Sets the default maximum number of concurrent requests per endpoint address.
+	 * Sets the default limit on the number of concurrent requests per server.
 	 *
 	 * This value is used when creating new endpoint limiters via
 	 * {@link #getOrCreateEndpointLimiter(String)}.
 	 *
-	 * @param maxParallelRequests maximum number of concurrent requests per
-	 *                            endpoint address
-	 * @throws IllegalArgumentException if {@code maxParallelRequests} is non-positive
+	 * @param parallelRequestLimitPerServer maximum number of concurrent requests per server
+	 * @throws IllegalArgumentException if {@code parallelRequestLimitPerServer} is non-positive
 	 */
-	public static void setDefaultMaxParallelRequests( final int maxParallelRequests ) {
-		if ( maxParallelRequests <= 0 ) {
-			throw new IllegalArgumentException("maxParallelRequests must be greater than zero");
+	public static void setDefaultParallelRequestLimitPerServer( final int parallelRequestLimitPerServer ) {
+		if ( parallelRequestLimitPerServer <= 0 ) {
+			throw new IllegalArgumentException("parallelRequestLimitPerServer must be greater than zero");
 		}
-		defaultMaxParallelRequests = maxParallelRequests;
+		defaultParallelRequestLimitPerServer = parallelRequestLimitPerServer;
 	}
 
 	/**
@@ -119,18 +118,18 @@ public class HttpClientProvider
 	 * If a limiter is already registered for the endpoint address, it is replaced.
 	 *
 	 * @param endpointAddress     endpoint address
-	 * @param maxParallelRequests maximum number of concurrent requests allowed for
-	 *                            the endpoint address
-	 * @throws IllegalArgumentException if maxParallelRequests is non-positive.
+	 * @param parallelRequestLimitPerServer limit on the number of concurrent requests allowed for
+	 *                                      the endpoint address
+	 * @throws IllegalArgumentException if parallelRequestLimitPerServer is non-positive.
 	 */
-	public static void registerEndpointLimiter( final String endpointAddress, final int maxParallelRequests ) {
-		if ( maxParallelRequests <= 0 ) {
-			throw new IllegalArgumentException("maxParallelRequests must be greater than zero");
+	public static void registerEndpointLimiter( final String endpointAddress, final int parallelRequestLimitPerServer ) {
+		if ( parallelRequestLimitPerServer <= 0 ) {
+			throw new IllegalArgumentException("parallelRequestLimitPerServer must be greater than zero");
 		}
 		final String url = endpointAddress.endsWith( "/" )
 				? endpointAddress.substring( 0, endpointAddress.length() - 1 )
 				: endpointAddress;
-		LIMITERS_BY_ENDPOINT_ADDRESS.put( url, new Semaphore(maxParallelRequests, true) );
+		LIMITERS_BY_ENDPOINT_ADDRESS.put( url, new Semaphore(parallelRequestLimitPerServer, true) );
 	}
 
 	/**
@@ -196,14 +195,14 @@ public class HttpClientProvider
 	 * Creates a new default concurrency limiter.
 	 *
 	 * <p>
-	 * The returned limiter enforces the current {@link #defaultMaxParallelRequests}
+	 * The returned limiter enforces the current {@link #defaultParallelRequestLimitPerServer}
 	 * and uses a fair (FIFO) scheduling policy.
 	 * </p>
 	 *
 	 * @return a new {@link Semaphore} configured with the default concurrency limit
 	 */
 	private static Semaphore newDefaultLimiter() {
-		return new Semaphore( defaultMaxParallelRequests, true );
+		return new Semaphore( defaultParallelRequestLimitPerServer, true );
 	}
 
 	/**
@@ -221,7 +220,7 @@ public class HttpClientProvider
 	public static void reset() {
 		CLIENT_BY_CONNECT_TIMEOUT.clear();
 		LIMITERS_BY_ENDPOINT_ADDRESS.clear();
-		defaultMaxParallelRequests = DEFAULT_MAX_PARALLEL_REQUESTS;
+		defaultParallelRequestLimitPerServer = DEFAULT_PARALLEL_REQUEST_LIMIT_PER_SERVER;
 	}
 
 	static final class LimitedHttpClient extends HttpClient

--- a/hefquin-base/src/main/java/se/liu/ida/hefquin/base/net/http/HttpClientProvider.java
+++ b/hefquin-base/src/main/java/se/liu/ida/hefquin/base/net/http/HttpClientProvider.java
@@ -102,14 +102,14 @@ public class HttpClientProvider
 	 * This value is used when creating new endpoint limiters via
 	 * {@link #getOrCreateEndpointLimiter(String)}.
 	 *
-	 * @param parallelRequestLimitPerServer maximum number of concurrent requests per server
-	 * @throws IllegalArgumentException if {@code parallelRequestLimitPerServer} is non-positive
+	 * @param limit maximum number of concurrent requests per server
+	 * @throws IllegalArgumentException if {@code limit} is non-positive
 	 */
-	public static void setDefaultParallelRequestLimitPerServer( final int parallelRequestLimitPerServer ) {
-		if ( parallelRequestLimitPerServer <= 0 ) {
+	public static void setDefaultParallelRequestLimitPerServer( final int limit ) {
+		if ( limit <= 0 ) {
 			throw new IllegalArgumentException("parallelRequestLimitPerServer must be greater than zero");
 		}
-		defaultParallelRequestLimitPerServer = parallelRequestLimitPerServer;
+		defaultParallelRequestLimitPerServer = limit;
 	}
 
 	/**
@@ -117,19 +117,19 @@ public class HttpClientProvider
 	 *
 	 * If a limiter is already registered for the endpoint address, it is replaced.
 	 *
-	 * @param endpointAddress     endpoint address
-	 * @param parallelRequestLimitPerServer limit on the number of concurrent requests allowed for
-	 *                                      the endpoint address
-	 * @throws IllegalArgumentException if parallelRequestLimitPerServer is non-positive.
+	 * @param endpointAddress endpoint address
+	 * @param limit           limit on the number of concurrent requests allowed for
+	 *                        the endpoint address
+	 * @throws IllegalArgumentException if {@code limit} is non-positive.
 	 */
-	public static void registerEndpointLimiter( final String endpointAddress, final int parallelRequestLimitPerServer ) {
-		if ( parallelRequestLimitPerServer <= 0 ) {
-			throw new IllegalArgumentException("parallelRequestLimitPerServer must be greater than zero");
+	public static void registerEndpointLimiter( final String endpointAddress, final int limit ) {
+		if ( limit <= 0 ) {
+			throw new IllegalArgumentException("limit must be greater than zero");
 		}
 		final String url = endpointAddress.endsWith( "/" )
 				? endpointAddress.substring( 0, endpointAddress.length() - 1 )
 				: endpointAddress;
-		LIMITERS_BY_ENDPOINT_ADDRESS.put( url, new Semaphore(parallelRequestLimitPerServer, true) );
+		LIMITERS_BY_ENDPOINT_ADDRESS.put( url, new Semaphore(limit, true) );
 	}
 
 	/**

--- a/hefquin-base/src/test/java/se/liu/ida/hefquin/base/net/http/HttpClientProviderTest.java
+++ b/hefquin-base/src/test/java/se/liu/ida/hefquin/base/net/http/HttpClientProviderTest.java
@@ -48,7 +48,7 @@ public class HttpClientProviderTest
 	@Test
 	public void limitConcurrentRequestsToOneViaGlobal() throws IOException {
 		final int numberOfRequests = 20;
-		HttpClientProvider.setDefaultMaxParallelRequests(1);
+		HttpClientProvider.setDefaultParallelRequestLimitPerServer(1);
 		final long start = System.currentTimeMillis();
 		final HttpClient client = HttpClientProvider.client();
 		final CompletableFuture<?>[] futures = sendAsyncRequests(client, url, numberOfRequests);
@@ -67,7 +67,7 @@ public class HttpClientProviderTest
 	@Test
 	public void limitConcurrentRequestsToOne() throws IOException {
 		final int numberOfRequests = 20;
-		HttpClientProvider.setDefaultMaxParallelRequests(20);
+		HttpClientProvider.setDefaultParallelRequestLimitPerServer(20);
 		HttpClientProvider.registerEndpointLimiter(url, 1);
 		final long start = System.currentTimeMillis();
 		final HttpClient client = HttpClientProvider.client();
@@ -146,7 +146,7 @@ public class HttpClientProviderTest
 	@Test
 	public void noLimitOnConcurrentRequestsViaGlobal() throws IOException {
 		final int numberOfRequests = 20;
-		HttpClientProvider.setDefaultMaxParallelRequests(numberOfRequests);
+		HttpClientProvider.setDefaultParallelRequestLimitPerServer(numberOfRequests);
 		final long start = System.currentTimeMillis();
 		final HttpClient client = HttpClientProvider.client();
 		final CompletableFuture<?>[] futures = sendAsyncRequests(client, url, numberOfRequests);
@@ -180,7 +180,7 @@ public class HttpClientProviderTest
 	@Test
 	public void endpointLimiterOverridesDefaultLimit() throws IOException {
 		final int numberOfRequests = 20;
-		HttpClientProvider.setDefaultMaxParallelRequests(1);
+		HttpClientProvider.setDefaultParallelRequestLimitPerServer(1);
 		HttpClientProvider.registerEndpointLimiter(url, numberOfRequests);
 		final long start = System.currentTimeMillis();
 		final HttpClient client = HttpClientProvider.client();


### PR DESCRIPTION
Closes #689.