### PR TITLE
Implement BasicAuthenticationInformation and add tests

### DIFF
--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/authentication/BasicAuthenticationInformation.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/authentication/BasicAuthenticationInformation.java
@@ -1,0 +1,80 @@
+package se.liu.ida.hefquin.federation.authentication;
+
+import java.net.http.HttpRequest.Builder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+import org.apache.jena.sparql.exec.http.QueryExecutionHTTPBuilder;
+
+/**
+ * Authentication information for basic authentication.
+ * <p>
+ * The username and password are combined into a single string by joining them
+ * with a colon and then encoded using Base64.
+ * <p>
+ * The resulting value is applied to outgoing HTTP requests using an
+ * {@code Authorization} header with the {@code Basic} authentication scheme.
+ * This class supports applying the authentication information to different
+ * HTTP request representations used by HeFQUIN.
+ */
+public class BasicAuthenticationInformation implements AuthenticationInformation
+{
+	private final String username;
+	private final String password;
+
+	public BasicAuthenticationInformation( final String username, final String password ) {
+		this.username = username;
+		this.password = password;
+	}
+
+	public String getUsername() {
+		return username;
+	}
+
+	public String getPassword() {
+		return password;
+	}
+
+	/**
+	 * Adds the basic token as an Authorization header to the given HTTP request builder.
+	 *
+	 * @param builder HTTP request builder to which the Authorization header is added
+	 */
+	@Override
+	public void applyTo( final Builder builder ) {
+		builder.setHeader( "Authorization", "Basic " + getBasicAuthToken() );
+	}
+
+	/**
+	 * Adds the basic token as an Authorization header to the given HTTP headers.
+	 *
+	 * @param headers HTTP headers to which the Authorization header is added
+	 */
+	@Override
+	public void applyTo( final Map<String, String> headers ) {
+		headers.put( "Authorization", "Basic " + getBasicAuthToken() );
+	}
+
+	/**
+	 * Adds the basic token as an Authorization header to the given HTTP headers.
+	 *
+	 * @param b QueryExecutionHTTPBuilder to which the Authorization header is added
+	 */
+	@Override
+	public void applyTo( final QueryExecutionHTTPBuilder b ) {
+		b.httpHeader( "Authorization", "Basic " + getBasicAuthToken() );
+	}
+
+	/**
+	 * Creates the Base64-encoded credentials used for HTTP Basic Authentication.
+	 * The username and password are joined with a colon and the resulting string
+	 * is encoded using Base64.
+	 *
+	 * @return the Base64-encoded username and password
+	 */
+	private String getBasicAuthToken() {
+		final String credentials = username + ":" + password;
+		return Base64.getEncoder().encodeToString( credentials.getBytes(StandardCharsets.UTF_8) );
+	}
+}

--- a/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/catalog/FederationDescriptionReader.java
+++ b/hefquin-access/src/main/java/se/liu/ida/hefquin/federation/catalog/FederationDescriptionReader.java
@@ -35,6 +35,7 @@ import se.liu.ida.hefquin.engine.wrappers.graphql.data.GraphQLSchema;
 import se.liu.ida.hefquin.engine.wrappers.graphql.impl.GraphQLSchemaInitializerImpl;
 import se.liu.ida.hefquin.federation.FederationMember;
 import se.liu.ida.hefquin.federation.authentication.AuthenticationInformation;
+import se.liu.ida.hefquin.federation.authentication.BasicAuthenticationInformation;
 import se.liu.ida.hefquin.federation.authentication.BearerAuthenticationInformation;
 import se.liu.ida.hefquin.federation.catalog.impl.FederationCatalogImpl;
 import se.liu.ida.hefquin.federation.members.RESTEndpoint;
