### PR TITLE
Change printing of errors in RunQueryWithoutSrcSel

### DIFF
--- a/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunQueryWithoutSrcSel.java
+++ b/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunQueryWithoutSrcSel.java
@@ -179,10 +179,11 @@ public class RunQueryWithoutSrcSel extends CmdARQ
 			System.err.println();
 			for ( int i = 0; i < numberOfExceptions; i++ ) {
 				final Exception ex = exceptions.get(i);
-				final Throwable rc = getRootCause( ex );
-				System.err.println( (i + 1) + " " + rc.getClass().getName() + ": " + rc.getMessage() );
-				System.err.println( "StackTrace:" );
-				ex.printStackTrace( System.err );
+				System.err.println( "Exception " + (i + 1) + ": " + ex.getMessage() );
+				if ( isVerbose() ) {
+					System.err.println( "StackTrace:" );
+					ex.printStackTrace( System.err );
+				}
 				System.err.println();
 			}
 		}
@@ -216,25 +217,6 @@ public class RunQueryWithoutSrcSel extends CmdARQ
 			System.err.println( "Failed to load query: " + ex.getMessage() );
 			throw new TerminationException( 1 );
 		}
-	}
-
-	/**
-	 * Returns the root cause of a throwable by traversing the cause chain.
-	 *
-	 * This method follows the chain of {@code Throwable.getCause()} until it
-	 * reaches the deepest non-null cause. If the input {@code throwable} has no
-	 * cause, the method returns the throwable itself.
-	 *
-	 * @param throwable the throwable from which to extract the root cause
-	 * @return the root cause of the throwable, or {@code null} if {@code throwable}
-	 *         is {@code null}
-	 */
-	private static Throwable getRootCause( final Throwable throwable ) {
-		Throwable cause = throwable;
-		while ( cause.getCause() != null ) {
-			cause = cause.getCause();
-		}
-		return cause;
 	}
 
 	/**

--- a/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunQueryWithoutSrcSel.java
+++ b/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunQueryWithoutSrcSel.java
@@ -89,6 +89,16 @@ public class RunQueryWithoutSrcSel extends CmdARQ
 		return "hefquin";
 	}
 
+	@Override
+	protected void processModulesAndArgs() {
+		super.processModulesAndArgs();
+
+		// Fix because 'ModGeneral' currently sets the verbose flag instead
+		// of the debug flag whenever the --debug argument is given.
+		if ( isVerbose() )
+			modGeneral.debug = true;
+	}
+
 	/**
 	 * Executes the query using the HeFQUIN federation engine and handles the
 	 * results and statistics.
@@ -180,7 +190,7 @@ public class RunQueryWithoutSrcSel extends CmdARQ
 			for ( int i = 0; i < numberOfExceptions; i++ ) {
 				final Exception ex = exceptions.get(i);
 				System.err.println( "Exception " + (i + 1) + ": " + ex.getMessage() );
-				if ( isVerbose() ) {
+				if ( isDebug() ) {
 					System.err.println( "StackTrace:" );
 					ex.printStackTrace( System.err );
 				}


### PR DESCRIPTION
Implements a more user-friendly printing of exceptions with the use of the `--debug` argument, as outlined in the following comment: https://github.com/LiUSemWeb/HeFQUIN/pull/680#issuecomment-5470435688

Weirdly enough, from inspecting `processArgs` of `ModGeneral`, giving the `--debug` flag does not set the `debug` boolean to true but instead, the verbose boolean. Therefore, `isVerbose()` is used.