### PR TITLE
Update RequestBasedCardinalityEstimator to new DataRetrievalResponse interface

### DIFF
--- a/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunHttpQuery.java
+++ b/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunHttpQuery.java
@@ -435,16 +435,13 @@ public class RunHttpQuery extends CmdGeneral
 	 */
 	protected void printExceptions( final JsonArray exceptions ) {
 		for ( int i = 0; i < exceptions.size(); i++ ) {
-			System.err.println();
-
 			final JsonObject exception = exceptions.get(i).getAsObject();
 
 			cmdError( "Exception " + (i + 1) + ": " + exception.getString("msg"), false );
 
-			if ( isDebug() ) {
+			if ( isDebug() )
 				cmdError( "StackTrace:", false );
 				cmdError( exception.getString("stacktrace"), false );
-			}
 		}
 	}
 }

--- a/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunHttpQuery.java
+++ b/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunHttpQuery.java
@@ -435,13 +435,16 @@ public class RunHttpQuery extends CmdGeneral
 	 */
 	protected void printExceptions( final JsonArray exceptions ) {
 		for ( int i = 0; i < exceptions.size(); i++ ) {
+			System.err.println();
+
 			final JsonObject exception = exceptions.get(i).getAsObject();
 
 			cmdError( "Exception " + (i + 1) + ": " + exception.getString("msg"), false );
 
-			if ( isDebug() )
+			if ( isDebug() ) {
 				cmdError( "StackTrace:", false );
 				cmdError( exception.getString("stacktrace"), false );
+			}
 		}
 	}
 }

--- a/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunHttpQuery.java
+++ b/hefquin-cli/src/main/java/se/liu/ida/hefquin/cli/RunHttpQuery.java
@@ -435,7 +435,7 @@ public class RunHttpQuery extends CmdGeneral
 	 */
 	protected void printExceptions( final JsonArray exceptions ) {
 		for ( int i = 0; i < exceptions.size(); i++ ) {
-			System.err.println();
+			cmdError( "", false );
 
 			final JsonObject exception = exceptions.get(i).getAsObject();
 

--- a/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/RequestBasedCardinalityEstimator.java
+++ b/hefquin-engine/src/main/java/se/liu/ida/hefquin/engine/queryproc/impl/cardinality/RequestBasedCardinalityEstimator.java
@@ -43,7 +43,7 @@ public class RequestBasedCardinalityEstimator implements CardinalityEstimator
 		addCardinalitiesForRequests(ctx, plans);
 
 		// Now, use the worker to determine the cardinality estimates
-		// for the given plans recursively. 
+		// for the given plans recursively.
 		new CardinalityEstimationWorkerImpl().addCardinalities(plans);
 	}
 
@@ -56,7 +56,7 @@ public class RequestBasedCardinalityEstimator implements CardinalityEstimator
 		addCardinalitiesForRequests(ctx, plans);
 
 		// Now, use the worker to determine the cardinality estimates
-		// for the given plans recursively. 
+		// for the given plans recursively.
 		new CardinalityEstimationWorkerImpl().addCardinalities(plans);
 	}
 
@@ -204,7 +204,7 @@ public class RequestBasedCardinalityEstimator implements CardinalityEstimator
 // TODO: We should try to be a bit smarter, using some heuristic that takes
 // the patterns of the given requests into account.
 // TODO: Also, in cases in which only some of the cardinality requests failed,
