### PR TITLE
Change constructors of federationaccessmanagers

### DIFF
--- a/config/DefaultConfDescr.ttl
+++ b/config/DefaultConfDescr.ttl
@@ -31,12 +31,17 @@ _:bFederationAccessManager rdf:type ec:FederationAccessManager ;
               ec:javaClassName "se.liu.ida.hefquin.federation.access.impl.reqproc.TPFRequestProcessorImpl" ]
             [ ec:argumentTypeName "se.liu.ida.hefquin.federation.access.impl.reqproc.BRTPFRequestProcessor" ;
               ec:javaClassName "se.liu.ida.hefquin.federation.access.impl.reqproc.BRTPFRequestProcessorImpl" ]
-            [ ec:argumentTypeName "se.liu.ida.hefquin.federation.access.impl.reqproc.Neo4jRequestProcessor" ;
-              ec:javaClassName "se.liu.ida.hefquin.federation.access.impl.reqproc.Neo4jRequestProcessorImpl" ]
-            [ ec:argumentTypeName "se.liu.ida.hefquin.federation.access.impl.reqproc.RESTRequestProcessor" ;
-              ec:javaClassName "se.liu.ida.hefquin.federation.access.impl.reqproc.RESTRequestProcessorImpl" ]
-            [ ec:argumentTypeName "se.liu.ida.hefquin.federation.access.impl.reqproc.GraphQLRequestProcessor" ;
-              ec:javaClassName "se.liu.ida.hefquin.federation.access.impl.reqproc.GraphQLRequestProcessorImpl" ]
+            [
+              ec:elementsTypeName "se.liu.ida.hefquin.federation.access.impl.RequestProcessor" ;
+              ec:elements (
+                [ ec:argumentTypeName "se.liu.ida.hefquin.federation.access.impl.reqproc.Neo4jRequestProcessor" ;
+                ec:javaClassName "se.liu.ida.hefquin.federation.access.impl.reqproc.Neo4jRequestProcessorImpl" ]
+                [ ec:argumentTypeName "se.liu.ida.hefquin.federation.access.impl.reqproc.RESTRequestProcessor" ;
+                ec:javaClassName "se.liu.ida.hefquin.federation.access.impl.reqproc.RESTRequestProcessorImpl" ]
+                [ ec:argumentTypeName "se.liu.ida.hefquin.federation.access.impl.reqproc.GraphQLRequestProcessor" ;
+                ec:javaClassName "se.liu.ida.hefquin.federation.access.impl.reqproc.GraphQLRequestProcessorImpl" ]
+              )
+            ]
           )
         ]
         # L1 cache

--- a/config/DefaultConfDescrExtended.ttl
+++ b/config/DefaultConfDescrExtended.ttl
@@ -19,12 +19,17 @@ PREFIX ex:     <http://example.org/>
                   ec:javaClassName "se.liu.ida.hefquin.federation.access.impl.reqproc.TPFRequestProcessorImpl" ]
                 [ ec:argumentTypeName "se.liu.ida.hefquin.federation.access.impl.reqproc.BRTPFRequestProcessor" ;
                   ec:javaClassName "se.liu.ida.hefquin.federation.access.impl.reqproc.BRTPFRequestProcessorImpl" ]
-                [ ec:argumentTypeName "se.liu.ida.hefquin.federation.access.impl.reqproc.Neo4jRequestProcessor" ;
-                  ec:javaClassName "se.liu.ida.hefquin.federation.access.impl.reqproc.Neo4jRequestProcessorImpl" ]
-                [ ec:argumentTypeName "se.liu.ida.hefquin.federation.access.impl.reqproc.RESTRequestProcessor" ;
-                  ec:javaClassName "se.liu.ida.hefquin.federation.access.impl.reqproc.RESTRequestProcessorImpl" ]
-                [ ec:argumentTypeName "se.liu.ida.hefquin.federation.access.impl.reqproc.GraphQLRequestProcessor" ;
-                  ec:javaClassName "se.liu.ida.hefquin.federation.access.impl.reqproc.GraphQLRequestProcessorImpl" ]
+                [
+                  ec:elementsTypeName "se.liu.ida.hefquin.federation.access.impl.RequestProcessor" ;
+                  ec:elements (
+                      [ ec:argumentTypeName "se.liu.ida.hefquin.federation.access.impl.reqproc.Neo4jRequestProcessor" ;
+                      ec:javaClassName "se.liu.ida.hefquin.federation.access.impl.reqproc.Neo4jRequestProcessorImpl" ]
+                      [ ec:argumentTypeName "se.liu.ida.hefquin.federation.access.impl.reqproc.RESTRequestProcessor" ;
+                      ec:javaClassName "se.liu.ida.hefquin.federation.access.impl.reqproc.RESTRequestProcessorImpl" ]
+                      [ ec:argumentTypeName "se.liu.ida.hefquin.federation.access.impl.reqproc.GraphQLRequestProcessor" ;
+                      ec:javaClassName "se.liu.ida.hefquin.federation.access.impl.reqproc.GraphQLRequestProcessorImpl" ]
+                  )
+                ]
               )
             ]
             # L1 cache

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/AsyncFederationAccessManagerImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/AsyncFederationAccessManagerImpl.java
@@ -1,5 +1,6 @@
 package se.liu.ida.hefquin.federation.access.impl;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -12,9 +13,6 @@ import se.liu.ida.hefquin.federation.access.DataRetrievalRequest;
 import se.liu.ida.hefquin.federation.access.DataRetrievalResponse;
 import se.liu.ida.hefquin.federation.access.FederationAccessException;
 import se.liu.ida.hefquin.federation.access.impl.reqproc.BRTPFRequestProcessor;