@@ -399,9 +400,12 @@ public class FederationDescriptionReader
 	/**
 	 * Parses the authentication configuration associated with the given interface.
 	 * <p>
-	 * Currently, only the {@code wotsec:BearerSecurityScheme} is supported. The
-	 * environment variable containing the bearer token is specified using
-	 * {@code fd:envarForToken}.
+	 * Currently, both {@code wotsec:BearerSecurityScheme} and
+	 * {@code wotsec:BasicSecurityScheme} are supported. For bearer authentication,
+	 * the environment variable containing the token is specified using
+	 * {@code fd:envarForToken}. For basic authentication, the environment variables
+	 * containing the username and password are specified using {@code fd:envarForUsername}
+	 * and {@code fd:envarForPassword}. Only header-based authentication is supported.
 	 *
 	 * @param iface the interface resource whose authentication configuration should
 	 *              be parsed
@@ -426,25 +430,35 @@ public class FederationDescriptionReader
 		final Resource securityScheme = securityConfig.asResource();
 
 		if ( securityScheme.hasProperty( RDF.type, WoTSecVocab.BearerSecurityScheme ) ) {
-			final String inValue =
-					ModelUtils.getSingleOptionalProperty_XSDString(
-							securityScheme,
-							WoTSecVocab.in );
-
-			if ( inValue != null && ! "header".equals(inValue) )
-				throw new IllegalArgumentException( "Only header-based bearer authentication is supported." );
+			requireHeaderBasedAuthentication( securityScheme, "bearer" );
 
 			final String tokenEnv =
 				ModelUtils.getSingleMandatoryProperty_XSDString(
 					securityScheme,
 					FDVocab.envarForToken );
 
-			final String token = getEnvironmentVariable( tokenEnv );
-
-			if ( token == null )
-				throw new IllegalArgumentException( "Environment variable '" + tokenEnv + "' is not set." );
+			final String token = getRequiredEnvironmentVariable( tokenEnv );
 
 			return new BearerAuthenticationInformation( token );
+		}
+		else if ( securityScheme.hasProperty( RDF.type, WoTSecVocab.BasicSecurityScheme ) ) {
+			requireHeaderBasedAuthentication( securityScheme, "basic" );
+
+			final String usernameEnv =
+				ModelUtils.getSingleMandatoryProperty_XSDString(
+					securityScheme,
+					FDVocab.envarForUsername );
+
+			final String username = getRequiredEnvironmentVariable( usernameEnv );
+
+			final String passwordEnv =
+				ModelUtils.getSingleMandatoryProperty_XSDString(
+					securityScheme,
+					FDVocab.envarForPassword );
+
+			final String password = getRequiredEnvironmentVariable( passwordEnv );
+
+			return new BasicAuthenticationInformation( username, password );
 		}
 
 		throw new IllegalArgumentException( "Unsupported security scheme: " + securityScheme );
@@ -601,13 +615,34 @@ public class FederationDescriptionReader
 	}
 
 	/**
-	 * Retrieves the value of the specified environment variable.
+	 * Checks whether the given security scheme specifies HTTP headers as the
+	 * location for authentication information.
+	*/
+	protected void requireHeaderBasedAuthentication( final Resource securityScheme, final String authenticationType ) {
+		final String inValue =
+				ModelUtils.getSingleOptionalProperty_XSDString(
+				securityScheme,
+				WoTSecVocab.in );
+
+		if ( inValue != null && ! "header".equals(inValue) )
+			throw new IllegalArgumentException( "Only header-based " + authenticationType + " authentication is supported." );
+	}
+
+	/**
+	 * Retrieves the value of the specified environment variable and throws an
+	 * exception if the variable is not set.
 	 *
-	 * @param tokenEnvName the name of the environment variable
-	 * @return the value of the environment variable, or {@code null} if it is not set
-	 */
-	protected String getEnvironmentVariable( final String tokenEnvName ) {
-		return System.getenv( tokenEnvName );
+	 * @param variableName the name of the environment variable
+	 * @return the value of the environment variable
+	 * @throws IllegalArgumentException if the environment variable is not set
+*/
+	protected String getRequiredEnvironmentVariable( final String variableName ) {
+		final String value = System.getenv( variableName );
+
+		if ( value == null )
+			throw new IllegalArgumentException( "Environment variable '" + variableName + "' is not set." );
+
+		return value;
 	}
 
 }

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/authentication/BasicAuthenticationInformationTest.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/authentication/BasicAuthenticationInformationTest.java
@@ -1,0 +1,25 @@
+package se.liu.ida.hefquin.federation.authentication;
+
+import static org.junit.Assert.assertEquals;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.Test;
+
+public class BasicAuthenticationInformationTest
+{
+	@Test
+	public void basicAuthenticationAddsAuthorizationHeader() {
+		final Map<String, String> headers = new HashMap<>();
+
+		final AuthenticationInformation auth = new BasicAuthenticationInformation("admin","root");
+
+		auth.applyTo( headers );
+
+		final String credentials = "admin:root";
+		assertEquals( "Basic " + Base64.getEncoder().encodeToString( credentials.getBytes(StandardCharsets.UTF_8) ), headers.get("Authorization") );
+	}
+}