-// we should at least get the values for those that did not fail. 
+// we should at least get the values for those that did not fail.
 			final QueryPlanProperty est = QueryPlanProperty.cardinality(Integer.MAX_VALUE,
 			                                                            Quality.PURE_GUESS);
 			final QueryPlanProperty min = QueryPlanProperty.minCardinality(0,
@@ -244,7 +244,7 @@ public class RequestBasedCardinalityEstimator implements CardinalityEstimator
 				final QueryPlanProperty.Quality minCardQuality;
 				final QueryPlanProperty.Quality maxCardQuality;
 
-				if ( resps[i].isError() ) {
+				if ( resps[i].isError() || resps[i].isDefective() ) {
 					cardValue = Integer.MAX_VALUE;
 					cardQuality = Quality.PURE_GUESS;
 					minCardValue = 0;
@@ -322,7 +322,7 @@ public class RequestBasedCardinalityEstimator implements CardinalityEstimator
 				if ( resps.length < respIdx - 1 )
 					throw new IllegalStateException("Wrong number of cardinality responses (namely, " + resps.length + ", but at least " + respIdx + " expected).");
 
-				if ( resps[respIdx].isError() ) {
+				if ( resps[respIdx].isError() || resps[respIdx].isDefective() ) {
 					errorFound = true;
 				}
 				else {

--- a/hefquin-service/src/main/java/se/liu/ida/hefquin/service/SparqlServlet.java
+++ b/hefquin-service/src/main/java/se/liu/ida/hefquin/service/SparqlServlet.java
@@ -158,10 +158,6 @@ public class SparqlServlet extends HttpServlet {
 
 		try {
 			final JsonObject result = execute( query, mimeType, ctx, queryResBuf, returnQueryProcStats, returnFedAccessStats );
-			if ( ! result.get(HttpConstants.JSON_EXCEPTIONS).getAsArray().isEmpty() ) {
-				writeJsonError( response, 500, result.get( HttpConstants.JSON_EXCEPTIONS ) );
-				return;
-			}
 
 			response.setStatus( 200 );
 			response.setContentType( mimeType );

--- a/hefquin-service/src/test/java/se/liu/ida/hefquin/service/SparqlServletTest.java
+++ b/hefquin-service/src/test/java/se/liu/ida/hefquin/service/SparqlServletTest.java
@@ -414,9 +414,9 @@ public class SparqlServletTest {
 	@Test
 	public void testMissingFederationMember() throws Exception {
 		final String invalid = "SELECT * WHERE { SERVICE <http://invalid/federation/member> { ?s ?p ?o } }";
-		final HttpPost request = createPostRequest( CONTENT_TYPE_FORM_URLENCODED, ACCEPT_SPARQL_RESULTS_XML, invalid );
+		final HttpPost request = createPostRequest( CONTENT_TYPE_FORM_URLENCODED, ACCEPT_SPARQL_RESULTS_JSON, invalid );
 		try ( final CloseableHttpResponse response = httpClient.execute( request ) ) {
-			assertEquals( 500, response.getStatusLine().getStatusCode() );
+			assertEquals( 200, response.getStatusLine().getStatusCode() );
 			final String responseContent = EntityUtils.toString( response.getEntity() );
 			assertTrue( responseContent.contains("Exception occurred when outputting the result of a SELECT query using the Jena machinery.") );
 		}
@@ -426,9 +426,9 @@ public class SparqlServletTest {
 	public void testUseOfHeFQUINParser() throws Exception {
 		final String validQueryStr = """
 			SELECT * WHERE { BIND (42 AS ?v) SERVICE <http://example.org/> PARAMS(?v AS "v") { ?s ?p ?o } }""";
-		final HttpPost request = createPostRequest( CONTENT_TYPE_FORM_URLENCODED, ACCEPT_SPARQL_RESULTS_XML, validQueryStr );
+		final HttpPost request = createPostRequest( CONTENT_TYPE_FORM_URLENCODED, ACCEPT_SPARQL_RESULTS_JSON, validQueryStr );
 		try ( final CloseableHttpResponse response = httpClient.execute( request ) ) {
-			assertEquals( 500, response.getStatusLine().getStatusCode() );
+			assertEquals( 200, response.getStatusLine().getStatusCode() );
 			final String responseContent = EntityUtils.toString( response.getEntity() );
 			assertFalse( responseContent.contains("PARAMS") );
 			assertTrue( responseContent.contains("Exception occurred when outputting the result of a SELECT query using the Jena machinery.") );


### PR DESCRIPTION
Closes #710.

The commit chain looks a bit silly because I thought I had pushed it to the wrong branch.

I also noticed a bug while working on this, that being the `isDebug` lacking braces in `printExceptions()`, that has been fixed.