-import se.liu.ida.hefquin.federation.access.impl.reqproc.GraphQLRequestProcessor;
-import se.liu.ida.hefquin.federation.access.impl.reqproc.Neo4jRequestProcessor;
-import se.liu.ida.hefquin.federation.access.impl.reqproc.RESTRequestProcessor;
 import se.liu.ida.hefquin.federation.access.impl.reqproc.SPARQLRequestProcessor;
 import se.liu.ida.hefquin.federation.access.impl.reqproc.TPFRequestProcessor;
 
@@ -38,10 +36,8 @@ public class AsyncFederationAccessManagerImpl extends FederationAccessManagerBas
 			final SPARQLRequestProcessor reqProcSPARQL,
 			final TPFRequestProcessor reqProcTPF,
 			final BRTPFRequestProcessor reqProcBRTPF,
-			final Neo4jRequestProcessor reqProcNeo4j,
-			final RESTRequestProcessor reqProcREST,
-			final GraphQLRequestProcessor reqProcGraphQL ) {
-		super(reqProcSPARQL, reqProcTPF, reqProcBRTPF, reqProcNeo4j, reqProcREST, reqProcGraphQL);
+			final List<RequestProcessor<?,?,?>> otherRequestProcessors ) {
+		super(reqProcSPARQL, reqProcTPF, reqProcBRTPF, otherRequestProcessors);
 
 		assert execService != null;
 		threadPool = execService;

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/BlockingFederationAccessManagerImpl.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/BlockingFederationAccessManagerImpl.java
@@ -1,5 +1,6 @@
 package se.liu.ida.hefquin.federation.access.impl;
 
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -24,10 +25,8 @@ public class BlockingFederationAccessManagerImpl extends FederationAccessManager
 			final SPARQLRequestProcessor reqProcSPARQL,
 			final TPFRequestProcessor reqProcTPF,
 			final BRTPFRequestProcessor reqProcBRTPF,
-			final Neo4jRequestProcessor reqProcNeo4j,
-			final RESTRequestProcessor reqProcREST,
-			final GraphQLRequestProcessor reqProcGraphQL ) {
-		super(reqProcSPARQL, reqProcTPF, reqProcBRTPF, reqProcNeo4j, reqProcREST, reqProcGraphQL);
+			final List<RequestProcessor<?,?,?>> otherRequestProcessors ) {
+		super(reqProcSPARQL, reqProcTPF, reqProcBRTPF, otherRequestProcessors);
 	}
 
 	@Override

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerBase2.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerBase2.java
@@ -12,9 +12,6 @@ import se.liu.ida.hefquin.federation.access.FederationAccessManager;
 import se.liu.ida.hefquin.federation.access.SPARQLRequest;
 import se.liu.ida.hefquin.federation.access.TPFRequest;
 import se.liu.ida.hefquin.federation.access.impl.reqproc.BRTPFRequestProcessor;
-import se.liu.ida.hefquin.federation.access.impl.reqproc.GraphQLRequestProcessor;
-import se.liu.ida.hefquin.federation.access.impl.reqproc.Neo4jRequestProcessor;
-import se.liu.ida.hefquin.federation.access.impl.reqproc.RESTRequestProcessor;
 import se.liu.ida.hefquin.federation.access.impl.reqproc.SPARQLRequestProcessor;
 import se.liu.ida.hefquin.federation.access.impl.reqproc.TPFRequestProcessor;
 import se.liu.ida.hefquin.federation.members.BRTPFServer;