--- a/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/catalog/FederationDescriptionReaderTest.java
+++ b/hefquin-access/src/test/java/se/liu/ida/hefquin/federation/catalog/FederationDescriptionReaderTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 
 import se.liu.ida.hefquin.federation.FederationMember;
 import se.liu.ida.hefquin.federation.authentication.AuthenticationInformation;
+import se.liu.ida.hefquin.federation.authentication.BasicAuthenticationInformation;
 import se.liu.ida.hefquin.federation.authentication.BearerAuthenticationInformation;
 import se.liu.ida.hefquin.federation.members.SPARQLEndpoint;
 import se.liu.ida.hefquin.federation.members.TPFServer;
@@ -273,7 +274,7 @@ public class FederationDescriptionReaderTest
 
 		final FederationDescriptionReader reader = new FederationDescriptionReader() {
 			@Override
-			protected String getEnvironmentVariable( final String name ) {
+			protected String getRequiredEnvironmentVariable( final String name ) {
 				return "ENV_VAR_FOR_TOKEN".equals(name)
 						? "TOKEN12345"
 						: null;
@@ -288,4 +289,47 @@ public class FederationDescriptionReaderTest
 		assertEquals( "TOKEN12345", ( ( BearerAuthenticationInformation ) auth ).getToken() );
 	}
 
+	@Test
+	public void usernameAndPasswordEnvVarsAreParsed() {
+		final String turtle =
+				  "PREFIX xsd:        <http://www.w3.org/2001/XMLSchema#>\n"
+				+ "PREFIX fd:         <http://w3id.org/hefquin/feddesc#>\n"
+				+ "PREFIX ex:         <http://example.org/>\n"
+				+ "PREFIX td:         <https://www.w3.org/2019/wot/td#>\n"
+				+ "PREFIX wotsec:     <https://www.w3.org/2019/wot/security#>\n"
+				+ "\n"
+				+ "ex:dbpediaSPARQL a fd:RDFBasedFederationMember ;\n"
+				+ "      fd:serviceURI \"http://dbpedia.org/sparql\"^^xsd:anyURI ;\n"
+				+ "      fd:interface [ a                         fd:FixedEndpointInterface ;\n"
+				+ "                     fd:supportedProtocol      fd:SPARQLProtocol ;\n"
+				+ "                     fd:endpointAddress        \"http://dbpedia.org/sparql\"^^xsd:anyURI ;\n"
+				+ "\n"
+				+ "                     td:hasSecurityConfiguration [ a                wotsec:BasicSecurityScheme ;\n"
+				+ "                                                   wotsec:in        \"header\" ;\n"
+				+ "                                                   fd:envarForUsername \"ENV_VAR_FOR_USERNAME\" ;\n"
+				+ "                                                   fd:envarForPassword \"ENV_VAR_FOR_PASSWORD\" ; ] ] ." ;
+
+		final Model fd = ModelFactory.createDefaultModel();
+		final RDFParserBuilder b = RDFParser.fromString( turtle, Lang.TURTLE );
+		b.parse( fd );
+
+		final FederationDescriptionReader reader = new FederationDescriptionReader() {
+			@Override
+			protected String getRequiredEnvironmentVariable( final String name ) {
+				if ( "ENV_VAR_FOR_USERNAME".equals(name) )
+					return "admin";
+				else if ( "ENV_VAR_FOR_PASSWORD".equals(name) )
+					return "root";
+				else return null;
+			}
+		};
+
+		final FederationCatalog cat = reader.parseFedDescr( fd );
+		final FederationMember fm = cat.getFederationMemberByURI( "http://dbpedia.org/sparql" );
+		final AuthenticationInformation auth = ( ( SPARQLEndpoint ) fm ).getAuthenticationInformation();
+
+		assertTrue( auth instanceof BasicAuthenticationInformation );
+		assertEquals( "admin", ( ( BasicAuthenticationInformation ) auth ).getUsername() );
+		assertEquals( "root", ( ( BasicAuthenticationInformation ) auth ).getPassword() );
+	}
 }


### PR DESCRIPTION
Further works upon #669.

Although, it does not add Basic authentication to requests for GraphQL and Neo4j endpoints (see #695).

The functionality of this PR has also been tested with a custom GraphDB SPARQL endpoint and works well.