@@ -37,24 +34,20 @@ public abstract class FederationAccessManagerBase2 extends FederationAccessManag
 			final SPARQLRequestProcessor reqProcSPARQL,
 			final TPFRequestProcessor reqProcTPF,
 			final BRTPFRequestProcessor reqProcBRTPF,
-			final Neo4jRequestProcessor reqProcNeo4j,
-			final RESTRequestProcessor reqProcREST,
-			final GraphQLRequestProcessor reqProcGraphQL )
+			final List<RequestProcessor<?,?,?>> otherReqProcessors )
 	{
 		assert reqProcSPARQL  != null;
 		assert reqProcTPF     != null;
 		assert reqProcBRTPF   != null;
-		assert reqProcNeo4j   != null;
-		assert reqProcREST    != null;
-		assert reqProcGraphQL != null;
 
 		this.reqProcSPARQL    = reqProcSPARQL;
 		this.reqProcTPF       = reqProcTPF;
 		this.reqProcBRTPF     = reqProcBRTPF;
 
-		reqProcessors.add(reqProcREST);
-		reqProcessors.add(reqProcNeo4j);
-		reqProcessors.add(reqProcGraphQL);
+		for ( final RequestProcessor<?,?,?> reqProc : otherReqProcessors ) {
+			assert reqProc != null;
+			reqProcessors.add(reqProc);
+		}
 	}
 
 	protected < ReqType extends DataRetrievalRequest,

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerWithCache.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/access/impl/FederationAccessManagerWithCache.java
@@ -3,7 +3,6 @@ package se.liu.ida.hefquin.federation.access.impl;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 
 import se.liu.ida.hefquin.base.datastructures.Cache;
 import se.liu.ida.hefquin.base.datastructures.impl.cache.CacheEntry;
@@ -29,12 +28,6 @@ import se.liu.ida.hefquin.federation.access.FederationAccessManager;
 import se.liu.ida.hefquin.federation.access.FederationAccessStats;
 import se.liu.ida.hefquin.federation.access.SPARQLRequest;
 import se.liu.ida.hefquin.federation.access.TPFRequest;
-import se.liu.ida.hefquin.federation.access.impl.reqproc.BRTPFRequestProcessorImpl;
-import se.liu.ida.hefquin.federation.access.impl.reqproc.GraphQLRequestProcessorImpl;
-import se.liu.ida.hefquin.federation.access.impl.reqproc.Neo4jRequestProcessorImpl;
-import se.liu.ida.hefquin.federation.access.impl.reqproc.RESTRequestProcessorImpl;
-import se.liu.ida.hefquin.federation.access.impl.reqproc.SPARQLRequestProcessorImpl;
-import se.liu.ida.hefquin.federation.access.impl.reqproc.TPFRequestProcessorImpl;
 
 public class FederationAccessManagerWithCache implements FederationAccessManager
 {
@@ -69,24 +62,6 @@ public class FederationAccessManagerWithCache implements FederationAccessManager
 	                                         final int cacheCapacity )
 	{
 		this( fedAccMan, cacheCapacity, new MyDefaultCachePolicies() );
-	}
-
-	/**
-	 * Creates a {@link FederationAccessManagerWithCache} with a default configuration.
-	 */
-	public FederationAccessManagerWithCache( final ExecutorService execService )
-	{
-		this( new AsyncFederationAccessManagerImpl(
-		      execService,
-			  10,
-		      new SPARQLRequestProcessorImpl(),
-		      new TPFRequestProcessorImpl(),
-		      new BRTPFRequestProcessorImpl(),
-		      new Neo4jRequestProcessorImpl(),
-		      new RESTRequestProcessorImpl(),
-		      new GraphQLRequestProcessorImpl()),
-		      100,
-		      new MyDefaultCachePolicies() );
 	}
 
 

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/AsyncFederationAccessManagerImplTest.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/access/impl/AsyncFederationAccessManagerImplTest.java
@@ -2,6 +2,7 @@ package se.liu.ida.hefquin.federation.access.impl;
 
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -198,9 +199,11 @@ public class AsyncFederationAccessManagerImplTest extends FederationTestBase
 		                                            reqProc,
 		                                            reqProcTPF,
 		                                            reqProcBRTPF,
-		                                            reqProcNeo4j,
-		                                            reqProcREST,
-		                                            reqProcGraphQL);
+		                                            List.of(
+		                                                reqProcNeo4j,
+		                                                reqProcREST,
+		                                                reqProcGraphQL )
+		                                            );
 	}
 
 	protected static class FakeRequestProcessorBase

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestTPFTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryplan/executable/impl/ops/ExecOpRequestTPFTest.java
@@ -93,9 +93,10 @@ public class ExecOpRequestTPFTest extends ExecOpTestBase
 			new SPARQLRequestProcessorImpl(),
 			new TPFRequestProcessorImpl(),
 			new BRTPFRequestProcessorImpl(),
-			new Neo4jRequestProcessorImpl(),
-			new RESTRequestProcessorImpl(),
-			new GraphQLRequestProcessorImpl() );
+			List.of(
+				new Neo4jRequestProcessorImpl(),
+				new RESTRequestProcessorImpl(),
+				new GraphQLRequestProcessorImpl() ) );
 		final FederationAccessManager fedAccessMgr = new FederationAccessManagerWithCache(internalFedAccMgr, 100);
 
 		final QueryProcContextExt ctx = new QueryProcContextExt() {

--- a/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/QueryProcessorImplTest.java
+++ b/hefquin-engine/src/test/java/se/liu/ida/hefquin/engine/queryproc/impl/QueryProcessorImplTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
@@ -70,7 +71,7 @@ public class QueryProcessorImplTest extends EngineTestBase
 				NodeFactory.createURI("http://example.org/s"),
 				NodeFactory.createURI("http://example.org/p"),
 				NodeFactory.createURI("http://example.org/o")) );
-		
+
 		final FederationCatalogImpl fedCat = new FederationCatalogImpl();
 		fedCat.addMember( "http://example.org", new TPFServerForTest(dataForMember) );
 
@@ -154,7 +155,7 @@ public class QueryProcessorImplTest extends EngineTestBase
 				NodeFactory.createURI("http://example.org/s"),
 				NodeFactory.createURI("http://example.org/p2"),
 				NodeFactory.createURI("http://example.org/o2")) );
-		
+
 		final FederationCatalogImpl fedCat = new FederationCatalogImpl();
 		fedCat.addMember( "http://example.org/tpf1", new TPFServerForTest(dataForMember1) );
 		fedCat.addMember( "http://example.org/tpf2", new TPFServerForTest(dataForMember2) );
@@ -201,7 +202,7 @@ public class QueryProcessorImplTest extends EngineTestBase
 				NodeFactory.createURI("http://example.org/s"),
 				NodeFactory.createURI("http://example.org/p1"),
 				NodeFactory.createURI("http://example.org/o2")) );
-		
+
 		final FederationCatalogImpl fedCat = new FederationCatalogImpl();
 		fedCat.addMember( "http://example.org/tpf1", new TPFServerForTest(dataForMember1) );
 		fedCat.addMember( "http://example.org/tpf2", new TPFServerForTest(dataForMember2) );
@@ -252,7 +253,7 @@ public class QueryProcessorImplTest extends EngineTestBase
 				NodeFactory.createURI("http://example.org/s2"),
 				NodeFactory.createURI("http://example.org/p"),
 				NodeFactory.createURI("http://example.org/o2")) );
-		
+
 		final FederationCatalogImpl fedCat = new FederationCatalogImpl();
 		fedCat.addMember( "http://example.org", new TPFServerForTest(dataForMember) );
 
@@ -292,7 +293,7 @@ public class QueryProcessorImplTest extends EngineTestBase
 				NodeFactory.createURI("http://example.org/s2"),
 				NodeFactory.createURI("http://example.org/p"),
 				NodeFactory.createURI("http://example.org/o2")) );
-		
+
 		final FederationCatalogImpl fedCat = new FederationCatalogImpl();
 		fedCat.addMember( "http://example.org", new TPFServerForTest(dataForMember) );
 
@@ -342,9 +343,10 @@ public class QueryProcessorImplTest extends EngineTestBase
 			final FederationAccessManager fedAccessMgr = new BlockingFederationAccessManagerImpl(reqProcSPARQL,
 			                                                                                     reqProcTPF,
 			                                                                                     reqProcBRTPF,
-			                                                                                     reqProcNeo4j,
-			                                                                                     reqProcREST,
-			                                                                                     reqProcGraphQL);
+			                                                                                     List.of(
+			                                                                                         reqProcNeo4j,
+			                                                                                         reqProcREST,
+			                                                                                         reqProcGraphQL ));
 
 			// executing the tested method
 			final Iterator<SolutionMapping> it = processQuery(queryString, fedCat, fedAccessMgr);


### PR DESCRIPTION
Change constructors of `FederationAccessManagerBase2` and its subclasses to use a list for request processor that will be moved out of `hefquin-access`.